### PR TITLE
refactor(memory): introduce MemoryProvider seam over the tiered store

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,13 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install pip-audit
-        run: pip install pip-audit
+        # Upgrade pip first: pip-audit audits the whole environment, so a CVE
+        # in the runner's stock pip (e.g. PYSEC-2026-196 in pip 26.1.1) would
+        # fail --strict even though it's build tooling, not a project dep.
+        # ci.yml and release.yml already do this; keep the three consistent.
+        run: |
+          python -m pip install --upgrade pip
+          pip install pip-audit
       - name: Audit
         # --skip-editable skips local-path packages. --strict treats any
         # vuln as a failure; remove if you need to triage MEDIUM/LOW

--- a/src/modelmeld/api/routes/chat.py
+++ b/src/modelmeld/api/routes/chat.py
@@ -31,7 +31,6 @@ from modelmeld.api.schemas import (
     ChatCompletionChunk,
     ChatCompletionRequest,
     TextPart,
-    UserMessage,
 )
 from modelmeld.api.subscription_passthrough import (
     PassthroughVendor,
@@ -53,11 +52,10 @@ from modelmeld.hooks import (
 )
 from modelmeld.memory import (
     ANONYMOUS_TENANT_ID,
+    MemoryContext,
     MemoryHeaderError,
     MemoryIdentity,
-    MemoryStore,
-    Role,
-    assemble_context,
+    MemoryProvider,
     extract_memory_identity,
     inject_into_request,
 )
@@ -79,7 +77,7 @@ async def chat_completions(
     rt: Router = fastapi_request.app.state.router
     scrubber: Scrubber | None = fastapi_request.app.state.scrubber
     hooks: HookRegistry = fastapi_request.app.state.hooks
-    memory: MemoryStore | None = getattr(fastapi_request.app.state, "memory_store", None)
+    provider: MemoryProvider | None = getattr(fastapi_request.app.state, "memory_provider", None)
     token_counter: TokenCounter | None = getattr(fastapi_request.app.state, "token_counter", None)
     completion_cache: CompletionCache | None = getattr(
         fastapi_request.app.state, "completion_cache", None,
@@ -191,7 +189,10 @@ async def chat_completions(
 
     # Memory injection. Prepend L1+L2 (and L3 in FULL mode)
     # BEFORE scrub so injected content is also scrubbed on egress.
-    mem_context = await assemble_context(memory, mem_identity)
+    mem_context = (
+        await provider.retrieve(mem_identity, request)
+        if provider is not None else MemoryContext()
+    )
     request = inject_into_request(request, mem_context)
     outgoing, redactions = _maybe_scrub(request, decision, scrubber)
     # Note: model override is applied inside the failover helpers per-attempt so
@@ -205,7 +206,7 @@ async def chat_completions(
         cache_status = "bypass" if completion_cache is not None else None
         return await _stream_with_failover(
             rt, decision, outgoing, redactions, hooks, request_id, started,
-            identity, memory, mem_identity, token_counter,
+            identity, provider, mem_identity, token_counter,
             cache_status=cache_status,
             hints=hints,
             model_registry=getattr(fastapi_request.app.state, "model_registry", None),
@@ -275,7 +276,7 @@ async def chat_completions(
 
     return await _completion_with_failover(
         rt, decision, outgoing, redactions, hooks, request_id, started, response,
-        identity, memory, mem_identity, token_counter,
+        identity, provider, mem_identity, token_counter,
         completion_cache=completion_cache, cache_key=cache_key, cache_ttl=cache_ttl,
         semantic_cache=semantic_cache, served_model=served_model,
         hints=hints,
@@ -414,7 +415,7 @@ async def _completion_with_failover(
     started: float,
     response: Response,
     identity: dict[str, str | None] | None,
-    memory: MemoryStore | None,
+    provider: MemoryProvider | None,
     mem_identity: MemoryIdentity,
     token_counter: TokenCounter | None,
     *,
@@ -485,7 +486,7 @@ async def _completion_with_failover(
         hooks, request_id, started, request, decision, redactions, failover_from,
         completion, identity, cache_status=miss_status,
     )
-    await _write_memory_turns(memory, mem_identity, request, completion, decision, token_counter)
+    await _write_memory_turns(provider, mem_identity, request, completion, decision, token_counter)
     return completion
 
 
@@ -502,7 +503,7 @@ async def _stream_with_failover(
     request_id: str,
     started: float,
     identity: dict[str, str | None] | None,
-    memory: MemoryStore | None,
+    provider: MemoryProvider | None,
     mem_identity: MemoryIdentity,
     token_counter: TokenCounter | None,
     *,
@@ -547,7 +548,7 @@ async def _stream_with_failover(
         _sse_stream(
             primary_aiter, first_chunk, hooks, request_id, started,
             request, decision, redactions, failover_from, identity,
-            memory, mem_identity, token_counter,
+            provider, mem_identity, token_counter,
         ),
         media_type="text/event-stream",
         headers=headers,
@@ -588,7 +589,7 @@ async def _sse_stream(
     redactions: list[Redaction],
     failover_from: str | None,
     identity: dict[str, str | None] | None,
-    memory: MemoryStore | None,
+    provider: MemoryProvider | None,
     mem_identity: MemoryIdentity,
     token_counter: TokenCounter | None,
 ) -> AsyncIterator[str]:
@@ -620,7 +621,7 @@ async def _sse_stream(
             output_tokens, last_usage, identity,
         )
         await _write_memory_turns_streaming(
-            memory, mem_identity, request, "".join(accumulated_text),
+            provider, mem_identity, request, "".join(accumulated_text),
             output_tokens, decision, token_counter,
         )
     else:
@@ -653,33 +654,31 @@ def _chunk_text_pieces(chunk: ChatCompletionChunk) -> list[str]:
 # ---------------------------------------------------------------------------
 
 async def _write_memory_turns(
-    memory: MemoryStore | None,
+    provider: MemoryProvider | None,
     mem_identity: MemoryIdentity,
     request: ChatCompletionRequest,
     completion: ChatCompletion,
     decision: RoutingDecision,
     token_counter: TokenCounter | None,
 ) -> None:
-    """Append the user prompt + assistant response to L0. Best-effort.
+    """Record the user prompt + assistant response. Best-effort.
 
-    Memory failures NEVER break the request. The user already got their answer;
-    losing a turn write is recoverable from L0 elsewhere (eventually) but a
-    500 isn't.
+    Memory failures NEVER break the request — the provider swallows + logs them.
+    This helper only does the route-shaped extraction (pull assistant text +
+    token count out of the completion) before handing off to the provider.
     """
-    if memory is None or not mem_identity.active:
+    if provider is None or not mem_identity.active:
         return
-    assert mem_identity.session_id is not None  # narrow for type checker
     model_used = decision.model_id_override or request.model
     assistant_text = _extract_completion_text(completion)
     if completion.usage and completion.usage.completion_tokens:
         assistant_tokens = completion.usage.completion_tokens
     else:
         assistant_tokens = _count_tokens(token_counter, assistant_text, model_used)
-    await _append_request_response_turns(
-        memory=memory,
-        mem_identity=mem_identity,
-        request=request,
-        assistant_text=assistant_text,
+    await provider.record(
+        mem_identity,
+        request,
+        assistant_text,
         assistant_tokens=assistant_tokens,
         model_used=model_used,
         token_counter=token_counter,
@@ -687,7 +686,7 @@ async def _write_memory_turns(
 
 
 async def _write_memory_turns_streaming(
-    memory: MemoryStore | None,
+    provider: MemoryProvider | None,
     mem_identity: MemoryIdentity,
     request: ChatCompletionRequest,
     assistant_text: str,
@@ -695,82 +694,21 @@ async def _write_memory_turns_streaming(
     decision: RoutingDecision,
     token_counter: TokenCounter | None,
 ) -> None:
-    if memory is None or not mem_identity.active:
+    if provider is None or not mem_identity.active:
         return
     model_used = decision.model_id_override or request.model
     # Streaming accumulator gave us a char-based count; if we have a real
     # counter, recount the full reassembled text now that the stream is done.
     if token_counter is not None and assistant_text:
         assistant_tokens = token_counter.count_text(assistant_text, model_used)
-    await _append_request_response_turns(
-        memory=memory,
-        mem_identity=mem_identity,
-        request=request,
-        assistant_text=assistant_text,
+    await provider.record(
+        mem_identity,
+        request,
+        assistant_text,
         assistant_tokens=assistant_tokens,
         model_used=model_used,
         token_counter=token_counter,
     )
-
-
-async def _append_request_response_turns(
-    memory: MemoryStore,
-    mem_identity: MemoryIdentity,
-    request: ChatCompletionRequest,
-    assistant_text: str,
-    assistant_tokens: int,
-    model_used: str,
-    token_counter: TokenCounter | None,
-) -> None:
-    """Shared write path for both streaming + non-streaming success."""
-    try:
-        await memory.get_or_create_session(
-            session_id=mem_identity.session_id,  # type: ignore[arg-type]
-            tenant_id=mem_identity.tenant_id,
-            user_id=mem_identity.user_id,
-        )
-        # Append the last user turn from the incoming request (the prompt the
-        # user just sent). We only log the newest user message — prior turns
-        # came from earlier requests and are already in L0.
-        last_user = _last_user_turn(request, token_counter, model_used)
-        if last_user is not None:
-            user_text, user_tokens = last_user
-            await memory.append_turn(
-                session_id=mem_identity.session_id,  # type: ignore[arg-type]
-                tenant_id=mem_identity.tenant_id,
-                role=Role.USER,
-                content=user_text,
-                token_count=user_tokens,
-                model_used=model_used,
-            )
-        await memory.append_turn(
-            session_id=mem_identity.session_id,  # type: ignore[arg-type]
-            tenant_id=mem_identity.tenant_id,
-            role=Role.ASSISTANT,
-            content=assistant_text,
-            token_count=assistant_tokens,
-            model_used=model_used,
-        )
-    except Exception:
-        logger.exception("memory write failed for session %s", mem_identity.session_id)
-
-
-def _last_user_turn(
-    request: ChatCompletionRequest,
-    token_counter: TokenCounter | None,
-    model_used: str,
-) -> tuple[str, int] | None:
-    """Find the most recent user message in the request + return (text, tokens)."""
-    for msg in reversed(request.messages):
-        if isinstance(msg, UserMessage):
-            if isinstance(msg.content, str):
-                text = msg.content
-            else:
-                text = "".join(
-                    part.text for part in msg.content if isinstance(part, TextPart)
-                )
-            return text, _count_tokens(token_counter, text, model_used)
-    return None
 
 
 def _count_tokens(

--- a/src/modelmeld/api/routes/messages.py
+++ b/src/modelmeld/api/routes/messages.py
@@ -82,9 +82,9 @@ from modelmeld.cache import (
 from modelmeld.hooks import HookRegistry
 from modelmeld.memory import (
     ANONYMOUS_TENANT_ID,
+    MemoryContext,
     MemoryHeaderError,
-    MemoryStore,
-    assemble_context,
+    MemoryProvider,
     extract_memory_identity,
     inject_into_request,
 )
@@ -253,8 +253,8 @@ async def anthropic_messages(
     rt: Router = fastapi_request.app.state.router
     scrubber: Scrubber | None = fastapi_request.app.state.scrubber
     hooks: HookRegistry = fastapi_request.app.state.hooks
-    memory: MemoryStore | None = getattr(
-        fastapi_request.app.state, "memory_store", None,
+    provider: MemoryProvider | None = getattr(
+        fastapi_request.app.state, "memory_provider", None,
     )
     token_counter: TokenCounter | None = getattr(
         fastapi_request.app.state, "token_counter", None,
@@ -404,7 +404,10 @@ async def anthropic_messages(
 
     # Memory injection. Operates on internal shape;
     # exact same call as the chat route.
-    mem_context = await assemble_context(memory, mem_identity)
+    mem_context = (
+        await provider.retrieve(mem_identity, internal_request)
+        if provider is not None else MemoryContext()
+    )
     internal_request = inject_into_request(internal_request, mem_context)
     outgoing, redactions = _maybe_scrub(internal_request, decision, scrubber)
 
@@ -418,7 +421,7 @@ async def anthropic_messages(
         input_tokens = _estimate_input_tokens(outgoing, token_counter)
         return await _stream_messages_with_failover(
             rt, decision, outgoing, redactions, hooks, request_id, started,
-            identity, memory, mem_identity, token_counter,
+            identity, provider, mem_identity, token_counter,
             request_model=body.model,
             input_tokens=input_tokens,
             cache_status=cache_status,
@@ -568,7 +571,7 @@ async def anthropic_messages(
         completion, identity, cache_status=miss_status,
     )
     await _write_memory_turns(
-        memory, mem_identity, outgoing, completion, decision, token_counter,
+        provider, mem_identity, outgoing, completion, decision, token_counter,
     )
 
     # Translate internal ChatCompletion → Anthropic response shape.
@@ -690,7 +693,7 @@ async def _stream_messages_with_failover(
     request_id: str,
     started: float,
     identity: dict[str, str | None] | None,
-    memory: MemoryStore | None,
+    provider: MemoryProvider | None,
     mem_identity: Any,       # MemoryIdentity
     token_counter: TokenCounter | None,
     *,
@@ -759,7 +762,7 @@ async def _stream_messages_with_failover(
         _sse_anthropic_stream(
             primary_aiter, first_chunk, hooks, request_id, started,
             request, decision, redactions, failover_from, identity,
-            memory, mem_identity, token_counter,
+            provider, mem_identity, token_counter,
             request_model=request_model, input_tokens=input_tokens,
         ),
         media_type="text/event-stream",
@@ -778,7 +781,7 @@ async def _sse_anthropic_stream(
     redactions: list,
     failover_from: str | None,
     identity: dict[str, str | None] | None,
-    memory: MemoryStore | None,
+    provider: MemoryProvider | None,
     mem_identity: Any,       # MemoryIdentity
     token_counter: TokenCounter | None,
     *,
@@ -832,7 +835,7 @@ async def _sse_anthropic_stream(
             output_tokens, last_usage, identity,
         )
         await _write_memory_turns_streaming(
-            memory, mem_identity, request, "".join(accumulated_text),
+            provider, mem_identity, request, "".join(accumulated_text),
             output_tokens, decision, token_counter,
         )
     else:

--- a/src/modelmeld/api/server.py
+++ b/src/modelmeld/api/server.py
@@ -15,7 +15,13 @@ from modelmeld.adapters import ProviderAdapter
 from modelmeld.cache import CompletionCache, SemanticCompletionCache
 from modelmeld.config import GatewaySettings
 from modelmeld.hooks import HookRegistry
-from modelmeld.memory import InMemoryMemoryStore, MemoryStore, PostgresMemoryStore
+from modelmeld.memory import (
+    InMemoryMemoryStore,
+    MemoryProvider,
+    MemoryStore,
+    PostgresMemoryStore,
+    TieredMemoryProvider,
+)
 from modelmeld.privacy import Scrubber, build_scrubber
 from modelmeld.router import Router, SingleAdapterRouter, build_router
 from modelmeld.scout import ModelRegistry, Scout, build_scout, default_registry
@@ -30,9 +36,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         router: Router | None = getattr(app.state, "router", None)
         if router is not None:
             await router.close()
-        memory: MemoryStore | None = getattr(app.state, "memory_store", None)
-        if memory is not None:
-            await memory.close()
+        # Closing the provider releases its underlying store (the provider
+        # wraps app.state.memory_store), so we don't close the store twice.
+        provider: MemoryProvider | None = getattr(app.state, "memory_provider", None)
+        if provider is not None:
+            await provider.close()
         cache: CompletionCache | None = getattr(app.state, "completion_cache", None)
         if cache is not None:
             await cache.close()
@@ -87,6 +95,10 @@ def build_app(
         )
     else:
         app.state.memory_store = InMemoryMemoryStore()
+    # The routes talk to a MemoryProvider, not the store directly. The default
+    # provider wraps the tiered store above; alternative engines (e.g. Mem0)
+    # are selected here in a later sprint via settings.memory_backend.
+    app.state.memory_provider = TieredMemoryProvider(app.state.memory_store)
     # Token counter. Default char-based; settings can switch to
     # litellm. Pass `token_counter=` to inject a custom impl in tests.
     app.state.token_counter = (

--- a/src/modelmeld/memory/__init__.py
+++ b/src/modelmeld/memory/__init__.py
@@ -58,6 +58,10 @@ from modelmeld.memory.postgres import (
     MissingPostgresDependencyError,
     PostgresMemoryStore,
 )
+from modelmeld.memory.provider import (
+    MemoryProvider,
+    TieredMemoryProvider,
+)
 from modelmeld.memory.summarizer import (
     SummarizeCallable,
     SummarizerConfig,
@@ -88,6 +92,7 @@ __all__ = [
     "MemoryHeaderError",
     "MemoryIdentity",
     "MemoryMode",
+    "MemoryProvider",
     "MemoryStore",
     "MissingPostgresDependencyError",
     "PostgresMemoryStore",
@@ -99,6 +104,7 @@ __all__ = [
     "Summary",
     "SummaryVersionMismatch",
     "TenantMismatchError",
+    "TieredMemoryProvider",
     "Turn",
     "adapter_summarize_call",
     "assemble_context",

--- a/src/modelmeld/memory/provider.py
+++ b/src/modelmeld/memory/provider.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""MemoryProvider — the seam between the request path and the memory engine.
+
+The chat + messages routes talk to a `MemoryProvider`, not to a `MemoryStore`
+directly. This decouples *what the gateway does on each request* (retrieve a
+context to inject, record the exchange) from *which engine backs it*.
+
+`TieredMemoryProvider` wraps the built-in L0/L1/L2/L3 `MemoryStore` and is the
+default — behavior is identical to calling `assemble_context` + the turn-append
+helpers directly, which is what the routes did before this seam existed.
+
+Alternative engines (e.g. a Mem0-backed provider) implement the same two-method
+contract and slot in via `GatewaySettings.memory_backend`. The protocol is kept
+least-common-denominator (record an exchange / retrieve a context) so heavier
+engines fit behind it without reshaping it.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+
+from modelmeld.api.schemas import ChatCompletionRequest, TextPart, UserMessage
+from modelmeld.memory.base import MemoryStore, Role
+from modelmeld.memory.context import MemoryContext, assemble_context
+from modelmeld.memory.identity import MemoryIdentity
+from modelmeld.tokens import TokenCounter
+
+logger = logging.getLogger(__name__)
+
+
+class MemoryProvider(ABC):
+    """Per-request memory contract the routes depend on.
+
+    Implementations MUST treat every call as tenant-scoped (the tenant_id lives
+    on `mem_identity`) and MUST NOT let a memory failure break the user's
+    request — `retrieve` returns an empty context on error; `record` swallows
+    and logs. The user already has (or is getting) their answer either way.
+    """
+
+    @abstractmethod
+    async def retrieve(
+        self,
+        mem_identity: MemoryIdentity,
+        request: ChatCompletionRequest,
+    ) -> MemoryContext:
+        """Return the memory context to inject for this request.
+
+        Empty context when memory is inactive/disabled for the request.
+        """
+
+    @abstractmethod
+    async def record(
+        self,
+        mem_identity: MemoryIdentity,
+        request: ChatCompletionRequest,
+        assistant_text: str,
+        *,
+        assistant_tokens: int = 0,
+        model_used: str | None = None,
+        token_counter: TokenCounter | None = None,
+    ) -> None:
+        """Persist the just-completed user→assistant exchange. Best-effort."""
+
+    async def close(self) -> None:
+        """Release any held resources. Default no-op."""
+
+
+class TieredMemoryProvider(MemoryProvider):
+    """Default provider over the built-in tiered `MemoryStore` (L0/L1/L2/L3).
+
+    Retrieval delegates to `assemble_context`; recording uses the same
+    turn-append path the routes used before the seam existed. Behavior-preserving
+    by construction.
+    """
+
+    def __init__(self, store: MemoryStore | None) -> None:
+        self._store = store
+
+    @property
+    def store(self) -> MemoryStore | None:
+        return self._store
+
+    async def retrieve(
+        self,
+        mem_identity: MemoryIdentity,
+        request: ChatCompletionRequest,
+    ) -> MemoryContext:
+        # `request` is unused here: tiered retrieval keys off the session
+        # identity, not the current prompt. It stays in the signature for
+        # engines that search by query (e.g. Mem0).
+        return await assemble_context(self._store, mem_identity)
+
+    async def record(
+        self,
+        mem_identity: MemoryIdentity,
+        request: ChatCompletionRequest,
+        assistant_text: str,
+        *,
+        assistant_tokens: int = 0,
+        model_used: str | None = None,
+        token_counter: TokenCounter | None = None,
+    ) -> None:
+        if self._store is None or not mem_identity.active:
+            return
+        assert mem_identity.session_id is not None  # narrow for type checker
+        store = self._store
+        used_model = model_used or request.model
+        try:
+            await store.get_or_create_session(
+                session_id=mem_identity.session_id,
+                tenant_id=mem_identity.tenant_id,
+                user_id=mem_identity.user_id,
+            )
+            # Append the newest user turn from the incoming request only — prior
+            # turns came from earlier requests and are already in L0.
+            last_user = _last_user_turn(request, token_counter, used_model)
+            if last_user is not None:
+                user_text, user_tokens = last_user
+                await store.append_turn(
+                    session_id=mem_identity.session_id,
+                    tenant_id=mem_identity.tenant_id,
+                    role=Role.USER,
+                    content=user_text,
+                    token_count=user_tokens,
+                    model_used=used_model,
+                )
+            await store.append_turn(
+                session_id=mem_identity.session_id,
+                tenant_id=mem_identity.tenant_id,
+                role=Role.ASSISTANT,
+                content=assistant_text,
+                token_count=assistant_tokens,
+                model_used=used_model,
+            )
+        except Exception:
+            logger.exception(
+                "memory write failed for session %s", mem_identity.session_id
+            )
+
+    async def close(self) -> None:
+        if self._store is not None:
+            await self._store.close()
+
+
+def _last_user_turn(
+    request: ChatCompletionRequest,
+    token_counter: TokenCounter | None,
+    model_used: str,
+) -> tuple[str, int] | None:
+    """Find the most recent user message in the request + return (text, tokens)."""
+    for msg in reversed(request.messages):
+        if isinstance(msg, UserMessage):
+            if isinstance(msg.content, str):
+                text = msg.content
+            else:
+                text = "".join(
+                    part.text for part in msg.content if isinstance(part, TextPart)
+                )
+            return text, _count_tokens(token_counter, text, model_used)
+    return None
+
+
+def _count_tokens(
+    counter: TokenCounter | None, text: str, model: str | None
+) -> int:
+    """Count tokens via the configured counter; char-based fallback if unset."""
+    if counter is not None:
+        return counter.count_text(text, model)
+    return max(1, len(text) // 4) if text else 0


### PR DESCRIPTION
Decouple the request path from the memory engine. Both /v1/chat/completions
and /v1/messages now talk to a MemoryProvider (retrieve / record) instead of
a MemoryStore directly. TieredMemoryProvider wraps the existing L0/L1/L2/L3
store and delegates to assemble_context + the turn-append path, so behavior
is unchanged.

build_app still resolves app.state.memory_store (back-compat) and now also
wraps it as app.state.memory_provider; the lifespan closes the provider
(which closes the underlying store, so no double-close).

This is the seam that lets alternative memory engines (e.g. a Mem0-backed
provider) slot in via settings.memory_backend without touching the routes.
The protocol is least-common-denominator (record an exchange / retrieve a
context) so heavier engines fit behind it.

Pure refactor, no behavior change: full suite green (1074 passed, 9 skipped),
ruff + pyright clean, open-core boundary verify passes.
