### PR TITLE
docs: add Codex CLI integration guide

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -46,6 +46,7 @@ Drop-in setup for the coding agents customers actually run day to day:
 - [**Continue.dev**](continue.md) — VS Code/JetBrains with per-role models
 - [**opencode**](opencode.md) — SST's terminal coding agent with a native provider system
 - [**Zed**](zed.md) — editor agent panel via OpenAI-compatible provider
+- [**Codex CLI**](codex-cli.md) — OpenAI terminal agent via OpenAI-compatible provider
 
 ## Agent framework guides
 

--- a/docs/integrations/codex-cli.md
+++ b/docs/integrations/codex-cli.md
@@ -1,0 +1,88 @@
+# Codex CLI -> ModelMeld
+
+[Codex CLI](https://github.com/openai/codex) is OpenAI's open-source
+terminal coding agent. It speaks OpenAI's `/v1/chat/completions` natively,
+so pointing it at ModelMeld is a base-URL override and an API-key swap.
+ModelMeld then picks the cheapest capable backend per request and records
+the routing decision in response headers.
+
+## Minimal setup
+
+Install Codex CLI, then set two environment variables before launching it:
+
+```sh
+export OPENAI_BASE_URL="https://api.modelmeld.ai/v1"
+export OPENAI_API_KEY="gws_<your-modelmeld-key>"
+codex
+```
+
+On Windows PowerShell:
+
+```powershell
+$env:OPENAI_BASE_URL = "https://api.modelmeld.ai/v1"
+$env:OPENAI_API_KEY = "gws_<your-modelmeld-key>"
+codex
+```
+
+Codex CLI reads these environment variables automatically — no config file
+edits needed. Send a small prompt to verify the connection works.
+
+## Optional routing check
+
+Codex CLI does not show HTTP response headers in the terminal. To confirm
+that the gateway is routing requests, run a direct request with the same
+key:
+
+```sh
+curl -i https://api.modelmeld.ai/v1/chat/completions \
+  -H "authorization: Bearer $OPENAI_API_KEY" \
+  -H "content-type: application/json" \
+  -d '{
+    "model": "gpt-5.5",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Reply with one sentence about ModelMeld routing."
+      }
+    ],
+    "max_tokens": 80
+  }'
+```
+
+Look for these response headers:
+
+| Header | What to check |
+| ------ | ------------- |
+| `x-modelmeld-routed-model` | The actual model selected by the gateway. |
+| `x-modelmeld-tier` | The serving tier used for the request. |
+| `x-modelmeld-task-category` | The inferred task category, unless you supplied a hint through another client. |
+
+For the full list of response headers and their meanings, see the [Routing-hint headers reference](../routing-hints.md).
+
+## Common gotchas
+
+- **Use `OPENAI_BASE_URL`, not a config file**. Codex CLI reads the
+  OpenAI-compatible base URL from the environment variable. There is no
+  settings file for provider configuration.
+- **Keep `/v1` in the base URL**. Codex appends chat-completions paths to
+  that base URL. If you omit `/v1`, requests will 404.
+- **Codex uses `gpt-5.5` by default**. ModelMeld will route this to the
+  cheapest capable model. If you want a specific model, pass `--model`
+  or set `OPENAI_MODEL` in the environment.
+- **Codex's sandbox mode is independent of ModelMeld**. Codex has its own
+  sandbox for shell commands. ModelMeld only handles LLM routing — it does
+  not affect Codex's sandbox behavior.
+- **Rate limits come from ModelMeld, not OpenAI**. If you hit rate limits,
+  check your ModelMeld dashboard, not your OpenAI account.
+
+## Advanced: custom routing headers
+
+To send custom routing hints (e.g., force a specific tier or task category),
+you can use a local proxy that injects `x-modelmeld-*` headers and point
+`OPENAI_BASE_URL` at that proxy. See the [Routing-hint headers reference](../routing-hints.md)
+for accepted values.
+
+## See also
+
+- [Codex CLI GitHub](https://github.com/openai/codex)
+- [ModelMeld integrations overview](README.md)


### PR DESCRIPTION
## Summary

Fixes #11

Add integration guide for OpenAI's Codex CLI terminal coding agent. Codex speaks OpenAI's `/v1/chat/completions` natively, so the integration is a simple base-URL override and API-key swap.

## Changes

- **docs/integrations/codex-cli.md** — New integration guide following the zed.md template:
  - One-paragraph "why bother" intro
  - Step-by-step setup (env vars for sh and PowerShell)
  - Routing verification via curl
  - Common gotchas section
  - Advanced routing header usage

- **docs/integrations/README.md** — Added Codex CLI to the coding tool guides list

## Test plan

- [x] Documentation follows existing template pattern (zed.md)
- [x] Environment variables match Codex CLI's actual configuration
- [x] Base URL includes `/v1` suffix
- [x] Response headers match ModelMeld's documented headers
- [x] Common gotchas are accurate and helpful

---
