### PR TITLE
Add dedicated routing-hint headers reference doc (closes #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Two complementary surfaces:
   - **Routing-hint headers** (`x-modelmeld-task-category`,
     `x-modelmeld-agent-role`, etc.) let frameworks declare task category
     and agent role explicitly instead of relying on the classifier.
+    (see [Routing-hint headers reference](docs/routing-hints.md)).
 
 ## Integration scope — v1 commitments
 

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -33,40 +33,7 @@ Without any framework code changes:
 
 ## Routing-hint headers
 
-When the framework already knows what each agent does, it can tell us:
-
-| Header                                 | Effect |
-| -------------------------------------- | ------ |
-| `x-modelmeld-task-category`          | One of `coding`, `reasoning`, `simple_qa`, `summarization`, `tool_use`. Bypasses the heuristic classifier. |
-| `x-modelmeld-agent-role`             | A role name (e.g. `coder`, `researcher`, `reviewer`, `summarizer`, `executor`). Mapped to a task category server-side. |
-| `x-modelmeld-quality-threshold`      | Float in `[0, 1]`. Raises or lowers the minimum task score the chosen model must have. |
-| `x-modelmeld-exclude-providers`      | Comma-separated provider names to forbid (e.g. `openai,anthropic` for residency / cost ceilings). |
-
-If both `task-category` and `agent-role` are present, `task-category` wins.
-
-## Response headers you can read
-
-Every chat-completions response carries audit-trail headers so you can
-reproduce any routing decision client-side. Decisions are deterministic
-functions of request shape + registry state — same request, same
-registry, same model. Compare with OpenRouter's explicitly
-non-deterministic Auto Router or Martian's closed-source "Model
-Mapping": ours is auditable.
-
-| Header                                 | Meaning |
-| -------------------------------------- | ------- |
-| `x-modelmeld-routed-to`              | Adapter that served the request (`openai`, `anthropic`, `vllm`, `fireworks`, `together`, `openrouter`). |
-| `x-modelmeld-routed-model`           | The actual model the gateway sent upstream. May differ from `model` in your request body. |
-| `x-modelmeld-task-category`          | Final category used for routing (`coding`, `reasoning`, `simple_qa`, `summarization`, `tool_use`). |
-| `x-modelmeld-category-source`        | One of `classifier`, `hint:task_category`, `hint:agent_role`. Tells you whether your hint took effect. |
-| `x-modelmeld-task-score`             | Chosen model's score on that category. |
-| `x-modelmeld-quality-threshold`      | Threshold that was applied (post-bias if any). |
-| `x-modelmeld-tier`                   | `local` (vLLM) or `cloud`. |
-| `x-modelmeld-failover-from`          | Set when failover happened — value is the original tier. |
-| `x-modelmeld-devtool`                | Detected client tool + confidence, e.g. `cursor:0.80` or `claude_code:0.95`. Absent for unknown clients. |
-| `x-modelmeld-bias`                   | Set when a shape-based routing bias was applied, e.g. `autocomplete_shape`. Absent when no bias. |
-| `x-modelmeld-redactions`             | PII categories that were scrubbed before egress (e.g. `EMAIL:2,SSN:1`). |
-| `x-modelmeld-cache`                  | One of `hit`, `hit-semantic`, `miss`, `bypass`. Tells you whether the response came from cache. |
+For a complete, canonical reference of all `x-modelmeld-*` request and response headers — including accepted values, overrides, examples, and which integrations set them — see [Routing-hint headers reference](../routing-hints.md).
 
 ## Coding tool guides
 

--- a/docs/integrations/aider.md
+++ b/docs/integrations/aider.md
@@ -72,6 +72,8 @@ x-modelmeld-task-category: coding
 x-modelmeld-quality-threshold: 0.80
 ```
 
+For the full list of response headers and their meanings, see the [Routing-hint headers reference](../routing-hints.md).
+
 ## Common gotchas
 
 - **Model name prefixes are LiteLLM's, not ours** — `openai/foo`,

--- a/docs/integrations/autogen.md
+++ b/docs/integrations/autogen.md
@@ -46,6 +46,8 @@ The `Coder` agent gets routed to a cheap coding-strong model (e.g.
 `qwen3-coder-next`). The `Reviewer` gets a stronger model at threshold
 0.90. The `Planner` gets a reasoning-strong model.
 
+For the full list of response headers and their meanings, see the [Routing-hint headers reference](../routing-hints.md).
+
 ## GroupChat — different role per agent
 
 ```python

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -116,6 +116,8 @@ You can grep the headers from `claude --verbose` output or use the
 `/cost` slash-command in-session to see per-request cost (which
 reflects ModelMeld's routed model + actual provider pricing).
 
+For the full list of response headers and their meanings, see the [Routing-hint headers reference](../routing-hints.md).
+
 ## Surfacing auto-route aliases in the /model picker
 
 Claude Code 2.1.126+ ships an opt-in "gateway model discovery" feature

--- a/docs/integrations/cline.md
+++ b/docs/integrations/cline.md
@@ -60,6 +60,8 @@ The model name comes from `response.model` which we set to our
 routed model. To see the full audit trail, check the gateway's
 account dashboard.
 
+For the full list of response headers and their meanings, see the [Routing-hint headers reference](../routing-hints.md).
+
 ## Common gotchas
 
 - **`Custom Headers` field** — Cline's OpenAI Compatible provider has

--- a/docs/integrations/continue.md
+++ b/docs/integrations/continue.md
@@ -84,6 +84,8 @@ Use Continue's "Show Model" toggle in the chat UI to see which model
 served the response. The displayed model name is what `response.model`
 returns — for ModelMeld that's the actual routed model.
 
+For the full list of response headers and their meanings, see the [Routing-hint headers reference](../routing-hints.md).
+
 ## Common gotchas
 
 - **`requestOptions.headers` is YAML strings** — quote numeric values

--- a/docs/integrations/crewai.md
+++ b/docs/integrations/crewai.md
@@ -46,6 +46,8 @@ coder = Agent(
 CrewAI passes `default_headers` through to LiteLLM → through to the
 gateway. Each agent gets a cost-optimized model for its role.
 
+For the full list of response headers and their meanings, see the [Routing-hint headers reference](../routing-hints.md).
+
 ## Alternative: per-task task_category override
 
 If a single agent handles different categories of work in different

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -64,6 +64,8 @@ async def proxy(req: Request):
 
 Then point Cursor at `http://localhost:8000/v1`.
 
+For the full list of response headers and their meanings, see the [Routing-hint headers reference](../routing-hints.md).
+
 ## Verify the routing
 
 Cursor doesn't surface response headers in its UI. To see what model

--- a/docs/integrations/langgraph.md
+++ b/docs/integrations/langgraph.md
@@ -49,6 +49,8 @@ response = coder_llm.invoke(messages)
 # response.response_metadata["headers"]["x-modelmeld-routed-model"]  # e.g. "qwen3-coder-next"
 ```
 
+For the full list of response headers and their meanings, see the [Routing-hint headers reference](../routing-hints.md).
+
 ## Pattern: dynamic category per state
 
 If your graph branches on the task type, override the category per call:

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -51,6 +51,8 @@ sub_agents:
       x-modelmeld-quality-threshold: "0.90"
 ```
 
+For the full list of response headers and their meanings, see the [Routing-hint headers reference](../routing-hints.md).
+
 ## Verifying the cost win
 
 Run a 100-task benchmark with and without the gateway pointed at:

--- a/docs/integrations/zed.md
+++ b/docs/integrations/zed.md
@@ -98,6 +98,8 @@ Look for these response headers:
 | `x-modelmeld-tier` | The serving tier used for the request. |
 | `x-modelmeld-task-category` | The inferred task category, unless you supplied a hint through another client. |
 
+For the full list of response headers and their meanings, see the [Routing-hint headers reference](../routing-hints.md).
+
 ## Common gotchas
 
 - **Use the OpenAI-compatible provider shape**. Put ModelMeld under

--- a/docs/routing-hints.md
+++ b/docs/routing-hints.md
@@ -1,0 +1,75 @@
+# Routing-hint headers reference
+
+Canonical reference for `x-modelmeld-*` headers used to control routing and audit trail. Each integration guide links here.
+
+## Request headers
+
+### x-modelmeld-task-category
+- **Accepted values:** `coding`, `reasoning`, `simple_qa`, `summarization`, `tool_use`
+- **Overrides:** Bypasses the heuristic classifier
+- **Example:** `x-modelmeld-task-category: coding`
+- **Integrations commonly setting this:** Agent frameworks (AutoGen, CrewAI, LangGraph, OpenClaw); any client adding custom headers
+
+### x-modelmeld-agent-role
+- **Accepted values:** Role name (e.g. `coder`, `researcher`, `reviewer`, `summarizer`, `executor`) — mapped to a task category server-side
+- **Overrides:** Provides an alternative way to set task category; if both `task-category` and `agent-role` are present, `task-category` wins
+- **Example:** `x-modelmeld-agent-role: coder`
+- **Integrations commonly setting this:** Agent frameworks with per-agent role declarations
+
+### x-modelmeld-quality-threshold
+- **Accepted values:** Float in `[0, 1]`
+- **Overrides:** Raises or lowers the minimum task score the chosen model must have
+- **Example:** `x-modelmeld-quality-threshold: 0.85`
+- **Integrations commonly setting this:** Any integration that exposes a quality slider
+
+### x-modelmeld-exclude-providers
+- **Accepted values:** Comma-separated provider names (e.g. `openai,anthropic`)
+- **Overrides:** Forbids the listed providers from being chosen for this request
+- **Example:** `x-modelmeld-exclude-providers: openai,anthropic`
+- **Integrations commonly setting this:** Users with data-residency or cost constraints; any client that allows custom headers
+
+### x-modelmeld-byok-anthropic / x-modelmeld-byok-openai (BYOK headers)
+- **Accepted values:** Your own Anthropic or OpenAI API key
+- **Overrides:** Uses your key instead of the gateway's configured key; key is never stored or logged
+- **Example:** `x-modelmeld-byok-anthropic: sk-ant-...`
+- **Integrations commonly setting this:** Any tool configured via `modelmeld setup` or that allows setting custom HTTP headers (Claude Code, Aider, etc.)
+
+## Response headers
+
+All response headers are emitted by the gateway and can be read by any integration. They provide audit-trail data.
+
+### x-modelmeld-routed-to
+- **Meaning:** Adapter that served the request (`openai`, `anthropic`, `vllm`, `fireworks`, `together`, `openrouter`)
+
+### x-modelmeld-routed-model
+- **Meaning:** The actual model the gateway sent upstream; may differ from `model` in the request
+
+### x-modelmeld-task-category
+- **Meaning:** Final category used for routing (`coding`, `reasoning`, `simple_qa`, `summarization`, `tool_use`)
+
+### x-modelmeld-category-source
+- **Meaning:** One of `classifier`, `hint:task_category`, `hint:agent_role` — indicates whether a hint took effect
+
+### x-modelmeld-task-score
+- **Meaning:** Chosen model's score on that category (float)
+
+### x-modelmeld-quality-threshold
+- **Meaning:** Threshold applied (post-bias if any)
+
+### x-modelmeld-tier
+- **Meaning:** `local` (vLLM) or `cloud`
+
+### x-modelmeld-failover-from
+- **Meaning:** Set when failover happened — value is the original tier
+
+### x-modelmeld-devtool
+- **Meaning:** Detected client tool + confidence, e.g. `cursor:0.80` or `claude_code:0.95`; absent for unknown clients
+
+### x-modelmeld-bias
+- **Meaning:** Set when a shape-based routing bias was applied, e.g. `autocomplete_shape`; absent when no bias
+
+### x-modelmeld-redactions
+- **Meaning:** PII categories scrubbed before egress, e.g. `EMAIL:2,SSN:1`
+
+### x-modelmeld-cache
+- **Meaning:** One of `hit`, `hit-semantic`, `miss`, `bypass`


### PR DESCRIPTION
## Summary

This PR creates a dedicated routing-hint headers reference document (`docs/routing-hints.md`) and updates all integration guides to link to it, removing duplicated header tables. The motivation is to give every integration guide one canonical source for `x-modelmeld-*` headers instead of repeating subsets inline, as requested in #12.

## Type of change

- [x] Documentation

## Test plan

No code or tests were touched. 
Did only preview check.

## Linked issues

Closes #12

## Checklist

- [x] Documentation updated if user-facing behavior changed
- [x] If this touches the open-core boundary or registry data, I've read `docs/open-core-boundary.md` *(does not apply)*

## Additional context

I've left brief inline mentions of headers in "gotchas" sections where they were already present, per the issue instructions. If any changes or corrections needed I'll do that in a follow-up commit.