### PR TITLE
fix(api): pin chat response model field to the canonical routed model

### DIFF
--- a/src/modelmeld/api/routes/chat.py
+++ b/src/modelmeld/api/routes/chat.py
@@ -453,6 +453,18 @@ async def _completion_with_failover(
                 ),
             ) from secondary
 
+    # #47: the response body must not surface an upstream-provider model slug.
+    # Pin the served-model field to the canonical routed model — the same value
+    # as the x-modelmeld-routed-model header — overwriting whatever string the
+    # adapter echoed from upstream. No-op when the adapter already returned the
+    # canonical id. Done before caching so cached bodies are clean too.
+    if decision.model_id_override:
+        canonical = _canonical_model_id_for_header(
+            decision.model_id_override, decision.adapter.name, model_registry,
+        ) or decision.model_id_override
+        if completion.model != canonical:
+            completion = completion.model_copy(update={"model": canonical})
+
     for key, value in _routing_headers(
         decision, redactions, failover_from,
         hints=hints,
@@ -544,11 +556,19 @@ async def _stream_with_failover(
     )
     if cache_status is not None:
         headers["x-modelmeld-cache"] = cache_status
+    # #47: canonical routed model to pin on every streamed chunk (matches the
+    # x-modelmeld-routed-model header). None when no model override is in play.
+    served_model = (
+        _canonical_model_id_for_header(
+            decision.model_id_override, decision.adapter.name, model_registry,
+        ) or decision.model_id_override
+        if decision.model_id_override else None
+    )
     return StreamingResponse(
         _sse_stream(
             primary_aiter, first_chunk, hooks, request_id, started,
             request, decision, redactions, failover_from, identity,
-            provider, mem_identity, token_counter,
+            provider, mem_identity, token_counter, served_model,
         ),
         media_type="text/event-stream",
         headers=headers,
@@ -592,6 +612,7 @@ async def _sse_stream(
     provider: MemoryProvider | None,
     mem_identity: MemoryIdentity,
     token_counter: TokenCounter | None,
+    served_model: str | None,
 ) -> AsyncIterator[str]:
     output_tokens = 0
     last_usage = None
@@ -599,6 +620,7 @@ async def _sse_stream(
     error: Exception | None = None
     try:
         if first is not None:
+            first = _pin_chunk_model(first, served_model)
             yield f"data: {first.model_dump_json(exclude_none=True)}\n\n"
             output_tokens += _chunk_content_tokens(first)
             accumulated_text.extend(_chunk_text_pieces(first))
@@ -606,6 +628,7 @@ async def _sse_stream(
                 last_usage = first.usage
         if aiter is not None:
             async for chunk in aiter:
+                chunk = _pin_chunk_model(chunk, served_model)
                 yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
                 output_tokens += _chunk_content_tokens(chunk)
                 accumulated_text.extend(_chunk_text_pieces(chunk))
@@ -647,6 +670,19 @@ def _chunk_text_pieces(chunk: ChatCompletionChunk) -> list[str]:
         if choice.delta.content:
             pieces.append(choice.delta.content)
     return pieces
+
+
+def _pin_chunk_model(
+    chunk: ChatCompletionChunk,
+    served_model: str | None,
+) -> ChatCompletionChunk:
+    """#47: pin a streamed chunk's model field to the canonical routed model so
+    no upstream-provider slug reaches the SSE payload. No-op when there was no
+    model override (served_model is None) or the chunk already matches.
+    """
+    if served_model and chunk.model and chunk.model != served_model:
+        return chunk.model_copy(update={"model": served_model})
+    return chunk
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_capability_routing_with_hints.py
+++ b/tests/test_capability_routing_with_hints.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 
 import httpx
@@ -19,6 +20,8 @@ from modelmeld.api.schemas import (
     ChatCompletionChunk,
     ChatCompletionRequest,
     Choice,
+    ChoiceDelta,
+    ChunkChoice,
     ResponseMessage,
     Usage,
 )
@@ -239,6 +242,100 @@ async def test_routed_model_header_uses_canonical_when_dispatch_uses_provider_sl
     # The dispatch-form string never appears in any header value
     for v in resp.headers.values():
         assert "some/dispatch-form" not in v
+
+
+# ---------------------------------------------------------------------------
+# #47: response BODY must not leak an upstream-provider model slug
+# ---------------------------------------------------------------------------
+
+# A provider-specific catalog id an adapter might echo back from upstream
+# (e.g. a hosted-pool provider's internal model name). The body must never
+# surface this when capability routing substituted the model.
+_LEAK_SLUG = "accounts/secret-provider/models/internal-123"
+
+
+class _LeakyAdapter(_FakeAdapter):
+    """Adapter whose RESPONSE carries a provider slug different from the
+    requested model — the real #47 leak vector."""
+
+    async def chat(self, request: ChatCompletionRequest) -> ChatCompletion:
+        self.received_models.append(request.model)
+        return ChatCompletion(
+            model=_LEAK_SLUG,
+            choices=[Choice(
+                index=0, message=ResponseMessage(content="ok"), finish_reason="stop",
+            )],
+            usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+
+class _LeakyStreamingAdapter(_FakeAdapter):
+    """Streaming variant: chunks carry the provider slug."""
+
+    async def stream_chat(
+        self, request: ChatCompletionRequest
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        self.received_models.append(request.model)
+        yield ChatCompletionChunk(
+            id="x", created=0, model=_LEAK_SLUG,
+            choices=[ChunkChoice(
+                index=0, delta=ChoiceDelta(content="ok"), finish_reason="stop",
+            )],
+        )
+
+
+def _capability_app(adapter: ProviderAdapter):
+    """Capability-routing app — the gateway substitutes a model the client
+    didn't ask for, so model_id_override is set on the decision."""
+    registry = ModelRegistry([_entry("canonical-name", "test-provider", 0.04, 0.04, simple_qa=0.85)])
+    scout = CapabilityScout(
+        registry=registry, quality_threshold=0.80,
+        eligible_providers=frozenset({"test-provider"}),
+    )
+    return build_app(
+        settings=GatewaySettings(),
+        router=CapabilityRouter(
+            scout=scout, adapters_by_provider={"test-provider": adapter},
+        ),
+        model_registry=registry,
+    )
+
+
+async def test_response_body_does_not_leak_provider_slug() -> None:
+    """Non-streaming: the adapter returns a provider slug, but the body echoes
+    the client's requested model — the slug never reaches the client."""
+    adapter = _LeakyAdapter("test-provider")
+    app = _capability_app(adapter)
+    payload = _payload("ping")
+
+    resp = await _post(app, payload)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    # Body shows the canonical routed model (matches the header), never the slug.
+    assert body["model"] == "canonical-name"
+    assert body["model"] == resp.headers["x-modelmeld-routed-model"]
+    assert _LEAK_SLUG not in json.dumps(body)
+
+
+async def test_streaming_body_does_not_leak_provider_slug() -> None:
+    """Streaming: every chunk's model echoes the requested model, and the slug
+    appears nowhere in the SSE payload."""
+    adapter = _LeakyStreamingAdapter("test-provider")
+    app = _capability_app(adapter)
+    payload = {**_payload("ping"), "stream": True}
+
+    resp = await _post(app, payload)
+
+    assert resp.status_code == 200
+    models_seen = [
+        json.loads(line[6:])["model"]
+        for line in resp.text.splitlines()
+        if line.startswith("data: ") and "[DONE]" not in line
+    ]
+    assert models_seen, "expected at least one streamed chunk"
+    assert all(m == "canonical-name" for m in models_seen)
+    assert _LEAK_SLUG not in resp.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
  The OpenAI `/v1/chat/completions` response body — and each streamed chunk —
  echoed whatever model string the adapter returned from upstream, which can
  differ from the canonical model the gateway actually routed to. This pins the
  body's `model` field to the canonical routed model (the same value as the
  `x-modelmeld-routed-model` header) on both the non-streaming and streaming
  paths, so body and header always agree. The Anthropic routes already normalize this.

  ## Type of change
  - [x] Bug fix (non-breaking change that resolves an issue)

  ## Test plan
  - New regression tests in `tests/test_capability_routing_with_hints.py` (stream
    + non-stream): an adapter whose response carries a different model than the one
    dispatched; assert the body/chunks report the canonical routed model.
  - Existing `test_capability_routing_overrides_request_model` still passes.
  - Full suite: 1084 passed, 11 skipped. ruff + pyright clean; open-core boundary verify passes.
  ## Linked issues
  N/A (internal tracker)

  ## Checklist
  - [x] Tests added or updated and they actually exercise the change
  - [x] `pytest` passes (full suite)
  - [x] All commits have DCO signoff
  - [x] Read `docs/open-core-boundary.md` (no boundary impact)

  ## Additional context
  The OpenAI surface reports the canonical routed model; the Anthropic surface
  reports the client's requested alias. Unifying the two is tracked as a follow-up