### PR TITLE
feat: add Postgres memory store skeleton

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 openai = ["openai>=1.40"]
 anthropic = ["anthropic>=0.30"]
 all-providers = ["openai>=1.40", "anthropic>=0.30"]
+postgres = ["sqlalchemy[asyncio]>=2.0", "psycopg[binary]>=3.2"]
 # Cross-tokenizer counting. Provides accurate per-model token
 # counts via tiktoken / anthropic / huggingface backends bundled by litellm.
 tokenizer = ["litellm>=1.40"]
@@ -48,6 +49,8 @@ dev = [
     "hypothesis>=6.100",   # property-based tests
     "ruff>=0.5",
     "pyright>=1.1",
+    "sqlalchemy[asyncio]>=2.0",
+    "aiosqlite>=0.19",
     "openai>=1.40",
     "anthropic>=0.30",
 ]

--- a/src/modelmeld/api/server.py
+++ b/src/modelmeld/api/server.py
@@ -15,7 +15,7 @@ from modelmeld.adapters import ProviderAdapter
 from modelmeld.cache import CompletionCache, SemanticCompletionCache
 from modelmeld.config import GatewaySettings
 from modelmeld.hooks import HookRegistry
-from modelmeld.memory import InMemoryMemoryStore, MemoryStore
+from modelmeld.memory import InMemoryMemoryStore, MemoryStore, PostgresMemoryStore
 from modelmeld.privacy import Scrubber, build_scrubber
 from modelmeld.router import Router, SingleAdapterRouter, build_router
 from modelmeld.scout import ModelRegistry, Scout, build_scout, default_registry
@@ -77,9 +77,16 @@ def build_app(
     app.state.scrubber = scrubber if scrubber is not None else build_scrubber(app.state.settings)
     app.state.hooks = hooks or HookRegistry()
     app.state.model_registry = model_registry or default_registry()
-    # Tiered memory. Default: in-process backend for
-    # dev/tests. Enterprise plugs in a Postgres-backed store later.
-    app.state.memory_store = memory_store if memory_store is not None else InMemoryMemoryStore()
+    # Tiered memory. Default: in-process backend for dev/tests; operators can
+    # opt into a SQL-backed store with MODELMELD_MEMORY_BACKEND=postgres.
+    if memory_store is not None:
+        app.state.memory_store = memory_store
+    elif app.state.settings.memory_backend == "postgres":
+        app.state.memory_store = PostgresMemoryStore(
+            app.state.settings.memory_database_url
+        )
+    else:
+        app.state.memory_store = InMemoryMemoryStore()
     # Token counter. Default char-based; settings can switch to
     # litellm. Pass `token_counter=` to inject a custom impl in tests.
     app.state.token_counter = (

--- a/src/modelmeld/config.py
+++ b/src/modelmeld/config.py
@@ -108,6 +108,12 @@ class GatewaySettings(BaseSettings):
     #               char-based with a warning when litellm isn't installed.
     token_counter_backend: Literal["char", "litellm"] = "char"
 
+    # Memory backend. Default remains in-process for dev/tests. Set
+    # MODELMELD_MEMORY_BACKEND=postgres plus MODELMELD_MEMORY_DATABASE_URL for
+    # a SQL-backed store shared across workers.
+    memory_backend: Literal["in_memory", "postgres"] = "in_memory"
+    memory_database_url: str | None = None
+
     # PII scrubbing. When True, message text is scrubbed before
     # any egress adapter call (is_egress=True). Local adapters (stub, vllm) are
     # never scrubbed since traffic stays inside the customer's boundary.

--- a/src/modelmeld/memory/__init__.py
+++ b/src/modelmeld/memory/__init__.py
@@ -54,6 +54,10 @@ from modelmeld.memory.in_memory import (
     InMemoryMemoryStore,
     TenantMismatchError,
 )
+from modelmeld.memory.postgres import (
+    MissingPostgresDependencyError,
+    PostgresMemoryStore,
+)
 from modelmeld.memory.summarizer import (
     SummarizeCallable,
     SummarizerConfig,
@@ -85,6 +89,8 @@ __all__ = [
     "MemoryIdentity",
     "MemoryMode",
     "MemoryStore",
+    "MissingPostgresDependencyError",
+    "PostgresMemoryStore",
     "Role",
     "Session",
     "SummarizeCallable",

--- a/src/modelmeld/memory/postgres.py
+++ b/src/modelmeld/memory/postgres.py
@@ -1,0 +1,378 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""SQL-backed MemoryStore skeleton for Postgres deployments."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any
+
+from modelmeld.memory.base import (
+    Fact,
+    MemoryStore,
+    Role,
+    Session,
+    Summary,
+    SummaryVersionMismatch,
+    Turn,
+    new_fact_id,
+    new_summary_id,
+    new_turn_id,
+    utc_now,
+    validate_tenant_id,
+)
+
+
+class MissingPostgresDependencyError(RuntimeError):
+    """Raised when the postgres extra is not installed."""
+
+
+def _sqlalchemy() -> tuple[Any, Any]:
+    try:
+        from sqlalchemy import text  # type: ignore[reportMissingImports]
+        from sqlalchemy.ext.asyncio import create_async_engine  # type: ignore[reportMissingImports]
+    except ModuleNotFoundError as exc:
+        raise MissingPostgresDependencyError(
+            "PostgresMemoryStore requires SQLAlchemy. Install with "
+            "`pip install modelmeld[postgres]`."
+        ) from exc
+    return text, create_async_engine
+
+
+def _normalize_url(url: str) -> str:
+    if url.startswith("postgres://"):
+        return "postgresql+psycopg://" + url.removeprefix("postgres://")
+    if url.startswith("postgresql://"):
+        return "postgresql+psycopg://" + url.removeprefix("postgresql://")
+    return url
+
+
+def _loads(value: Any) -> dict[str, Any]:
+    return json.loads(value) if isinstance(value, str) else dict(value)
+
+
+def _dt(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+class PostgresMemoryStore(MemoryStore):
+    """Async SQL MemoryStore.
+
+    The table stores typed JSON documents. Turns are keyed by
+    `(tenant_id, session_id, turn_idx)` through `item_key`/`sort_idx`; tests pass
+    a SQLite async engine, while production uses a Postgres URL and JSONB.
+    """
+
+    def __init__(
+        self,
+        database_url: str | None = None,
+        *,
+        engine: Any | None = None,
+        create_schema: bool = True,
+    ) -> None:
+        if engine is None:
+            if not database_url:
+                raise ValueError(
+                    "PostgresMemoryStore requires MODELMELD_MEMORY_DATABASE_URL"
+                )
+            _, create_async_engine = _sqlalchemy()
+            self._engine = create_async_engine(_normalize_url(database_url))
+            self._owns_engine = True
+        else:
+            self._engine = engine
+            self._owns_engine = False
+        self._create_schema = create_schema
+        self._initialized = False
+        self._init_lock = asyncio.Lock()
+        self._write_lock = asyncio.Lock()
+
+    @property
+    def _json_expr(self) -> str:
+        return "CAST(:payload AS jsonb)" if self._engine.dialect.name == "postgresql" else ":payload"
+
+    async def initialize(self) -> None:
+        if self._initialized:
+            return
+        async with self._init_lock:
+            if self._initialized:
+                return
+            if self._create_schema:
+                text, _ = _sqlalchemy()
+                json_type = "JSONB" if self._engine.dialect.name == "postgresql" else "TEXT"
+                async with self._engine.begin() as conn:
+                    await conn.execute(text(f"""
+                        CREATE TABLE IF NOT EXISTS modelmeld_memory_docs (
+                            kind TEXT NOT NULL,
+                            tenant_id TEXT NOT NULL,
+                            session_id TEXT NOT NULL,
+                            item_key TEXT NOT NULL,
+                            sort_idx INTEGER NOT NULL,
+                            payload {json_type} NOT NULL,
+                            PRIMARY KEY (kind, tenant_id, session_id, item_key)
+                        )
+                    """))
+            self._initialized = True
+
+    async def _put(
+        self,
+        kind: str,
+        tenant_id: str,
+        session_id: str,
+        item_key: str,
+        sort_idx: int,
+        payload: dict[str, Any],
+    ) -> None:
+        await self.initialize()
+        text, _ = _sqlalchemy()
+        async with self._engine.begin() as conn:
+            await conn.execute(text(f"""
+                INSERT INTO modelmeld_memory_docs (
+                    kind, tenant_id, session_id, item_key, sort_idx, payload
+                )
+                VALUES (
+                    :kind, :tenant_id, :session_id, :item_key, :sort_idx,
+                    {self._json_expr}
+                )
+                ON CONFLICT (kind, tenant_id, session_id, item_key) DO UPDATE SET
+                    sort_idx = excluded.sort_idx,
+                    payload = excluded.payload
+            """), {
+                "kind": kind,
+                "tenant_id": tenant_id,
+                "session_id": session_id,
+                "item_key": item_key,
+                "sort_idx": sort_idx,
+                "payload": json.dumps(payload, separators=(",", ":"), sort_keys=True),
+            })
+
+    async def _get(self, kind: str, tenant_id: str, session_id: str, item_key: str) -> dict[str, Any] | None:
+        await self.initialize()
+        text, _ = _sqlalchemy()
+        async with self._engine.begin() as conn:
+            result = await conn.execute(text("""
+                SELECT payload FROM modelmeld_memory_docs
+                WHERE kind = :kind AND tenant_id = :tenant_id
+                  AND session_id = :session_id AND item_key = :item_key
+            """), {
+                "kind": kind, "tenant_id": tenant_id,
+                "session_id": session_id, "item_key": item_key,
+            })
+            row = result.first()
+            return _loads(row._mapping["payload"]) if row is not None else None
+
+    async def _list(self, kind: str, tenant_id: str, session_id: str) -> list[dict[str, Any]]:
+        await self.initialize()
+        text, _ = _sqlalchemy()
+        async with self._engine.begin() as conn:
+            result = await conn.execute(text("""
+                SELECT payload FROM modelmeld_memory_docs
+                WHERE kind = :kind AND tenant_id = :tenant_id AND session_id = :session_id
+                ORDER BY sort_idx ASC, item_key ASC
+            """), {"kind": kind, "tenant_id": tenant_id, "session_id": session_id})
+            return [_loads(row._mapping["payload"]) for row in result.all()]
+
+    async def _delete(self, kind: str, tenant_id: str, session_id: str, item_key: str) -> bool:
+        await self.initialize()
+        text, _ = _sqlalchemy()
+        async with self._engine.begin() as conn:
+            result = await conn.execute(text("""
+                DELETE FROM modelmeld_memory_docs
+                WHERE kind = :kind AND tenant_id = :tenant_id
+                  AND session_id = :session_id AND item_key = :item_key
+            """), {
+                "kind": kind, "tenant_id": tenant_id,
+                "session_id": session_id, "item_key": item_key,
+            })
+            return bool(result.rowcount)
+
+    async def _require_session(self, session_id: str, tenant_id: str) -> None:
+        if await self.get_session(session_id, tenant_id) is None:
+            raise LookupError(
+                f"Session not found: tenant_id={tenant_id!r} session_id={session_id!r}"
+            )
+
+    def _session(self, data: dict[str, Any]) -> Session:
+        return Session(
+            session_id=data["session_id"],
+            tenant_id=data["tenant_id"],
+            user_id=data["user_id"],
+            created_at=_dt(data["created_at"]),
+            metadata=data["metadata"],
+        )
+
+    def _turn(self, data: dict[str, Any]) -> Turn:
+        return Turn(
+            turn_id=data["turn_id"],
+            session_id=data["session_id"],
+            tenant_id=data["tenant_id"],
+            role=Role(data["role"]),
+            content=data["content"],
+            token_count=data["token_count"],
+            model_used=data["model_used"],
+            timestamp=_dt(data["timestamp"]),
+        )
+
+    def _fact(self, data: dict[str, Any]) -> Fact:
+        return Fact(
+            fact_id=data["fact_id"],
+            session_id=data["session_id"],
+            tenant_id=data["tenant_id"],
+            key=data["key"],
+            value=data["value"],
+            source=data["source"],
+            confidence=data["confidence"],
+            timestamp=_dt(data["timestamp"]),
+        )
+
+    def _summary(self, data: dict[str, Any]) -> Summary:
+        return Summary(
+            summary_id=data["summary_id"],
+            session_id=data["session_id"],
+            tenant_id=data["tenant_id"],
+            text=data["text"],
+            last_applied_turn_id=data["last_applied_turn_id"],
+            version=data["version"],
+            source_model=data["source_model"],
+            created_at=_dt(data["created_at"]),
+            updated_at=_dt(data["updated_at"]),
+        )
+
+    async def get_or_create_session(
+        self,
+        session_id: str,
+        tenant_id: str,
+        user_id: str | None = None,
+        metadata: Mapping[str, str] | None = None,
+    ) -> Session:
+        validate_tenant_id(tenant_id)
+        existing = await self.get_session(session_id, tenant_id)
+        if existing is not None:
+            return existing
+        data = {
+            "session_id": session_id, "tenant_id": tenant_id, "user_id": user_id,
+            "created_at": utc_now().isoformat(),
+            "metadata": dict(metadata) if metadata else {},
+        }
+        async with self._write_lock:
+            existing = await self.get_session(session_id, tenant_id)
+            if existing is not None:
+                return existing
+            await self._put("session", tenant_id, session_id, "_", 0, data)
+            return self._session(data)
+
+    async def get_session(self, session_id: str, tenant_id: str) -> Session | None:
+        validate_tenant_id(tenant_id)
+        data = await self._get("session", tenant_id, session_id, "_")
+        return self._session(data) if data is not None else None
+
+    async def append_turn(
+        self,
+        session_id: str,
+        tenant_id: str,
+        role: Role,
+        content: str,
+        token_count: int,
+        model_used: str | None = None,
+    ) -> Turn:
+        validate_tenant_id(tenant_id)
+        async with self._write_lock:
+            await self._require_session(session_id, tenant_id)
+            turn_idx = await self.turn_count(session_id, tenant_id)
+            data = {
+                "turn_id": new_turn_id(), "session_id": session_id,
+                "tenant_id": tenant_id, "role": role.value, "content": content,
+                "token_count": token_count, "model_used": model_used,
+                "timestamp": utc_now().isoformat(),
+            }
+            await self._put("turn", tenant_id, session_id, f"{turn_idx:020d}", turn_idx, data)
+            return self._turn(data)
+
+    async def list_turns(
+        self,
+        session_id: str,
+        tenant_id: str,
+        limit: int | None = None,
+    ) -> list[Turn]:
+        validate_tenant_id(tenant_id)
+        turns = [self._turn(data) for data in await self._list("turn", tenant_id, session_id)]
+        return turns if limit is None or limit <= 0 else turns[-limit:]
+
+    async def turn_count(self, session_id: str, tenant_id: str) -> int:
+        validate_tenant_id(tenant_id)
+        return len(await self._list("turn", tenant_id, session_id))
+
+    async def set_fact(
+        self,
+        session_id: str,
+        tenant_id: str,
+        key: str,
+        value: str,
+        source: str = "declared",
+        confidence: float = 1.0,
+    ) -> Fact:
+        validate_tenant_id(tenant_id)
+        if not 0.0 <= confidence <= 1.0:
+            raise ValueError(f"confidence must be in [0,1], got {confidence}")
+        async with self._write_lock:
+            await self._require_session(session_id, tenant_id)
+            data = {
+                "fact_id": new_fact_id(), "session_id": session_id,
+                "tenant_id": tenant_id, "key": key, "value": value,
+                "source": source, "confidence": confidence,
+                "timestamp": utc_now().isoformat(),
+            }
+            await self._put("fact", tenant_id, session_id, key, 0, data)
+            return self._fact(data)
+
+    async def get_facts(self, session_id: str, tenant_id: str) -> list[Fact]:
+        validate_tenant_id(tenant_id)
+        return [self._fact(data) for data in await self._list("fact", tenant_id, session_id)]
+
+    async def delete_fact(self, session_id: str, tenant_id: str, key: str) -> bool:
+        validate_tenant_id(tenant_id)
+        return await self._delete("fact", tenant_id, session_id, key)
+
+    async def get_summary(self, session_id: str, tenant_id: str) -> Summary | None:
+        validate_tenant_id(tenant_id)
+        data = await self._get("summary", tenant_id, session_id, "_")
+        return self._summary(data) if data is not None else None
+
+    async def upsert_summary(
+        self,
+        session_id: str,
+        tenant_id: str,
+        text: str,
+        last_applied_turn_id: str | None,
+        source_model: str | None = None,
+        expected_version: int | None = None,
+    ) -> Summary:
+        validate_tenant_id(tenant_id)
+        async with self._write_lock:
+            await self._require_session(session_id, tenant_id)
+            existing = await self.get_summary(session_id, tenant_id)
+            version = existing.version if existing is not None else 0
+            if expected_version is not None and expected_version != version:
+                raise SummaryVersionMismatch(expected=expected_version, actual=version)
+            now = utc_now().isoformat()
+            data = {
+                "summary_id": existing.summary_id if existing else new_summary_id(),
+                "session_id": session_id, "tenant_id": tenant_id, "text": text,
+                "last_applied_turn_id": last_applied_turn_id, "version": version + 1,
+                "source_model": source_model,
+                "created_at": existing.created_at.isoformat() if existing else now,
+                "updated_at": now,
+            }
+            await self._put("summary", tenant_id, session_id, "_", 0, data)
+            return self._summary(data)
+
+    async def clear_summary(self, session_id: str, tenant_id: str) -> bool:
+        validate_tenant_id(tenant_id)
+        return await self._delete("summary", tenant_id, session_id, "_")
+
+    async def close(self) -> None:
+        if self._owns_engine:
+            await self._engine.dispose()

--- a/tests/test_memory_postgres.py
+++ b/tests/test_memory_postgres.py
@@ -1,0 +1,126 @@
+"""PostgresMemoryStore contract coverage via SQLite-backed SQLAlchemy."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from modelmeld.config import GatewaySettings
+from modelmeld.memory import PostgresMemoryStore, Role, SummaryVersionMismatch
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("sqlalchemy") is None
+    or importlib.util.find_spec("aiosqlite") is None,
+    reason="SQLAlchemy + aiosqlite test dependencies are not installed",
+)
+
+
+async def _make_store(tmp_path) -> PostgresMemoryStore:
+    from sqlalchemy.ext.asyncio import create_async_engine  # type: ignore[reportMissingImports]
+
+    db_path = tmp_path / "memory.sqlite3"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    store = PostgresMemoryStore(engine=engine)
+    await store.initialize()
+    return store
+
+
+async def test_postgres_memory_store_round_trips_session_turn_fact_summary(tmp_path) -> None:
+    store = await _make_store(tmp_path)
+    try:
+        session = await store.get_or_create_session(
+            "s-1",
+            "acme",
+            user_id="alice",
+            metadata={"workspace": "eng"},
+        )
+        assert session.metadata == {"workspace": "eng"}
+
+        first = await store.append_turn(
+            "s-1",
+            "acme",
+            Role.USER,
+            "remember blue",
+            3,
+            model_used="gpt-5-mini",
+        )
+        await store.append_turn("s-1", "acme", Role.ASSISTANT, "noted", 2)
+
+        assert await store.turn_count("s-1", "acme") == 2
+        assert [turn.content for turn in await store.list_turns("s-1", "acme")] == [
+            "remember blue",
+            "noted",
+        ]
+        assert [
+            turn.content for turn in await store.list_turns("s-1", "acme", limit=1)
+        ] == ["noted"]
+
+        fact = await store.set_fact("s-1", "acme", "favorite_color", "blue")
+        assert fact.key == "favorite_color"
+        await store.set_fact("s-1", "acme", "favorite_color", "green")
+        facts = await store.get_facts("s-1", "acme")
+        assert len(facts) == 1
+        assert facts[0].value == "green"
+
+        summary = await store.upsert_summary(
+            "s-1",
+            "acme",
+            "The user likes green.",
+            first.turn_id,
+            source_model="gpt-5-mini",
+            expected_version=0,
+        )
+        assert summary.version == 1
+        updated = await store.upsert_summary(
+            "s-1",
+            "acme",
+            "The user prefers green.",
+            first.turn_id,
+            source_model="gpt-5-mini",
+            expected_version=1,
+        )
+        assert updated.version == 2
+        current = await store.get_summary("s-1", "acme")
+        assert current is not None
+        assert current.text == "The user prefers green."
+    finally:
+        await store.close()
+
+
+async def test_postgres_memory_store_preserves_tenant_isolation(tmp_path) -> None:
+    store = await _make_store(tmp_path)
+    try:
+        await store.get_or_create_session("shared", "tenant-a")
+        await store.get_or_create_session("shared", "tenant-b")
+        await store.append_turn("shared", "tenant-a", Role.USER, "a-only", 1)
+        await store.append_turn("shared", "tenant-b", Role.USER, "b-only", 1)
+
+        a_turns = await store.list_turns("shared", "tenant-a")
+        b_turns = await store.list_turns("shared", "tenant-b")
+        assert [turn.content for turn in a_turns] == ["a-only"]
+        assert [turn.content for turn in b_turns] == ["b-only"]
+    finally:
+        await store.close()
+
+
+async def test_postgres_memory_store_enforces_summary_versions(tmp_path) -> None:
+    store = await _make_store(tmp_path)
+    try:
+        await store.get_or_create_session("s-1", "acme")
+        await store.upsert_summary("s-1", "acme", "v1", None, expected_version=0)
+        with pytest.raises(SummaryVersionMismatch):
+            await store.upsert_summary("s-1", "acme", "stale", None, expected_version=0)
+    finally:
+        await store.close()
+
+
+def test_build_app_uses_postgres_memory_backend_from_settings(tmp_path) -> None:
+    from modelmeld.api.server import build_app
+
+    settings = GatewaySettings(
+        memory_backend="postgres",
+        memory_database_url=f"sqlite+aiosqlite:///{tmp_path / 'server.sqlite3'}",
+    )
+    app = build_app(settings)
+    assert isinstance(app.state.memory_store, PostgresMemoryStore)


### PR DESCRIPTION
## Summary

Add a SQL-backed PostgresMemoryStore skeleton for persistent memory across workers. The implementation keeps the default in_memory backend unchanged, adds MODELMELD_MEMORY_BACKEND=postgres wiring, and stores memory documents in a simple table with JSON/JSONB payloads.

Closes #2

## Type of change

- [x] Feature
- [x] Tests

## Test plan

- python -m ruff check pyproject.toml src\modelmeld\api\server.py src\modelmeld\config.py src\modelmeld\memory\__init__.py src\modelmeld\memory\postgres.py tests\test_memory_postgres.py
- python -m pytest tests\test_memory_postgres.py
- python -m pytest tests\test_memory_in_memory.py tests\test_memory_identity.py tests\test_memory_summary.py tests\test_memory_tenant_isolation.py tests\test_chat_memory_integration.py tests\test_api_smoke.py tests\test_memory_postgres.py

## Notes

The Postgres store can also be exercised with a SQLite async engine in tests, so contributors do not need a running Postgres service for the contract coverage.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated if user-facing behavior changed
- [x] All commits have DCO signoff (git commit -s) -- see CONTRIBUTING.md