### PR TITLE
fix(messages): surface cache_control stats on the streaming path

### DIFF
--- a/src/modelmeld/translation/openai_anthropic.py
+++ b/src/modelmeld/translation/openai_anthropic.py
@@ -321,6 +321,36 @@ def from_anthropic_response(response: dict[str, Any]) -> ChatCompletion:
 # Streaming: Anthropic events → OpenAI chunks
 # ---------------------------------------------------------------------------
 
+def _usage_from_anthropic_message_start(usage_dict: dict[str, Any]) -> Usage | None:
+    """Carry an Anthropic `message_start` usage block — input tokens + cache
+    stats — onto the first OpenAI chunk, so downstream consumers (and the
+    OpenAI→Anthropic re-translation) can surface them. Anthropic reports cache
+    counts ONLY in message_start, so this is the one chance to capture them in a
+    stream. Returns None when there's nothing to carry. Mirrors
+    `from_anthropic_response`.
+    """
+    if not usage_dict:
+        return None
+    cache_write = usage_dict.get("cache_creation_input_tokens")
+    cache_read = usage_dict.get("cache_read_input_tokens")
+    prompt_details: PromptTokensDetails | None = None
+    if cache_write is not None or cache_read is not None:
+        prompt_details = PromptTokensDetails(
+            cache_creation_input_tokens=cache_write,
+            cache_read_input_tokens=cache_read,
+            cached_tokens=cache_read,
+        )
+    in_tok = int(usage_dict.get("input_tokens", 0))
+    if prompt_details is None and in_tok == 0:
+        return None
+    return Usage(
+        prompt_tokens=in_tok,
+        completion_tokens=0,
+        total_tokens=in_tok,
+        prompt_tokens_details=prompt_details,
+    )
+
+
 class AnthropicStreamTranslator:
     """Accumulates state across an Anthropic stream and emits OpenAI chunks.
 
@@ -358,9 +388,13 @@ class AnthropicStreamTranslator:
             self.id = message.get("id", self.id)
             self.model = message.get("model", self.model)
             self.created = int(time.time())
-            # Emit the role chunk now.
+            # Emit the role chunk now, carrying any cache stats from the
+            # message_start usage (the only place Anthropic reports them).
             self.role_emitted = True
-            return self._chunk(ChoiceDelta(role="assistant", content=""))
+            return self._chunk(
+                ChoiceDelta(role="assistant", content=""),
+                usage=_usage_from_anthropic_message_start(message.get("usage", {})),
+            )
 
         if etype == "content_block_start":
             idx = event.get("index", 0)
@@ -889,6 +923,10 @@ class OpenAIToAnthropicStreamTranslator:
         # Accumulated state, emitted at finalize().
         self._finish_reason: FinishReason | None = None
         self._final_output_tokens: int = 0
+        # Anthropic cache stats, captured from the first chunk that carries them
+        # (they ride in prompt_tokens_details) and emitted in message_start.
+        self._cache_creation: int | None = None
+        self._cache_read: int | None = None
         # Whether any content_block was ever opened. If still False at finalize,
         # emit a single empty text block so Anthropic's "≥1 block per response"
         # invariant holds.
@@ -900,14 +938,26 @@ class OpenAIToAnthropicStreamTranslator:
         """Process one OpenAI chunk; return 0+ Anthropic events to emit."""
         events: list[AnthropicStreamEvent] = []
 
+        # Capture usage (output tokens + Anthropic cache stats) BEFORE emitting
+        # message_start: the cache counts ride on the first chunk, and
+        # message_start is emitted on that same chunk, so they must be read
+        # first to make it into the event.
+        if chunk.usage is not None:
+            self._final_output_tokens = chunk.usage.completion_tokens
+            details = chunk.usage.prompt_tokens_details
+            if details is not None:
+                if details.cache_creation_input_tokens is not None:
+                    self._cache_creation = details.cache_creation_input_tokens
+                if details.cache_read_input_tokens is not None:
+                    self._cache_read = details.cache_read_input_tokens
+
         # message_start (exactly once, on the first chunk).
         if not self._message_started:
             self._message_started = True
             self._message_id = self._normalize_id(chunk.id)
             events.append(self._make_message_start())
 
-        # Pull finish_reason / usage from the chunk regardless of choices
-        # shape. Some adapters emit a final usage-only chunk with choices=[].
+        # Pull finish_reason from the chunk regardless of choices shape.
         if chunk.choices:
             choice = chunk.choices[0]
             delta = choice.delta
@@ -923,9 +973,6 @@ class OpenAIToAnthropicStreamTranslator:
 
             if choice.finish_reason is not None:
                 self._finish_reason = choice.finish_reason
-
-        if chunk.usage is not None:
-            self._final_output_tokens = chunk.usage.completion_tokens
 
         return events
 
@@ -998,6 +1045,8 @@ class OpenAIToAnthropicStreamTranslator:
                 usage=AnthropicUsage(
                     input_tokens=self.input_tokens,
                     output_tokens=0,
+                    cache_creation_input_tokens=self._cache_creation,
+                    cache_read_input_tokens=self._cache_read,
                 ),
             ),
         )

--- a/tests/test_streaming_cache_stats.py
+++ b/tests/test_streaming_cache_stats.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""Anthropic `cache_control` stats survive the streaming path.
+
+Non-streaming already surfaces `cache_creation_input_tokens` /
+`cache_read_input_tokens` (the cache-write + cache-hit counts customers use to
+verify their caching works). These tests cover the streaming path, where the
+counts have to survive two translations — Anthropic SSE → internal OpenAI
+chunks → Anthropic SSE — and Anthropic reports them ONLY in `message_start`.
+
+Three layers:
+  - inbound translator carries them off Anthropic's message_start onto the chunk
+  - outbound translator re-emits them in the Anthropic message_start it builds
+  - end-to-end through /v1/messages streaming
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+import httpx
+
+from modelmeld.adapters.base import ProviderAdapter
+from modelmeld.api.schemas import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionRequest,
+    ChoiceDelta,
+    ChunkChoice,
+    PromptTokensDetails,
+    Usage,
+)
+from modelmeld.api.schemas_anthropic import AnthropicMessageStartEvent
+from modelmeld.api.server import build_app
+from modelmeld.translation import OpenAIToAnthropicStreamTranslator
+from modelmeld.translation.openai_anthropic import AnthropicStreamTranslator
+
+# ---------------------------------------------------------------------------
+# Inbound: Anthropic message_start usage → OpenAI chunk prompt_tokens_details
+# ---------------------------------------------------------------------------
+
+def test_inbound_carries_cache_stats_onto_role_chunk() -> None:
+    t = AnthropicStreamTranslator()
+    chunk = t.translate_event({
+        "type": "message_start",
+        "message": {
+            "id": "msg_1", "model": "claude-opus-4-7",
+            "usage": {
+                "input_tokens": 120,
+                "cache_creation_input_tokens": 4933,
+                "cache_read_input_tokens": 12,
+            },
+        },
+    })
+    assert chunk is not None and chunk.usage is not None
+    details = chunk.usage.prompt_tokens_details
+    assert details is not None
+    assert details.cache_creation_input_tokens == 4933
+    assert details.cache_read_input_tokens == 12
+    assert details.cached_tokens == 12  # mirrored cross-vendor slot
+
+
+def test_inbound_no_cache_means_no_prompt_details() -> None:
+    t = AnthropicStreamTranslator()
+    chunk = t.translate_event({
+        "type": "message_start",
+        "message": {"id": "x", "model": "m", "usage": {"input_tokens": 10}},
+    })
+    assert chunk is not None and chunk.usage is not None
+    assert chunk.usage.prompt_tokens_details is None
+
+
+# ---------------------------------------------------------------------------
+# Outbound: chunk prompt_tokens_details → Anthropic message_start usage
+# ---------------------------------------------------------------------------
+
+def _first_message_start(events) -> AnthropicMessageStartEvent:
+    starts = [e for e in events if isinstance(e, AnthropicMessageStartEvent)]
+    assert len(starts) == 1
+    return starts[0]
+
+
+def test_outbound_emits_cache_stats_in_message_start() -> None:
+    t = OpenAIToAnthropicStreamTranslator(request_model="claude-opus-4-7", input_tokens=120)
+    first = ChatCompletionChunk(
+        id="msg_1", created=0, model="claude-opus-4-7",
+        choices=[ChunkChoice(index=0, delta=ChoiceDelta(role="assistant", content=""))],
+        usage=Usage(
+            prompt_tokens=120, completion_tokens=0, total_tokens=120,
+            prompt_tokens_details=PromptTokensDetails(
+                cache_creation_input_tokens=4933,
+                cache_read_input_tokens=12,
+                cached_tokens=12,
+            ),
+        ),
+    )
+    usage = _first_message_start(t.translate_chunk(first)).message.usage
+    assert usage.cache_creation_input_tokens == 4933
+    assert usage.cache_read_input_tokens == 12
+
+
+def test_outbound_no_cache_fields_when_chunk_has_none() -> None:
+    t = OpenAIToAnthropicStreamTranslator(request_model="m", input_tokens=5)
+    first = ChatCompletionChunk(
+        id="msg_2", created=0, model="m",
+        choices=[ChunkChoice(index=0, delta=ChoiceDelta(role="assistant", content=""))],
+        usage=None,
+    )
+    usage = _first_message_start(t.translate_chunk(first)).message.usage
+    assert usage.cache_creation_input_tokens is None
+    assert usage.cache_read_input_tokens is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: /v1/messages streaming surfaces the cache counts
+# ---------------------------------------------------------------------------
+
+class _CacheStreamAdapter(ProviderAdapter):
+    """Streams a first chunk carrying cache stats (what the inbound translator
+    produces from Anthropic's message_start), then a final usage chunk."""
+
+    name = "mock-cache-stream"
+    is_egress = False
+
+    async def chat(self, request: ChatCompletionRequest) -> ChatCompletion:
+        raise NotImplementedError("streaming-only fixture")
+
+    async def stream_chat(
+        self, request: ChatCompletionRequest,
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        cid = "msg_cache_fixture"
+        yield ChatCompletionChunk(
+            id=cid, created=1, model=request.model,
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(role="assistant", content="hi"))],
+            usage=Usage(
+                prompt_tokens=120, completion_tokens=0, total_tokens=120,
+                prompt_tokens_details=PromptTokensDetails(
+                    cache_creation_input_tokens=4933,
+                    cache_read_input_tokens=12,
+                    cached_tokens=12,
+                ),
+            ),
+        )
+        yield ChatCompletionChunk(
+            id=cid, created=1, model=request.model,
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(), finish_reason="stop")],
+            usage=Usage(prompt_tokens=120, completion_tokens=5, total_tokens=125),
+        )
+
+    async def health(self) -> bool:
+        return True
+
+
+def _parse_sse(raw: str) -> list[dict]:
+    out: list[dict] = []
+    for block in raw.split("\n\n"):
+        for line in block.split("\n"):
+            if line.startswith("data: "):
+                out.append(json.loads(line[len("data: "):]))
+    return out
+
+
+async def test_messages_streaming_surfaces_cache_stats_in_message_start() -> None:
+    app = build_app(adapter=_CacheStreamAdapter())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/v1/messages", json={
+            "model": "claude-opus-4-7", "max_tokens": 64, "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+    assert resp.status_code == 200
+    events = _parse_sse(resp.text)
+    start = next(e for e in events if e.get("type") == "message_start")
+    usage = start["message"]["usage"]
+    assert usage["cache_creation_input_tokens"] == 4933
+    assert usage["cache_read_input_tokens"] == 12


### PR DESCRIPTION
## Summary
  Anthropic reports prompt-cache counts (`cache_creation_input_tokens` /
  `cache_read_input_tokens`) only in the `message_start` event. On the
  `/v1/messages` streaming path these were dropped at both translation hops
  (Anthropic SSE → internal OpenAI chunks → Anthropic SSE), so customers couldn't
  verify caching on streamed responses even though the discount still applied.
  Non-streaming has surfaced them since 0.7.1; this brings streaming to parity.

  ## Type of change
  - [x] Bug fix (non-breaking change that resolves an issue)

  ## Test plan
  - New `tests/test_streaming_cache_stats.py` (5 tests): inbound translator carries
    cache stats onto the role chunk; outbound translator emits them in
    `message_start`; with/without-cache cases; end-to-end `/v1/messages` streaming
    asserting the counts appear in the SSE `message_start`.
  - Full suite: 1089 passed, 11 skipped. ruff + pyright clean; open-core boundary verify passes.
  ## Linked issues
  N/A (internal tracker)

  ## Checklist
  - [x] Tests added or updated and they actually exercise the change
  - [x] `pytest` passes (full suite)
  - [x] All commits have DCO signoff
  - [x] Read `docs/open-core-boundary.md` (no boundary impact)

  ## Additional context
  The OpenAI surface (`/v1/chat/completions`) streaming gets the cache fields on
  the role chunk via the inbound change too, but OpenAI clients conventionally
  read usage on the final chunk (`stream_options.include_usage`); surfacing it
  cleanly there is a separate follow-up.