### PR TITLE
feat(memory): gateway-native memory via Mem0 provider (modelmeld[mem0])

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -57,3 +57,12 @@ declared role:
 - [CrewAI](crewai.md)
 - [LangGraph](langgraph.md)
 - [OpenClaw](openclaw.md)
+
+## Gateway-managed memory (experimental)
+
+For agents/workflows that call the API directly and want the gateway to
+remember the conversation — no SDK, just a session-id header:
+
+- [**Conversation memory at the gateway**](memory.md) — opt-in mem0-backed
+  memory via `MODELMELD_MEMORY_BACKEND=mem0`. (Coding tools manage their own
+  history and don't need this.)

--- a/docs/integrations/memory.md
+++ b/docs/integrations/memory.md
@@ -1,0 +1,116 @@
+# Conversation memory at the gateway (experimental)
+
+> **Status: experimental.** The API and defaults may change. Off by default —
+> the gateway does no memory work unless you opt in (see below).
+
+Most coding tools (Claude Code, Cursor, Aider, Cline) manage their own
+conversation history and resend it every turn — they don't need this. This is
+for the other case: **an agent or workflow calling the API directly that sends
+only the latest message and expects the gateway to remember the rest.**
+
+The pitch: **memory with zero client code — just send a session-id header.** No
+SDK to wire in, no vector store for you to operate. The gateway records each
+exchange and injects the relevant prior context on the next request.
+
+It's backed by [mem0](https://github.com/mem0ai/mem0) (Apache-2.0) running
+behind the gateway's request path. mem0 does the extraction + retrieval; the
+gateway does the transparent injection.
+
+## Enable it
+
+```bash
+pip install 'modelmeld[mem0]'
+```
+
+```bash
+export MODELMELD_MEMORY_BACKEND=mem0
+# Route mem0's own LLM + embedder calls through THIS gateway (see "Cost" below):
+export MODELMELD_MEM0_BASE_URL=http://localhost:8080/v1
+export MODELMELD_MEM0_API_KEY=<a-modelmeld-key>
+# Vector store: a qdrant server (shared, per-tenant collection)...
+export MODELMELD_MEM0_VECTOR_STORE_URL=http://localhost:6333
+# ...or omit the URL and set a path for an embedded on-disk store (per-tenant subdir):
+# export MODELMELD_MEM0_VECTOR_STORE_PATH=/var/lib/modelmeld/mem0
+```
+
+The default `in_memory` / `postgres` tiered backends are unaffected — this only
+applies when `MODELMELD_MEMORY_BACKEND=mem0`.
+
+## Use it
+
+Memory activates when the request carries a session id. Send the same id across
+turns and the gateway threads context for you:
+
+```bash
+curl https://your-gateway/v1/chat/completions \
+  -H "Authorization: Bearer gws_<key>" \
+  -H "x-modelmeld-session-id: agent-run-42" \
+  -d '{"model":"anthropic/modelmeld-auto",
+       "messages":[{"role":"user","content":"Remember: my name is Alice."}]}'
+
+# next turn — send ONLY the new message; the gateway recalls the rest:
+curl https://your-gateway/v1/chat/completions \
+  -H "Authorization: Bearer gws_<key>" \
+  -H "x-modelmeld-session-id: agent-run-42" \
+  -d '{"model":"anthropic/modelmeld-auto",
+       "messages":[{"role":"user","content":"What is my name?"}]}'
+```
+
+Headers:
+
+| Header | Meaning |
+|---|---|
+| `x-modelmeld-session-id` | **Required to activate memory.** Stable per conversation. |
+| `x-modelmeld-memory-mode` | `augment` (default) / `full` / `off`. |
+| `x-modelmeld-user-id` | Optional caller-supplied user id (agent frameworks). |
+
+No session id → no memory work happens; the request is a plain pass-through.
+
+## Cost — read this
+
+Memory is **not free.** With the default `infer=True`, every write runs an
+**LLM extraction call** (plus embedding calls) so mem0 can distill durable facts
+from the turn. That cost is real and you should plan for it.
+
+Two levers keep it cheap:
+
+1. **Route mem0's extraction through this gateway** (`MODELMELD_MEM0_BASE_URL`
+   pointed at your own `/v1`). Then the extraction call is itself cost-routed by
+   the gateway's normal routing — sent to a cheap OSS model, or to a local model
+   you host (in which case it's effectively free).
+2. **Set `MODELMELD_MEM0_INFER=false`** to skip extraction entirely and store
+   raw turns. No per-write LLM call; lower retrieval quality.
+
+There is no "free memory." Anyone claiming otherwise is hiding the extraction
+cost. Measure it for your workload before relying on it.
+
+## Tenant isolation
+
+Each tenant gets its **own vector collection** (not a shared collection with
+metadata filters) — see [multi-tenant-isolation.md](../multi-tenant-isolation.md).
+Within a tenant, memories are scoped to the session. A request's tenant comes
+from gateway auth; anonymous traffic shares one sentinel namespace, so run with
+auth enabled in production.
+
+## Settings reference
+
+| Env var | Default | Notes |
+|---|---|---|
+| `MODELMELD_MEMORY_BACKEND` | `in_memory` | Set to `mem0` to enable. |
+| `MODELMELD_MEM0_INFER` | `true` | `false` = raw store, no per-write LLM. |
+| `MODELMELD_MEM0_TOP_K` | `10` | Memories retrieved per request. |
+| `MODELMELD_MEM0_RERANK` | `false` | mem0 reranking on retrieval. |
+| `MODELMELD_MEM0_BASE_URL` | _(mem0 default)_ | Route mem0's LLM + embedder here. |
+| `MODELMELD_MEM0_API_KEY` | — | Key for the above. |
+| `MODELMELD_MEM0_LLM_MODEL` | `gpt-5-mini` | Extraction model. |
+| `MODELMELD_MEM0_EMBEDDER_MODEL` | `text-embedding-3-small` | Embedding model. |
+| `MODELMELD_MEM0_VECTOR_STORE_URL` | — | qdrant server URL (shared, per-tenant collection). |
+| `MODELMELD_MEM0_VECTOR_STORE_PATH` | — | Embedded on-disk qdrant (per-tenant subdir). |
+
+## Limitations
+
+- Experimental; defaults and surface may change.
+- `infer=True` adds latency + cost per write (the extraction call).
+- mem0 telemetry is disabled by default (`MEM0_TELEMETRY=False`); set it
+  explicitly to re-enable.
+- Retrieval quality depends on the extraction + embedding models you point it at.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,10 @@ openai = ["openai>=1.40"]
 anthropic = ["anthropic>=0.30"]
 all-providers = ["openai>=1.40", "anthropic>=0.30"]
 postgres = ["sqlalchemy[asyncio]>=2.0", "psycopg[binary]>=3.2"]
+# Gateway-native memory backend (memory_backend="mem0"). Wraps the
+# Apache-2.0 mem0 OSS core behind the MemoryProvider seam — the gateway
+# does the request-path injection; mem0 does extraction + retrieval.
+mem0 = ["mem0ai>=2.0,<3"]
 # Cross-tokenizer counting. Provides accurate per-model token
 # counts via tiktoken / anthropic / huggingface backends bundled by litellm.
 tokenizer = ["litellm>=1.40"]
@@ -59,6 +63,7 @@ dev = [
     "aiosqlite>=0.19",
     "openai>=1.40",
     "anthropic>=0.30",
+    "mem0ai>=2.0,<3",      # mem0 provider tests (memory_backend="mem0")
 ]
 [project.scripts]
 # Customer-facing CLI. `modelmeld setup --tool claude-code` is the

--- a/src/modelmeld/api/server.py
+++ b/src/modelmeld/api/server.py
@@ -17,6 +17,7 @@ from modelmeld.config import GatewaySettings
 from modelmeld.hooks import HookRegistry
 from modelmeld.memory import (
     InMemoryMemoryStore,
+    Mem0MemoryProvider,
     MemoryProvider,
     MemoryStore,
     PostgresMemoryStore,
@@ -95,10 +96,15 @@ def build_app(
         )
     else:
         app.state.memory_store = InMemoryMemoryStore()
-    # The routes talk to a MemoryProvider, not the store directly. The default
-    # provider wraps the tiered store above; alternative engines (e.g. Mem0)
-    # are selected here in a later sprint via settings.memory_backend.
-    app.state.memory_provider = TieredMemoryProvider(app.state.memory_store)
+    # The routes talk to a MemoryProvider, not the store directly. Default
+    # wraps the tiered store above; memory_backend="mem0" swaps in a
+    # Mem0-backed provider (optional dep: pip install modelmeld[mem0]).
+    if app.state.settings.memory_backend == "mem0":
+        app.state.memory_provider = Mem0MemoryProvider.from_settings(
+            app.state.settings
+        )
+    else:
+        app.state.memory_provider = TieredMemoryProvider(app.state.memory_store)
     # Token counter. Default char-based; settings can switch to
     # litellm. Pass `token_counter=` to inject a custom impl in tests.
     app.state.token_counter = (

--- a/src/modelmeld/config.py
+++ b/src/modelmeld/config.py
@@ -138,8 +138,30 @@ class GatewaySettings(BaseSettings):
     # Memory backend. Default remains in-process for dev/tests. Set
     # MODELMELD_MEMORY_BACKEND=postgres plus MODELMELD_MEMORY_DATABASE_URL for
     # a SQL-backed store shared across workers.
-    memory_backend: Literal["in_memory", "postgres"] = "in_memory"
+    memory_backend: Literal["in_memory", "postgres", "mem0"] = "in_memory"
     memory_database_url: str | None = None
+
+    # Mem0 provider (memory_backend="mem0"). Optional dep: pip install
+    # modelmeld[mem0]. The gateway does request-path injection; mem0 does
+    # extraction + retrieval. Tenant isolation uses a SEPARATE vector
+    # collection per tenant (not shared-collection metadata filters).
+    # `infer=True` runs an LLM extraction call per write — route it through
+    # this gateway via mem0_base_url so it gets cost-routed (see docs).
+    mem0_infer: bool = True
+    mem0_top_k: int = 10
+    mem0_rerank: bool = False
+    mem0_embedding_dims: int = 1536
+    mem0_llm_model: str = "gpt-5-mini"
+    mem0_embedder_model: str = "text-embedding-3-small"
+    # Route mem0's extraction LLM + embedder at an OpenAI-compatible endpoint
+    # (e.g. this gateway). None → mem0's default (api.openai.com).
+    mem0_base_url: str | None = None
+    mem0_api_key: str | None = None
+    # Vector store. URL → shared qdrant server (per-tenant collection);
+    # else on-disk embedded qdrant under this path (per-tenant subdir).
+    mem0_vector_store_url: str | None = None
+    mem0_vector_store_api_key: str | None = None
+    mem0_vector_store_path: str | None = None
 
     # PII scrubbing. When True, message text is scrubbed before
     # any egress adapter call (is_egress=True). Local adapters (stub, vllm) are

--- a/src/modelmeld/memory/__init__.py
+++ b/src/modelmeld/memory/__init__.py
@@ -54,6 +54,10 @@ from modelmeld.memory.in_memory import (
     InMemoryMemoryStore,
     TenantMismatchError,
 )
+from modelmeld.memory.mem0_provider import (
+    Mem0DependencyError,
+    Mem0MemoryProvider,
+)
 from modelmeld.memory.postgres import (
     MissingPostgresDependencyError,
     PostgresMemoryStore,
@@ -88,6 +92,8 @@ __all__ = [
     "Fact",
     "InMemoryMemoryStore",
     "InvalidTenantIdError",
+    "Mem0DependencyError",
+    "Mem0MemoryProvider",
     "MemoryContext",
     "MemoryHeaderError",
     "MemoryIdentity",

--- a/src/modelmeld/memory/mem0_provider.py
+++ b/src/modelmeld/memory/mem0_provider.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""Mem0-backed MemoryProvider.
+
+Wraps the Apache-2.0 mem0 OSS core behind the `MemoryProvider` seam. The
+gateway keeps doing request-path injection (via the shared
+`inject_into_request`); mem0 does the extraction + semantic retrieval that
+would otherwise be ours to build.
+
+Selected with `GatewaySettings.memory_backend = "mem0"`. Requires the optional
+dependency: `pip install modelmeld[mem0]`.
+
+Tenant isolation (security-critical): each tenant gets its OWN mem0 vector
+collection — `tenant_collection_name(tenant_id)` — NOT a shared collection with
+metadata filters. We keep one `AsyncMemory` instance per tenant, created lazily.
+Within a tenant, memories are scoped to the session via mem0's `run_id`.
+
+Cost note: `infer=True` (default) runs an LLM extraction call per write.
+Point `mem0_base_url` at this gateway so that call is cost-routed by our own
+router (and self-hosters on local models pay ~nothing). `infer=False` stores
+raw turns with no per-write LLM call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+from modelmeld.api.schemas import ChatCompletionRequest, TextPart, UserMessage
+from modelmeld.memory.base import (
+    Summary,
+    new_summary_id,
+    tenant_collection_name,
+    utc_now,
+)
+from modelmeld.memory.context import MemoryContext
+from modelmeld.memory.identity import MemoryIdentity
+from modelmeld.memory.provider import MemoryProvider
+
+if TYPE_CHECKING:
+    from modelmeld.config import GatewaySettings
+
+logger = logging.getLogger(__name__)
+
+
+class Mem0DependencyError(ImportError):
+    """Raised when the `mem0` backend is selected but `mem0ai` isn't installed."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "memory_backend='mem0' requires the mem0 extra. "
+            "Install it with: pip install 'modelmeld[mem0]'"
+        )
+
+
+class Mem0MemoryProvider(MemoryProvider):
+    """MemoryProvider backed by mem0's AsyncMemory, one collection per tenant."""
+
+    def __init__(
+        self,
+        *,
+        infer: bool = True,
+        top_k: int = 10,
+        rerank: bool = False,
+        embedding_dims: int = 1536,
+        llm_model: str = "gpt-5-mini",
+        embedder_model: str = "text-embedding-3-small",
+        base_url: str | None = None,
+        api_key: str | None = None,
+        vector_store_url: str | None = None,
+        vector_store_api_key: str | None = None,
+        vector_store_path: str | None = None,
+    ) -> None:
+        # Disable mem0's posthog telemetry by default (it phones home about
+        # usage). setdefault leaves an explicit operator opt-in untouched.
+        # Set before importing mem0 so the telemetry client sees it.
+        os.environ.setdefault("MEM0_TELEMETRY", "False")
+
+        # Fail loudly + early if the optional dep is missing — at construction,
+        # not on the first request.
+        try:
+            from mem0 import AsyncMemory  # noqa: F401
+        except ImportError as e:
+            raise Mem0DependencyError() from e
+
+        self._infer = infer
+        self._top_k = top_k
+        self._rerank = rerank
+        self._embedding_dims = embedding_dims
+        self._llm_model = llm_model
+        self._embedder_model = embedder_model
+        self._base_url = base_url
+        self._api_key = api_key
+        self._vector_store_url = vector_store_url
+        self._vector_store_api_key = vector_store_api_key
+        self._vector_store_path = vector_store_path
+
+        self._mems: dict[str, Any] = {}   # tenant_id -> AsyncMemory
+        self._lock = asyncio.Lock()
+
+    @classmethod
+    def from_settings(cls, settings: GatewaySettings) -> Mem0MemoryProvider:
+        return cls(
+            infer=settings.mem0_infer,
+            top_k=settings.mem0_top_k,
+            rerank=settings.mem0_rerank,
+            embedding_dims=settings.mem0_embedding_dims,
+            llm_model=settings.mem0_llm_model,
+            embedder_model=settings.mem0_embedder_model,
+            base_url=settings.mem0_base_url,
+            api_key=settings.mem0_api_key,
+            vector_store_url=settings.mem0_vector_store_url,
+            vector_store_api_key=settings.mem0_vector_store_api_key,
+            vector_store_path=settings.mem0_vector_store_path,
+        )
+
+    # ----- config + per-tenant instance -----------------------------------
+
+    def _build_config(self, tenant_id: str) -> dict[str, Any]:
+        collection = tenant_collection_name(tenant_id)
+
+        llm_cfg: dict[str, Any] = {"model": self._llm_model}
+        embed_cfg: dict[str, Any] = {
+            "model": self._embedder_model,
+            "embedding_dims": self._embedding_dims,
+        }
+        if self._base_url:
+            # Route mem0's extraction LLM + embedder through our gateway.
+            llm_cfg["openai_base_url"] = self._base_url
+            embed_cfg["openai_base_url"] = self._base_url
+        if self._api_key:
+            llm_cfg["api_key"] = self._api_key
+            embed_cfg["api_key"] = self._api_key
+
+        vs_cfg: dict[str, Any] = {
+            "collection_name": collection,
+            "embedding_model_dims": self._embedding_dims,
+        }
+        if self._vector_store_url:
+            # Shared qdrant server: tenant isolation via the per-tenant
+            # collection_name above.
+            vs_cfg["url"] = self._vector_store_url
+            if self._vector_store_api_key:
+                vs_cfg["api_key"] = self._vector_store_api_key
+        elif self._vector_store_path:
+            # Embedded on-disk qdrant: give each tenant its own directory so
+            # the embedded stores never share a file/lock.
+            vs_cfg["path"] = os.path.join(self._vector_store_path, collection)
+
+        return {
+            "llm": {"provider": "openai", "config": llm_cfg},
+            "embedder": {"provider": "openai", "config": embed_cfg},
+            "vector_store": {"provider": "qdrant", "config": vs_cfg},
+        }
+
+    async def _mem_for(self, tenant_id: str) -> Any:
+        """Return (lazily creating) the AsyncMemory instance for this tenant.
+
+        One instance per tenant → one vector collection per tenant. Double-checked
+        locking so concurrent first-requests for a tenant don't build two.
+        """
+        mem = self._mems.get(tenant_id)
+        if mem is not None:
+            return mem
+        async with self._lock:
+            mem = self._mems.get(tenant_id)
+            if mem is None:
+                from mem0 import AsyncMemory
+
+                mem = AsyncMemory.from_config(self._build_config(tenant_id))
+                self._mems[tenant_id] = mem
+        return mem
+
+    # ----- MemoryProvider contract ----------------------------------------
+
+    async def retrieve(
+        self,
+        mem_identity: MemoryIdentity,
+        request: ChatCompletionRequest,
+    ) -> MemoryContext:
+        if not mem_identity.active:
+            return MemoryContext()
+        assert mem_identity.session_id is not None
+        query = _last_user_text(request)
+        if not query:
+            return MemoryContext()
+        try:
+            mem = await self._mem_for(mem_identity.tenant_id)
+            result = await mem.search(
+                query,
+                top_k=self._top_k,
+                rerank=self._rerank,
+                filters={"run_id": mem_identity.session_id},
+            )
+        except Exception:
+            logger.exception(
+                "mem0 retrieve failed for session %s (degraded; no context)",
+                mem_identity.session_id,
+            )
+            return MemoryContext()
+
+        memories = _extract_memory_texts(result)
+        if not memories:
+            return MemoryContext()
+        text = "Relevant memories from this session:\n" + "\n".join(
+            f"- {m}" for m in memories
+        )
+        now = utc_now()
+        synthetic = Summary(
+            summary_id=new_summary_id(),
+            session_id=mem_identity.session_id,
+            tenant_id=mem_identity.tenant_id,
+            text=text,
+            last_applied_turn_id=None,
+            version=0,
+            source_model="mem0",
+            created_at=now,
+            updated_at=now,
+        )
+        return MemoryContext(summary=synthetic)
+
+    async def record(
+        self,
+        mem_identity: MemoryIdentity,
+        request: ChatCompletionRequest,
+        assistant_text: str,
+        *,
+        assistant_tokens: int = 0,
+        model_used: str | None = None,
+        token_counter: Any | None = None,
+    ) -> None:
+        if not mem_identity.active:
+            return
+        assert mem_identity.session_id is not None
+        user_text = _last_user_text(request)
+        messages: list[dict[str, str]] = []
+        if user_text:
+            messages.append({"role": "user", "content": user_text})
+        if assistant_text:
+            messages.append({"role": "assistant", "content": assistant_text})
+        if not messages:
+            return
+        try:
+            mem = await self._mem_for(mem_identity.tenant_id)
+            await mem.add(
+                messages,
+                run_id=mem_identity.session_id,
+                infer=self._infer,
+            )
+        except Exception:
+            logger.exception(
+                "mem0 record failed for session %s", mem_identity.session_id
+            )
+
+
+def _last_user_text(request: ChatCompletionRequest) -> str:
+    """Most recent user message text from the request, or '' if none."""
+    for msg in reversed(request.messages):
+        if isinstance(msg, UserMessage):
+            if isinstance(msg.content, str):
+                return msg.content
+            return "".join(
+                part.text for part in msg.content if isinstance(part, TextPart)
+            )
+    return ""
+
+
+def _extract_memory_texts(result: Any) -> list[str]:
+    """Pull memory strings out of a mem0 search result.
+
+    mem0 returns either a list of memory dicts or `{"results": [...]}` depending
+    on version/output format. Each entry carries the text under "memory".
+    """
+    rows = result.get("results", []) if isinstance(result, dict) else result
+    texts: list[str] = []
+    for row in rows or []:
+        if isinstance(row, dict):
+            mem_text = row.get("memory") or row.get("text")
+            if mem_text:
+                texts.append(str(mem_text))
+        elif isinstance(row, str):
+            texts.append(row)
+    return texts

--- a/src/modelmeld/memory/mem0_provider.py
+++ b/src/modelmeld/memory/mem0_provider.py
@@ -86,6 +86,13 @@ class Mem0MemoryProvider(MemoryProvider):
         except ImportError as e:
             raise Mem0DependencyError() from e
 
+        logger.warning(
+            "Mem0 memory backend is EXPERIMENTAL. infer=%s means an LLM "
+            "extraction call per write — route it through this gateway via "
+            "mem0_base_url so it's cost-optimized. See docs/integrations/memory.md.",
+            infer,
+        )
+
         self._infer = infer
         self._top_k = top_k
         self._rerank = rerank

--- a/tests/test_mem0_integration.py
+++ b/tests/test_mem0_integration.py
@@ -1,0 +1,114 @@
+"""Live integration check for Mem0MemoryProvider.
+
+Drives the REAL mem0 AsyncMemory (real extraction pipeline + embedded qdrant)
+through the provider's record/retrieve cycle, with mem0's LLM + embedder pointed
+at an in-process mock OpenAI-compatible server. This is the check the fake-backed
+unit tests can't give: that our `filters={"run_id": ...}` actually retrieves what
+`add(run_id=...)` stored, and that the search return shape matches our parser.
+
+Skipped by default (needs the mem0 extra + is slower). Run with:
+    MODELMELD_RUN_MEM0_INTEGRATION=1 pytest tests/test_mem0_integration.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from modelmeld.api.schemas import ChatCompletionRequest, UserMessage
+from modelmeld.memory import MemoryIdentity, MemoryMode
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("MODELMELD_RUN_MEM0_INTEGRATION"),
+    reason="set MODELMELD_RUN_MEM0_INTEGRATION=1 to run the live mem0 integration check",
+)
+
+
+class _MockOpenAIHandler(BaseHTTPRequestHandler):
+    def log_message(self, *a):  # silence
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length).decode("utf-8", "replace")
+        if self.path.endswith("/embeddings"):
+            payload = {
+                "object": "list",
+                "data": [{"object": "embedding", "index": 0, "embedding": [0.001] * 1536}],
+                "model": "text-embedding-3-small",
+                "usage": {"prompt_tokens": 1, "total_tokens": 1},
+            }
+        else:  # /chat/completions
+            low = body.lower()
+            if "event" in low or "update" in low or '"id"' in low:
+                content = json.dumps({"memory": [
+                    {"id": "0", "text": "user's name is alice", "event": "ADD"},
+                ]})
+            else:
+                content = json.dumps({"facts": ["user's name is alice"]})
+            payload = {
+                "id": "chatcmpl-x", "object": "chat.completion", "created": 0,
+                "model": "gpt-5-mini",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": content},
+                             "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            }
+        data = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+@pytest.fixture
+def mock_openai():
+    srv = HTTPServer(("127.0.0.1", 0), _MockOpenAIHandler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    time.sleep(0.2)
+    port = srv.server_address[1]
+    yield f"http://127.0.0.1:{port}/v1"
+    srv.shutdown()
+
+
+def _provider(base_url: str, path: str):
+    from modelmeld.memory import Mem0MemoryProvider
+
+    return Mem0MemoryProvider(
+        infer=True, top_k=10, base_url=base_url, api_key="sk-test",
+        vector_store_path=path,
+    )
+
+
+def _identity(tenant="acme", session="s-1") -> MemoryIdentity:
+    return MemoryIdentity(
+        tenant_id=tenant, session_id=session, user_id="alice", mode=MemoryMode.AUGMENT,
+    )
+
+
+def _req(text: str) -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="claude-opus-4-7", messages=[UserMessage(role="user", content=text)],
+    )
+
+
+async def test_real_mem0_record_then_retrieve(mock_openai, tmp_path) -> None:
+    provider = _provider(mock_openai, str(tmp_path / "qdrant"))
+    await provider.record(_identity(), _req("Remember: my name is alice."), "Noted.")
+    ctx = await provider.retrieve(_identity(), _req("what is my name?"))
+    assert ctx.summary is not None, "real mem0 round-trip should retrieve the stored memory"
+    assert "alice" in ctx.summary.text.lower()
+
+
+async def test_real_mem0_tenant_isolation(mock_openai, tmp_path) -> None:
+    provider = _provider(mock_openai, str(tmp_path / "qdrant"))
+    await provider.record(
+        _identity(tenant="tenant-a"), _req("secret: my name is alice"), "ok",
+    )
+    ctx = await provider.retrieve(_identity(tenant="tenant-b"), _req("what is my name?"))
+    assert ctx.summary is None, "tenant B must not retrieve tenant A's memory"

--- a/tests/test_mem0_provider.py
+++ b/tests/test_mem0_provider.py
@@ -1,0 +1,183 @@
+"""Mem0MemoryProvider — scoping, context packing, and tenant isolation.
+
+mem0's AsyncMemory is replaced with an in-process fake (no network, no qdrant)
+so these tests exercise the PROVIDER's contract: correct session scoping,
+packing search results into a MemoryContext, and — the security-critical part —
+that each tenant gets its own isolated vector collection.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import ClassVar
+
+import pytest
+
+from modelmeld.api.schemas import ChatCompletionRequest, UserMessage
+from modelmeld.memory import MemoryIdentity, MemoryMode
+from modelmeld.memory.base import tenant_collection_name
+
+
+class FakeAsyncMemory:
+    """Stand-in for mem0.AsyncMemory. One instance per collection; stores adds
+    locally so a search only ever sees memories written to the same instance."""
+
+    # collection_name -> instance, so tests can inspect what got built.
+    registry: ClassVar[dict[str, FakeAsyncMemory]] = {}
+
+    def __init__(self, config: dict) -> None:
+        self.config = config
+        self.collection = config["vector_store"]["config"]["collection_name"]
+        self.adds: list[tuple[list[dict], dict]] = []
+
+    @classmethod
+    def from_config(cls, config: dict) -> FakeAsyncMemory:
+        inst = cls(config)
+        cls.registry[inst.collection] = inst
+        return inst
+
+    async def add(self, messages, **kwargs):
+        self.adds.append((messages, kwargs))
+        return {"results": []}
+
+    async def search(self, query, **kwargs):
+        self.last_search_kwargs = kwargs
+        mems = [
+            m["content"]
+            for msgs, _ in self.adds
+            for m in msgs
+            if m["role"] == "user"
+        ]
+        return {"results": [{"memory": t} for t in mems]}
+
+
+@pytest.fixture
+def fake_mem0(monkeypatch):
+    """Install a fake `mem0` module exposing FakeAsyncMemory."""
+    FakeAsyncMemory.registry = {}
+    fake_module = types.ModuleType("mem0")
+    fake_module.AsyncMemory = FakeAsyncMemory
+    monkeypatch.setitem(sys.modules, "mem0", fake_module)
+    yield FakeAsyncMemory
+
+
+def _provider(**kwargs):
+    from modelmeld.memory import Mem0MemoryProvider
+
+    defaults = dict(infer=True, top_k=5, base_url="http://gw/v1", api_key="k")
+    defaults.update(kwargs)
+    return Mem0MemoryProvider(**defaults)
+
+
+def _identity(tenant="acme", session="s-1", active=True) -> MemoryIdentity:
+    return MemoryIdentity(
+        tenant_id=tenant,
+        session_id=session if active else None,
+        user_id="alice",
+        mode=MemoryMode.AUGMENT,
+    )
+
+
+def _req(text: str) -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="claude-opus-4-7",
+        messages=[UserMessage(role="user", content=text)],
+    )
+
+
+# ---------------------------------------------------------------------------
+# record + retrieve
+# ---------------------------------------------------------------------------
+
+async def test_record_scopes_by_session_run_id(fake_mem0) -> None:
+    provider = _provider()
+    await provider.record(
+        _identity(), _req("remember my name is alice"), "Got it, alice.",
+    )
+    inst = fake_mem0.registry[tenant_collection_name("acme")]
+    assert len(inst.adds) == 1
+    messages, kwargs = inst.adds[0]
+    assert kwargs["run_id"] == "s-1"
+    assert kwargs["infer"] is True
+    assert {m["role"] for m in messages} == {"user", "assistant"}
+
+
+async def test_record_infer_false_passed_through(fake_mem0) -> None:
+    provider = _provider(infer=False)
+    await provider.record(_identity(), _req("hi"), "hello")
+    inst = fake_mem0.registry[tenant_collection_name("acme")]
+    assert inst.adds[0][1]["infer"] is False
+
+
+async def test_retrieve_packs_memories_and_filters_by_session(fake_mem0) -> None:
+    provider = _provider()
+    await provider.record(_identity(), _req("my name is alice"), "ok")
+    ctx = await provider.retrieve(_identity(), _req("what is my name?"))
+    assert ctx.summary is not None
+    assert "my name is alice" in ctx.summary.text
+    inst = fake_mem0.registry[tenant_collection_name("acme")]
+    assert inst.last_search_kwargs["filters"] == {"run_id": "s-1"}
+    assert inst.last_search_kwargs["top_k"] == 5
+
+
+async def test_retrieve_empty_when_no_memories(fake_mem0) -> None:
+    provider = _provider()
+    ctx = await provider.retrieve(_identity(), _req("anything?"))
+    assert ctx.summary is None
+    assert not ctx.has_content()
+
+
+# ---------------------------------------------------------------------------
+# Tenant isolation (security-critical)
+# ---------------------------------------------------------------------------
+
+async def test_tenant_isolation_separate_collections(fake_mem0) -> None:
+    provider = _provider()
+    # Tenant A writes a secret under session s-1.
+    await provider.record(
+        _identity(tenant="tenant-a", session="s-1"),
+        _req("tenant A secret: launch code 1234"),
+        "noted",
+    )
+    # Tenant B retrieves the SAME session id — must see nothing of A's.
+    ctx = await provider.retrieve(
+        _identity(tenant="tenant-b", session="s-1"), _req("launch code?"),
+    )
+    assert ctx.summary is None, "tenant B must not see tenant A's memory"
+    # And the two tenants resolved to distinct vector collections.
+    assert tenant_collection_name("tenant-a") in fake_mem0.registry
+    assert tenant_collection_name("tenant-b") in fake_mem0.registry
+    assert tenant_collection_name("tenant-a") != tenant_collection_name("tenant-b")
+
+
+# ---------------------------------------------------------------------------
+# Inactive identity = no-op
+# ---------------------------------------------------------------------------
+
+def test_telemetry_disabled_by_default(fake_mem0, monkeypatch) -> None:
+    monkeypatch.delenv("MEM0_TELEMETRY", raising=False)
+    _provider()
+    assert __import__("os").environ["MEM0_TELEMETRY"] == "False"
+
+
+async def test_inactive_identity_no_ops(fake_mem0) -> None:
+    provider = _provider()
+    await provider.record(_identity(active=False), _req("x"), "y")
+    ctx = await provider.retrieve(_identity(active=False), _req("x"))
+    assert ctx.summary is None
+    assert fake_mem0.registry == {}, "no mem0 instance should be built for inactive id"
+
+
+# ---------------------------------------------------------------------------
+# Missing optional dependency
+# ---------------------------------------------------------------------------
+
+def test_missing_mem0ai_raises_helpful_error(monkeypatch) -> None:
+    from modelmeld.memory import Mem0DependencyError, Mem0MemoryProvider
+
+    # Block the import so `from mem0 import AsyncMemory` fails.
+    monkeypatch.setitem(sys.modules, "mem0", None)
+    with pytest.raises(Mem0DependencyError) as exc:
+        Mem0MemoryProvider()
+    assert "modelmeld[mem0]" in str(exc.value)


### PR DESCRIPTION
## Summary
  Adds an opt-in, Mem0-backed conversation-memory backend behind the `MemoryProvider`
  seam (#39), selected via `memory_backend="mem0"` (`pip install modelmeld[mem0]`).
  Gives agents/raw-API callers zero-client-code memory: send `x-modelmeld-session-id`
  and the gateway records each exchange and injects relevant prior context next turn.
  Coding tools manage their own history and don't need this — this targets direct-API
  agent/workflow callers. The gateway does request-path injection; mem0 does
  extraction + retrieval.

  ## Type of change
  - [x] New feature (non-breaking change that adds capability)
  - [x] Documentation

  ## Test plan
  - `tests/test_mem0_provider.py` (8 tests, fake AsyncMemory, no network): session/run_id
    scoping, context packing, **per-tenant isolation**, telemetry-off, inactive no-op,
    missing-dependency error.
  - `tests/test_mem0_integration.py` (gated by `MODELMELD_RUN_MEM0_INTEGRATION=1`): real
    mem0 `AsyncMemory` + embedded qdrant through record→retrieve against a mock OpenAI
    endpoint; confirms `filters={"run_id"}` retrieves what `add(run_id=)` stored and
    tenant isolation holds.
  - Full suite: 1082 passed, 11 skipped. ruff + pyright clean. `scripts/verify_boundary.py`
  passes.
  - Default (`in_memory`/`postgres` tiered) behavior unchanged.

  ## Linked issues
  Refs #39 (MemoryProvider seam).

  ## Checklist
  - [x] Tests added/updated and they exercise the change
  - [x] Documentation updated (`docs/integrations/memory.md`)
  - [x] `pytest` passes (full suite)
  - [x] All commits have DCO signoff
  - [x] Read `docs/open-core-boundary.md` (adds an optional OSS extra; boundary verify passes)

  ## Additional context
  Experimental + opt-in; dormant unless `memory_backend=mem0` AND the `[mem0]` extra are
  set. `infer=true` runs an LLM extraction call per write — routable through this gateway
  (`mem0_base_url`) so it's cost-routed; `infer=false` stores raw turns with no per-write
  LLM. mem0 telemetry disabled by default. On merge, release-please opens a `release 0.8.0`
  PR; merging that publishes to PyPI.