### PR TITLE
feat(responses): /v1/responses endpoint with streaming (Codex CLI surface)

### DIFF
--- a/src/modelmeld/api/routes/responses.py
+++ b/src/modelmeld/api/routes/responses.py
@@ -3,14 +3,16 @@
 
 """POST /v1/responses — OpenAI Responses API surface (Codex CLI plug-and-play).
 
-Phase 1 is non-streaming. The handler reuses the chat pipeline: translate the
-Responses request to the internal Chat shape, run the same routing / BYOK /
-subscription-passthrough / PII-scrub / capability-routing path, then translate
-the ChatCompletion back to a Responses result. Audit headers, hooks, and memory
-write-back come for free via `_completion_with_failover`.
+The handler reuses the chat pipeline: translate the Responses request to the
+internal Chat shape, run the same routing / BYOK / subscription-passthrough /
+PII-scrub / capability-routing path, then translate back. Non-streaming goes
+through `_completion_with_failover`; streaming emits Responses SSE events via
+`ResponsesStreamTranslator`. Audit headers, hooks, and memory write-back are
+shared with the chat route.
 
-`stream=true` returns 501 until the Responses SSE event stream lands (Phase 2);
-Codex CLI streams, so this endpoint isn't yet a full Codex drop-in.
+Streaming covers text (Phase 2a). Tool-call streaming (function_call items +
+response.function_call_arguments.* events) is a 2b follow-up; non-streaming
+already handles tool calls.
 """
 
 from __future__ import annotations
@@ -19,20 +21,29 @@ import time
 import uuid
 
 from fastapi import APIRouter, HTTPException, Request, Response
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
+from modelmeld.adapters import AdapterError
 from modelmeld.api._safe_error_detail import safe_error_detail
 from modelmeld.api.auth_detection import classify_authorization
 from modelmeld.api.byok import build_byok_adapters, extract_byok_credentials
 from modelmeld.api.routes.chat import (
+    _apply_model_override,
     _auth_identity,
     _byok_required_detail,
+    _canonical_model_id_for_header,
+    _chunk_content_tokens,
+    _chunk_text_pieces,
     _completion_with_failover,
     _fire_failure,
+    _fire_success_stream,
     _is_byok_required_error,
     _is_no_eligible_model_error,
     _maybe_scrub,
     _no_eligible_model_detail,
+    _routing_headers,
+    _try_open_stream,
+    _write_memory_turns_streaming,
 )
 from modelmeld.api.routing_hints import RoutingHintError, extract_hints_from_headers
 from modelmeld.api.schemas_responses import ResponsesRequest
@@ -55,6 +66,10 @@ from modelmeld.translation.openai_responses import (
     from_responses_request,
     to_responses_response,
 )
+from modelmeld.translation.responses_stream import (
+    ResponsesStreamTranslator,
+    format_responses_sse,
+)
 
 router = APIRouter()
 
@@ -64,16 +79,7 @@ async def responses(
     body: ResponsesRequest,
     fastapi_request: Request,
     response: Response,
-) -> JSONResponse:
-    if body.stream:
-        raise HTTPException(
-            status_code=501,
-            detail=(
-                "streaming is not yet supported on /v1/responses; "
-                "set stream=false (Responses SSE streaming is a follow-up)"
-            ),
-        )
-
+) -> JSONResponse | StreamingResponse:
     rt: Router = fastapi_request.app.state.router
     scrubber: Scrubber | None = fastapi_request.app.state.scrubber
     hooks: HookRegistry = fastapi_request.app.state.hooks
@@ -153,8 +159,15 @@ async def responses(
     internal_request = inject_into_request(internal_request, mem_context)
     outgoing, redactions = _maybe_scrub(internal_request, decision, scrubber)
 
-    # Shared dispatch: failover, audit headers (on `response`), hooks, memory
-    # write-back, and the canonical-model pin all happen here.
+    if body.stream:
+        return await _stream_responses_with_failover(
+            rt, decision, outgoing, redactions, hooks, request_id, started,
+            identity, provider, mem_identity, token_counter,
+            hints=hints, model_registry=model_registry,
+        )
+
+    # Non-streaming. Shared dispatch: failover, audit headers (on `response`),
+    # hooks, memory write-back, and the canonical-model pin all happen here.
     completion = await _completion_with_failover(
         rt, decision, outgoing, redactions, hooks, request_id, started, response,
         identity, provider, mem_identity, token_counter,
@@ -166,3 +179,129 @@ async def responses(
         content=payload.model_dump(exclude_none=True),
         headers=dict(response.headers),
     )
+
+
+# ---------------------------------------------------------------------------
+# Streaming (Responses SSE)
+# ---------------------------------------------------------------------------
+
+async def _stream_responses_with_failover(
+    rt: Router,
+    decision,
+    request,
+    redactions: list,
+    hooks: HookRegistry,
+    request_id: str,
+    started: float,
+    identity: dict[str, str | None] | None,
+    provider: MemoryProvider | None,
+    mem_identity,
+    token_counter: TokenCounter | None,
+    *,
+    hints=None,
+    model_registry=None,
+) -> StreamingResponse:
+    failover_from: str | None = None
+    primary_aiter, first_chunk, primary_error = await _try_open_stream(
+        decision.adapter, _apply_model_override(request, decision),
+    )
+    if first_chunk is None and primary_aiter is None:
+        fallback = await rt.route_after_failure(decision, request, error=primary_error)
+        if fallback is None:
+            err = primary_error or AdapterError("primary stream open failed")
+            await _fire_failure(
+                hooks, request_id, started, request, decision, redactions, None,
+                err, "adapter_error", identity,
+            )
+            raise HTTPException(status_code=502, detail=safe_error_detail(err))
+        failover_from = str(decision.tier)
+        decision = fallback
+        primary_aiter, first_chunk, _ = await _try_open_stream(
+            decision.adapter, _apply_model_override(request, decision),
+        )
+        if primary_aiter is None and first_chunk is None:
+            await _fire_failure(
+                hooks, request_id, started, request, decision, redactions,
+                failover_from, AdapterError("fallback stream open failed"),
+                "adapter_error", identity,
+            )
+            raise HTTPException(status_code=502, detail="fallback stream open failed")
+
+    headers = _routing_headers(
+        decision, redactions, failover_from, hints=hints, model_registry=model_registry,
+    )
+    served_model = (
+        _canonical_model_id_for_header(
+            decision.model_id_override, decision.adapter.name, model_registry,
+        )
+        or decision.model_id_override
+        or request.model
+    )
+    return StreamingResponse(
+        _sse_responses(
+            primary_aiter, first_chunk, hooks, request_id, started, request,
+            decision, redactions, failover_from, identity, provider, mem_identity,
+            token_counter, served_model,
+        ),
+        media_type="text/event-stream",
+        headers=headers,
+    )
+
+
+async def _sse_responses(
+    aiter,
+    first,
+    hooks: HookRegistry,
+    request_id: str,
+    started: float,
+    request,
+    decision,
+    redactions: list,
+    failover_from: str | None,
+    identity: dict[str, str | None] | None,
+    provider: MemoryProvider | None,
+    mem_identity,
+    token_counter: TokenCounter | None,
+    served_model: str,
+):
+    translator = ResponsesStreamTranslator(model=served_model)
+    output_tokens = 0
+    last_usage = None
+    accumulated_text: list[str] = []
+    error: Exception | None = None
+    try:
+        if first is not None:
+            for event in translator.translate_chunk(first):
+                yield format_responses_sse(event)
+            output_tokens += _chunk_content_tokens(first)
+            accumulated_text.extend(_chunk_text_pieces(first))
+            if first.usage is not None:
+                last_usage = first.usage
+        if aiter is not None:
+            async for chunk in aiter:
+                for event in translator.translate_chunk(chunk):
+                    yield format_responses_sse(event)
+                output_tokens += _chunk_content_tokens(chunk)
+                accumulated_text.extend(_chunk_text_pieces(chunk))
+                if chunk.usage is not None:
+                    last_usage = chunk.usage
+    except Exception as e:
+        error = e
+
+    if error is None:
+        # Responses SSE has no [DONE] terminator; response.completed ends it.
+        for event in translator.finalize():
+            yield format_responses_sse(event)
+        await _fire_success_stream(
+            hooks, request_id, started, request, decision, redactions, failover_from,
+            output_tokens, last_usage, identity,
+        )
+        await _write_memory_turns_streaming(
+            provider, mem_identity, request, "".join(accumulated_text),
+            output_tokens, decision, token_counter,
+        )
+    else:
+        await _fire_failure(
+            hooks, request_id, started, request, decision, redactions, failover_from,
+            error, "stream_error", identity,
+        )

--- a/src/modelmeld/api/routes/responses.py
+++ b/src/modelmeld/api/routes/responses.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""POST /v1/responses — OpenAI Responses API surface (Codex CLI plug-and-play).
+
+Phase 1 is non-streaming. The handler reuses the chat pipeline: translate the
+Responses request to the internal Chat shape, run the same routing / BYOK /
+subscription-passthrough / PII-scrub / capability-routing path, then translate
+the ChatCompletion back to a Responses result. Audit headers, hooks, and memory
+write-back come for free via `_completion_with_failover`.
+
+`stream=true` returns 501 until the Responses SSE event stream lands (Phase 2);
+Codex CLI streams, so this endpoint isn't yet a full Codex drop-in.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi.responses import JSONResponse
+
+from modelmeld.api._safe_error_detail import safe_error_detail
+from modelmeld.api.auth_detection import classify_authorization
+from modelmeld.api.byok import build_byok_adapters, extract_byok_credentials
+from modelmeld.api.routes.chat import (
+    _auth_identity,
+    _byok_required_detail,
+    _completion_with_failover,
+    _fire_failure,
+    _is_byok_required_error,
+    _is_no_eligible_model_error,
+    _maybe_scrub,
+    _no_eligible_model_detail,
+)
+from modelmeld.api.routing_hints import RoutingHintError, extract_hints_from_headers
+from modelmeld.api.schemas_responses import ResponsesRequest
+from modelmeld.api.subscription_passthrough import (
+    PassthroughVendor,
+    resolve_passthrough_router,
+)
+from modelmeld.hooks import HookRegistry
+from modelmeld.memory import (
+    MemoryContext,
+    MemoryHeaderError,
+    MemoryProvider,
+    extract_memory_identity,
+    inject_into_request,
+)
+from modelmeld.privacy import Scrubber
+from modelmeld.router import Router, RouterError
+from modelmeld.tokens import TokenCounter
+from modelmeld.translation.openai_responses import (
+    from_responses_request,
+    to_responses_response,
+)
+
+router = APIRouter()
+
+
+@router.post("/responses", response_model=None)
+async def responses(
+    body: ResponsesRequest,
+    fastapi_request: Request,
+    response: Response,
+) -> JSONResponse:
+    if body.stream:
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                "streaming is not yet supported on /v1/responses; "
+                "set stream=false (Responses SSE streaming is a follow-up)"
+            ),
+        )
+
+    rt: Router = fastapi_request.app.state.router
+    scrubber: Scrubber | None = fastapi_request.app.state.scrubber
+    hooks: HookRegistry = fastapi_request.app.state.hooks
+    provider: MemoryProvider | None = getattr(
+        fastapi_request.app.state, "memory_provider", None,
+    )
+    token_counter: TokenCounter | None = getattr(
+        fastapi_request.app.state, "token_counter", None,
+    )
+    settings = getattr(fastapi_request.app.state, "settings", None)
+    model_registry = getattr(fastapi_request.app.state, "model_registry", None)
+    identity = _auth_identity(fastapi_request)
+
+    try:
+        mem_identity = extract_memory_identity(
+            fastapi_request.headers,
+            auth_tenant_id=(identity or {}).get("tenant_id") if identity else None,
+            auth_user_id=(identity or {}).get("user_id") if identity else None,
+        )
+    except MemoryHeaderError as e:
+        raise HTTPException(status_code=400, detail=f"invalid_memory_header: {e}") from e
+
+    allowlist = getattr(fastapi_request.state, "api_key_model_allowlist", None)
+    if allowlist is not None and body.model not in allowlist:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Model '{body.model}' is not in this API key's allowlist",
+        )
+
+    started = time.perf_counter()
+    request_id = f"req_{uuid.uuid4().hex[:24]}"
+
+    try:
+        hints = extract_hints_from_headers(fastapi_request.headers)
+    except RoutingHintError as e:
+        raise HTTPException(status_code=400, detail=f"invalid_routing_hint: {e}") from e
+
+    byok_creds = extract_byok_credentials(fastapi_request.headers.items())
+    byok_adapters = build_byok_adapters(byok_creds) if not byok_creds.is_empty() else {}
+
+    # OAuth-bearer requests route through the Codex passthrough adapter, the
+    # same vendor the /v1/chat/completions path uses.
+    auth_classification = classify_authorization(
+        fastapi_request.headers.get("authorization"),
+    )
+    passthrough_router = resolve_passthrough_router(
+        auth_classification,
+        vendor=PassthroughVendor.CODEX,
+        allow_passthrough=bool(getattr(settings, "allow_subscription_passthrough", False)),
+    )
+    active_router: Router = passthrough_router or rt
+
+    internal_request = from_responses_request(body)
+
+    try:
+        decision = await active_router.route(
+            internal_request,
+            hints=hints,
+            extra_adapters=byok_adapters if byok_adapters else None,
+        )
+    except RouterError as e:
+        await _fire_failure(
+            hooks, request_id, started, internal_request, None, [], None,
+            e, "router_error", identity,
+        )
+        if _is_byok_required_error(e, byok_creds):
+            raise HTTPException(status_code=400, detail=_byok_required_detail(e)) from e
+        if _is_no_eligible_model_error(e):
+            raise HTTPException(status_code=400, detail=_no_eligible_model_detail(e)) from e
+        raise HTTPException(status_code=503, detail=safe_error_detail(e)) from e
+
+    # Memory injection before scrub so injected context is scrubbed on egress.
+    mem_context = (
+        await provider.retrieve(mem_identity, internal_request)
+        if provider is not None else MemoryContext()
+    )
+    internal_request = inject_into_request(internal_request, mem_context)
+    outgoing, redactions = _maybe_scrub(internal_request, decision, scrubber)
+
+    # Shared dispatch: failover, audit headers (on `response`), hooks, memory
+    # write-back, and the canonical-model pin all happen here.
+    completion = await _completion_with_failover(
+        rt, decision, outgoing, redactions, hooks, request_id, started, response,
+        identity, provider, mem_identity, token_counter,
+        hints=hints, model_registry=model_registry,
+    )
+
+    payload = to_responses_response(completion, model=completion.model)
+    return JSONResponse(
+        content=payload.model_dump(exclude_none=True),
+        headers=dict(response.headers),
+    )

--- a/src/modelmeld/api/schemas_responses.py
+++ b/src/modelmeld/api/schemas_responses.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""Pydantic models for the OpenAI Responses API surface (`POST /v1/responses`).
+
+This is the third wire format the gateway speaks (alongside Chat Completions and
+Anthropic Messages). Codex CLI talks the Responses API natively, so exposing it
+at the standard `/v1/responses` path lets Codex point at the gateway with no
+plugin shim.
+
+Request shape: an `input` (string or list of role/content items) plus a separate
+`instructions` string. Response shape: an `output` array of typed items
+(`message`, `function_call`) rather than `choices`. Models are permissive
+(`extra="allow"`) where Codex sends fields we don't act on, so unknown fields
+round-trip instead of 422-ing.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# ---------------------------------------------------------------------------
+# Request
+# ---------------------------------------------------------------------------
+
+class ResponsesContentPart(BaseModel):
+    """One content part of an input item. Responses uses typed parts
+    (`input_text`, `output_text`, `input_image`, …); Phase 1 reads text parts."""
+
+    model_config = ConfigDict(extra="allow")
+    type: str
+    text: str | None = None
+
+
+class ResponsesInputItem(BaseModel):
+    """One role/content entry in the `input` array."""
+
+    model_config = ConfigDict(extra="allow")
+    role: str  # user | assistant | system | developer
+    content: str | list[ResponsesContentPart]
+
+
+class ResponsesRequest(BaseModel):
+    """OpenAI Responses API request body."""
+
+    model_config = ConfigDict(extra="allow")
+    model: str
+    input: str | list[ResponsesInputItem]
+    instructions: str | None = None
+    tools: list[dict[str, Any]] | None = None
+    tool_choice: str | dict[str, Any] | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    max_output_tokens: int | None = None
+    stream: bool = False
+    store: bool | None = None
+    metadata: dict[str, Any] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Response
+# ---------------------------------------------------------------------------
+
+class ResponsesOutputText(BaseModel):
+    type: Literal["output_text"] = "output_text"
+    text: str
+    annotations: list[Any] = Field(default_factory=list)
+
+
+class ResponsesMessageItem(BaseModel):
+    type: Literal["message"] = "message"
+    id: str
+    role: Literal["assistant"] = "assistant"
+    status: Literal["completed"] = "completed"
+    content: list[ResponsesOutputText]
+
+
+class ResponsesFunctionCallItem(BaseModel):
+    type: Literal["function_call"] = "function_call"
+    id: str
+    call_id: str
+    name: str
+    arguments: str
+    status: Literal["completed"] = "completed"
+
+
+class ResponsesUsage(BaseModel):
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+
+
+class ResponsesResponse(BaseModel):
+    id: str
+    object: Literal["response"] = "response"
+    created_at: int
+    model: str
+    status: Literal["completed"] = "completed"
+    output: list[ResponsesMessageItem | ResponsesFunctionCallItem]
+    usage: ResponsesUsage

--- a/src/modelmeld/api/server.py
+++ b/src/modelmeld/api/server.py
@@ -129,13 +129,21 @@ def build_app(
         )
 
     from modelmeld.api.body_size_limit import BodySizeLimitMiddleware
-    from modelmeld.api.routes import chat, healthz, messages, models, version
+    from modelmeld.api.routes import (
+        chat,
+        healthz,
+        messages,
+        models,
+        responses,
+        version,
+    )
 
     app.include_router(healthz.router)
     app.include_router(version.router)
     app.include_router(models.router, prefix="/v1")
     app.include_router(chat.router, prefix="/v1")
     app.include_router(messages.router, prefix="/v1")
+    app.include_router(responses.router, prefix="/v1")
 
     # Body-size cap (defense against OOM/DoS from oversized payloads). Chat
     # and messages routes may carry large prompts so the default sits at 4 MB;

--- a/src/modelmeld/translation/openai_responses.py
+++ b/src/modelmeld/translation/openai_responses.py
@@ -25,8 +25,10 @@ from modelmeld.api.schemas import (
     AssistantMessage,
     ChatCompletion,
     ChatCompletionRequest,
+    FunctionDef,
     Message,
     SystemMessage,
+    Tool,
     UserMessage,
 )
 from modelmeld.api.schemas_responses import (
@@ -58,25 +60,30 @@ def _to_message(role: str, text: str) -> Message:
     return UserMessage(role="user", content=text)
 
 
-def _to_chat_tools(tools: list[dict[str, Any]] | None) -> list[dict[str, Any]] | None:
+def _to_chat_tools(tools: list[dict[str, Any]] | None) -> list[Tool] | None:
     """Responses function tools are flat (`{type, name, parameters, …}`); Chat
     nests them under `function`. Translate function tools; drop other tool types
     (e.g. built-in `web_search`) which have no Chat-Completions equivalent."""
     if not tools:
         return None
-    out: list[dict[str, Any]] = []
+    out: list[Tool] = []
     for tool in tools:
         if tool.get("type") != "function":
             continue
-        fn = tool.get("function") or {
-            "name": tool.get("name"),
-            "description": tool.get("description"),
-            "parameters": tool.get("parameters"),
-        }
-        out.append({
-            "type": "function",
-            "function": {k: v for k, v in fn.items() if v is not None},
-        })
+        # Flat Responses shape or already-nested Chat shape.
+        fn = tool.get("function") or tool
+        name = fn.get("name")
+        if not name:
+            continue
+        out.append(Tool(
+            type="function",
+            function=FunctionDef(
+                name=name,
+                description=fn.get("description"),
+                parameters=fn.get("parameters"),
+                strict=fn.get("strict"),
+            ),
+        ))
     return out or None
 
 

--- a/src/modelmeld/translation/openai_responses.py
+++ b/src/modelmeld/translation/openai_responses.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""Translation between the OpenAI Responses API and our internal Chat shape.
+
+Inbound  (`from_responses_request`): Responses request → ChatCompletionRequest.
+    `instructions` becomes a system message; `input` items become role/content
+    messages; Responses function tools are rewritten to Chat tool shape.
+
+Outbound (`to_responses_response`): ChatCompletion → Responses result. The
+    assistant's text becomes a `message` output item; each tool call becomes a
+    `function_call` output item (Responses surfaces tool calls in the output
+    array, not as a block on an assistant message).
+
+Phase 1 is non-streaming. The Responses SSE event stream is a separate follow-up.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from uuid import uuid4
+
+from modelmeld.api.schemas import (
+    AssistantMessage,
+    ChatCompletion,
+    ChatCompletionRequest,
+    Message,
+    SystemMessage,
+    UserMessage,
+)
+from modelmeld.api.schemas_responses import (
+    ResponsesContentPart,
+    ResponsesFunctionCallItem,
+    ResponsesMessageItem,
+    ResponsesOutputText,
+    ResponsesRequest,
+    ResponsesResponse,
+    ResponsesUsage,
+)
+
+# ---------------------------------------------------------------------------
+# Inbound: Responses request → ChatCompletionRequest
+# ---------------------------------------------------------------------------
+
+def _item_text(content: str | list[ResponsesContentPart]) -> str:
+    if isinstance(content, str):
+        return content
+    return "".join(part.text for part in content if part.text)
+
+
+def _to_message(role: str, text: str) -> Message:
+    # `developer` is the Responses-era rename of the system role.
+    if role in ("system", "developer"):
+        return SystemMessage(role="system", content=text)
+    if role == "assistant":
+        return AssistantMessage(role="assistant", content=text)
+    return UserMessage(role="user", content=text)
+
+
+def _to_chat_tools(tools: list[dict[str, Any]] | None) -> list[dict[str, Any]] | None:
+    """Responses function tools are flat (`{type, name, parameters, …}`); Chat
+    nests them under `function`. Translate function tools; drop other tool types
+    (e.g. built-in `web_search`) which have no Chat-Completions equivalent."""
+    if not tools:
+        return None
+    out: list[dict[str, Any]] = []
+    for tool in tools:
+        if tool.get("type") != "function":
+            continue
+        fn = tool.get("function") or {
+            "name": tool.get("name"),
+            "description": tool.get("description"),
+            "parameters": tool.get("parameters"),
+        }
+        out.append({
+            "type": "function",
+            "function": {k: v for k, v in fn.items() if v is not None},
+        })
+    return out or None
+
+
+def from_responses_request(req: ResponsesRequest) -> ChatCompletionRequest:
+    messages: list[Message] = []
+    if req.instructions:
+        messages.append(SystemMessage(role="system", content=req.instructions))
+    if isinstance(req.input, str):
+        messages.append(UserMessage(role="user", content=req.input))
+    else:
+        for item in req.input:
+            messages.append(_to_message(item.role, _item_text(item.content)))
+    return ChatCompletionRequest(
+        model=req.model,
+        messages=messages,
+        max_tokens=req.max_output_tokens,
+        temperature=req.temperature,
+        top_p=req.top_p,
+        tools=_to_chat_tools(req.tools),
+        tool_choice=req.tool_choice,
+        stream=req.stream,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Outbound: ChatCompletion → Responses result
+# ---------------------------------------------------------------------------
+
+def to_responses_response(completion: ChatCompletion, model: str) -> ResponsesResponse:
+    output: list[ResponsesMessageItem | ResponsesFunctionCallItem] = []
+    if completion.choices:
+        msg = completion.choices[0].message
+        if msg.content:
+            output.append(ResponsesMessageItem(
+                id=f"msg_{uuid4().hex[:24]}",
+                content=[ResponsesOutputText(text=msg.content)],
+            ))
+        for tc in msg.tool_calls or []:
+            output.append(ResponsesFunctionCallItem(
+                id=f"fc_{uuid4().hex[:24]}",
+                call_id=tc.id,
+                name=tc.function.name,
+                arguments=tc.function.arguments,
+            ))
+    # Responses guarantees ≥1 output item; emit an empty message if the
+    # completion produced neither text nor tool calls.
+    if not output:
+        output.append(ResponsesMessageItem(
+            id=f"msg_{uuid4().hex[:24]}",
+            content=[ResponsesOutputText(text="")],
+        ))
+
+    usage = completion.usage
+    return ResponsesResponse(
+        id=completion.id or f"resp_{uuid4().hex[:24]}",
+        created_at=int(time.time()),
+        model=model,
+        output=output,
+        usage=ResponsesUsage(
+            input_tokens=usage.prompt_tokens if usage else 0,
+            output_tokens=usage.completion_tokens if usage else 0,
+            total_tokens=usage.total_tokens if usage else 0,
+        ),
+    )

--- a/src/modelmeld/translation/responses_stream.py
+++ b/src/modelmeld/translation/responses_stream.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""Internal Chat chunk stream → OpenAI Responses API SSE events.
+
+The Responses streaming protocol is a lifecycle of typed events, each with a
+monotonic `sequence_number`:
+
+    response.created
+    response.output_item.added        (the assistant message item)
+    response.content_part.added       (an output_text part)
+    response.output_text.delta × N    (the text, chunk by chunk)
+    response.output_text.done
+    response.content_part.done
+    response.output_item.done
+    response.completed                (terminal; carries usage)
+
+Phase 2a handles text. Tool-call streaming (function_call items +
+response.function_call_arguments.delta/done) is a 2b follow-up; the
+non-streaming path already covers tool calls.
+
+Events are emitted as plain dicts shaped to the wire format. They are validated
+against the OpenAI SDK's own event models in the tests, so "matches the SDK" ==
+"matches what Codex parses."
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Iterable
+from typing import Any
+from uuid import uuid4
+
+from modelmeld.api.schemas import ChatCompletionChunk
+
+_OUTPUT_INDEX = 0
+_CONTENT_INDEX = 0
+
+
+def format_responses_sse(event: dict[str, Any]) -> str:
+    """Serialize one event dict to a Responses SSE frame."""
+    return f"event: {event['type']}\ndata: {json.dumps(event)}\n\n"
+
+
+class ResponsesStreamTranslator:
+    """State machine: ChatCompletionChunk stream → Responses SSE event dicts."""
+
+    def __init__(self, model: str, *, response_id: str | None = None) -> None:
+        self.model = model
+        self.response_id = response_id or f"resp_{uuid4().hex[:24]}"
+        self.item_id = f"msg_{uuid4().hex[:24]}"
+        self._created_at = int(time.time())
+        self._seq = 0
+        self._started = False
+        self._finished = False
+        self._text_parts: list[str] = []
+        self._input_tokens = 0
+        self._output_tokens = 0
+
+    # -- public API --------------------------------------------------------
+
+    def translate_chunk(self, chunk: ChatCompletionChunk) -> list[dict[str, Any]]:
+        events: list[dict[str, Any]] = []
+        if not self._started:
+            events.extend(self._start_events())
+        if chunk.choices:
+            delta = chunk.choices[0].delta
+            if delta.content:
+                self._text_parts.append(delta.content)
+                events.append({
+                    "type": "response.output_text.delta",
+                    "sequence_number": self._next_seq(),
+                    "item_id": self.item_id,
+                    "output_index": _OUTPUT_INDEX,
+                    "content_index": _CONTENT_INDEX,
+                    "delta": delta.content,
+                    "logprobs": [],
+                })
+        if chunk.usage is not None:
+            self._output_tokens = chunk.usage.completion_tokens
+            self._input_tokens = chunk.usage.prompt_tokens
+        return events
+
+    def finalize(self) -> list[dict[str, Any]]:
+        """Closing events. Idempotent — second call returns []."""
+        if self._finished:
+            return []
+        self._finished = True
+        events: list[dict[str, Any]] = []
+        if not self._started:
+            events.extend(self._start_events())
+
+        full_text = "".join(self._text_parts)
+        part = {"type": "output_text", "text": full_text, "annotations": []}
+        events.append({
+            "type": "response.output_text.done",
+            "sequence_number": self._next_seq(),
+            "item_id": self.item_id, "output_index": _OUTPUT_INDEX,
+            "content_index": _CONTENT_INDEX, "text": full_text, "logprobs": [],
+        })
+        events.append({
+            "type": "response.content_part.done",
+            "sequence_number": self._next_seq(),
+            "item_id": self.item_id, "output_index": _OUTPUT_INDEX,
+            "content_index": _CONTENT_INDEX, "part": part,
+        })
+        done_item = self._message_item("completed", [part])
+        events.append({
+            "type": "response.output_item.done",
+            "sequence_number": self._next_seq(),
+            "output_index": _OUTPUT_INDEX, "item": done_item,
+        })
+        events.append({
+            "type": "response.completed",
+            "sequence_number": self._next_seq(),
+            "response": self._response_obj("completed", [done_item], self._usage()),
+        })
+        return events
+
+    # -- internal ----------------------------------------------------------
+
+    def _next_seq(self) -> int:
+        n = self._seq
+        self._seq += 1
+        return n
+
+    def _start_events(self) -> Iterable[dict[str, Any]]:
+        self._started = True
+        yield {
+            "type": "response.created",
+            "sequence_number": self._next_seq(),
+            "response": self._response_obj("in_progress", []),
+        }
+        yield {
+            "type": "response.output_item.added",
+            "sequence_number": self._next_seq(),
+            "output_index": _OUTPUT_INDEX,
+            "item": self._message_item("in_progress", []),
+        }
+        yield {
+            "type": "response.content_part.added",
+            "sequence_number": self._next_seq(),
+            "item_id": self.item_id, "output_index": _OUTPUT_INDEX,
+            "content_index": _CONTENT_INDEX,
+            "part": {"type": "output_text", "text": "", "annotations": []},
+        }
+
+    def _message_item(self, status: str, content: list[dict[str, Any]]) -> dict[str, Any]:
+        return {
+            "type": "message", "id": self.item_id, "status": status,
+            "role": "assistant", "content": content,
+        }
+
+    def _usage(self) -> dict[str, Any]:
+        return {
+            "input_tokens": self._input_tokens,
+            "output_tokens": self._output_tokens,
+            "total_tokens": self._input_tokens + self._output_tokens,
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens_details": {"reasoning_tokens": 0},
+        }
+
+    def _response_obj(
+        self, status: str, output: list[dict[str, Any]], usage: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        obj: dict[str, Any] = {
+            "id": self.response_id, "object": "response",
+            "created_at": self._created_at, "model": self.model,
+            "status": status, "output": output,
+            "error": None, "incomplete_details": None, "instructions": None,
+            "metadata": {}, "parallel_tool_calls": True,
+            "temperature": None, "top_p": None,
+            "tool_choice": "auto", "tools": [],
+        }
+        obj["usage"] = usage
+        return obj

--- a/tests/test_responses_stream.py
+++ b/tests/test_responses_stream.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""ResponsesStreamTranslator: ChatCompletion chunks → Responses SSE events.
+
+The load-bearing test validates every emitted event against the OpenAI SDK's
+own Pydantic event models — the same library Codex parses with — so a passing
+suite means the wire shapes match what Codex expects.
+"""
+
+from __future__ import annotations
+
+from openai.types.responses import (
+    ResponseCompletedEvent,
+    ResponseContentPartAddedEvent,
+    ResponseContentPartDoneEvent,
+    ResponseCreatedEvent,
+    ResponseOutputItemAddedEvent,
+    ResponseOutputItemDoneEvent,
+    ResponseTextDeltaEvent,
+    ResponseTextDoneEvent,
+)
+
+from modelmeld.api.schemas import ChatCompletionChunk, ChoiceDelta, ChunkChoice, Usage
+from modelmeld.translation.responses_stream import (
+    ResponsesStreamTranslator,
+    format_responses_sse,
+)
+
+_SDK_EVENT = {
+    "response.created": ResponseCreatedEvent,
+    "response.output_item.added": ResponseOutputItemAddedEvent,
+    "response.content_part.added": ResponseContentPartAddedEvent,
+    "response.output_text.delta": ResponseTextDeltaEvent,
+    "response.output_text.done": ResponseTextDoneEvent,
+    "response.content_part.done": ResponseContentPartDoneEvent,
+    "response.output_item.done": ResponseOutputItemDoneEvent,
+    "response.completed": ResponseCompletedEvent,
+}
+
+
+def _chunk(content: str | None = None, *, usage: Usage | None = None) -> ChatCompletionChunk:
+    delta = ChoiceDelta(role="assistant", content=content) if content is not None else ChoiceDelta()
+    return ChatCompletionChunk(
+        id="c", created=0, model="qwen",
+        choices=[ChunkChoice(index=0, delta=delta)], usage=usage,
+    )
+
+
+def _run() -> list[dict]:
+    t = ResponsesStreamTranslator(model="qwen3-coder-next")
+    events: list[dict] = []
+    events += t.translate_chunk(_chunk("Hello "))
+    events += t.translate_chunk(_chunk("world"))
+    events += t.translate_chunk(_chunk(usage=Usage(prompt_tokens=10, completion_tokens=2, total_tokens=12)))
+    events += t.finalize()
+    return events
+
+
+def test_event_sequence() -> None:
+    types = [e["type"] for e in _run()]
+    assert types == [
+        "response.created",
+        "response.output_item.added",
+        "response.content_part.added",
+        "response.output_text.delta",
+        "response.output_text.delta",
+        "response.output_text.done",
+        "response.content_part.done",
+        "response.output_item.done",
+        "response.completed",
+    ]
+
+
+def test_every_event_validates_against_openai_sdk() -> None:
+    # If a dict doesn't match the SDK's shape, model_validate raises — meaning
+    # Codex (which uses the same SDK) wouldn't parse it either.
+    for event in _run():
+        cls = _SDK_EVENT[event["type"]]
+        cls.model_validate(event)
+
+
+def test_text_accumulates_and_usage_propagates() -> None:
+    events = _run()
+    done = next(e for e in events if e["type"] == "response.output_text.done")
+    assert done["text"] == "Hello world"
+    completed = next(e for e in events if e["type"] == "response.completed")
+    assert completed["response"]["status"] == "completed"
+    assert completed["response"]["usage"]["output_tokens"] == 2
+    assert completed["response"]["usage"]["input_tokens"] == 10
+
+
+def test_sequence_numbers_are_monotonic_from_zero() -> None:
+    seqs = [e["sequence_number"] for e in _run()]
+    assert seqs == list(range(len(seqs)))
+
+
+def test_finalize_is_idempotent() -> None:
+    t = ResponsesStreamTranslator(model="m")
+    t.translate_chunk(_chunk("hi"))
+    first = t.finalize()
+    assert first
+    assert t.finalize() == []
+
+
+def test_sse_frame_format() -> None:
+    frame = format_responses_sse({"type": "response.completed", "sequence_number": 0})
+    assert frame.startswith("event: response.completed\ndata: ")
+    assert frame.endswith("\n\n")

--- a/tests/test_route_responses.py
+++ b/tests/test_route_responses.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 
 import httpx
@@ -15,6 +16,8 @@ from modelmeld.api.schemas import (
     ChatCompletionChunk,
     ChatCompletionRequest,
     Choice,
+    ChoiceDelta,
+    ChunkChoice,
     FunctionCall,
     ResponseMessage,
     SystemMessage,
@@ -42,8 +45,16 @@ class _StubAdapter(ProviderAdapter):
     async def stream_chat(
         self, request: ChatCompletionRequest,
     ) -> AsyncIterator[ChatCompletionChunk]:
-        if False:  # pragma: no cover
-            yield
+        text = self._completion.choices[0].message.content or ""
+        yield ChatCompletionChunk(
+            id="c", created=0, model=request.model,
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(role="assistant", content=text))],
+        )
+        yield ChatCompletionChunk(
+            id="c", created=0, model=request.model,
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(), finish_reason="stop")],
+            usage=self._completion.usage,
+        )
 
     async def health(self) -> bool:
         return True
@@ -129,7 +140,35 @@ async def test_tool_calls_surface_as_function_call_items() -> None:
     assert fcs[0]["call_id"] == "call_42"
 
 
-async def test_streaming_not_yet_supported_returns_501() -> None:
-    app = build_app(adapter=_StubAdapter(_text_completion("x")))
-    resp = await _post(app, {"model": "m", "input": "hi", "stream": True})
-    assert resp.status_code == 501
+def _parse_responses_sse(raw: str) -> list[dict]:
+    out: list[dict] = []
+    for block in raw.split("\n\n"):
+        for line in block.split("\n"):
+            if line.startswith("data: "):
+                out.append(json.loads(line[len("data: "):]))
+    return out
+
+
+async def test_streaming_emits_responses_sse_lifecycle() -> None:
+    adapter = _StubAdapter(_text_completion("Hello world", model="qwen3-coder-next"))
+    app = build_app(adapter=adapter)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/v1/responses",
+            json={"model": "anthropic/modelmeld-auto", "input": "hi", "stream": True},
+        )
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert resp.headers["x-modelmeld-routed-to"] == "stub-responses"
+
+    events = _parse_responses_sse(resp.text)
+    types = [e["type"] for e in events]
+    assert types[0] == "response.created"
+    assert types[-1] == "response.completed"
+    assert "response.output_text.delta" in types
+    text = "".join(e["delta"] for e in events if e["type"] == "response.output_text.delta")
+    assert text == "Hello world"
+    assert events[-1]["response"]["status"] == "completed"

--- a/tests/test_route_responses.py
+++ b/tests/test_route_responses.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""End-to-end /v1/responses (Phase 1, non-streaming)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import httpx
+
+from modelmeld.adapters.base import ProviderAdapter
+from modelmeld.api.schemas import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionRequest,
+    Choice,
+    FunctionCall,
+    ResponseMessage,
+    SystemMessage,
+    ToolCall,
+    Usage,
+    UserMessage,
+)
+from modelmeld.api.server import build_app
+
+
+class _StubAdapter(ProviderAdapter):
+    """Returns a fixed ChatCompletion and records the request it received."""
+
+    name = "stub-responses"
+    is_egress = False
+
+    def __init__(self, completion: ChatCompletion) -> None:
+        self._completion = completion
+        self.received: ChatCompletionRequest | None = None
+
+    async def chat(self, request: ChatCompletionRequest) -> ChatCompletion:
+        self.received = request
+        return self._completion
+
+    async def stream_chat(
+        self, request: ChatCompletionRequest,
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        if False:  # pragma: no cover
+            yield
+
+    async def health(self) -> bool:
+        return True
+
+
+def _text_completion(text: str, *, model: str = "qwen3-coder-next") -> ChatCompletion:
+    return ChatCompletion(
+        id="chatcmpl-x", model=model,
+        choices=[Choice(index=0, message=ResponseMessage(role="assistant", content=text), finish_reason="stop")],
+        usage=Usage(prompt_tokens=9, completion_tokens=3, total_tokens=12),
+    )
+
+
+async def _post(app, body: dict) -> httpx.Response:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        return await client.post("/v1/responses", json=body)
+
+
+async def test_text_request_round_trips_to_responses_shape() -> None:
+    adapter = _StubAdapter(_text_completion("the answer", model="qwen3-coder-next"))
+    app = build_app(adapter=adapter)
+
+    resp = await _post(app, {"model": "anthropic/modelmeld-auto", "input": "hello"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["object"] == "response"
+    assert body["status"] == "completed"
+    assert body["model"] == "qwen3-coder-next"   # the routed/served model
+    assert body["output"][0]["type"] == "message"
+    assert body["output"][0]["content"][0]["type"] == "output_text"
+    assert body["output"][0]["content"][0]["text"] == "the answer"
+    assert body["usage"]["input_tokens"] == 9
+    # Audit-header parity with the other surfaces.
+    assert resp.headers["x-modelmeld-routed-to"] == "stub-responses"
+    # The adapter saw the translated Chat-shape request.
+    assert isinstance(adapter.received.messages[0], UserMessage)
+    assert adapter.received.messages[0].content == "hello"
+
+
+async def test_instructions_become_a_system_message() -> None:
+    adapter = _StubAdapter(_text_completion("ok"))
+    app = build_app(adapter=adapter)
+
+    resp = await _post(app, {
+        "model": "m", "instructions": "Be terse.", "input": "hi",
+    })
+
+    assert resp.status_code == 200
+    msgs = adapter.received.messages
+    assert isinstance(msgs[0], SystemMessage)
+    assert msgs[0].content == "Be terse."
+    assert isinstance(msgs[1], UserMessage)
+
+
+async def test_tool_calls_surface_as_function_call_items() -> None:
+    completion = ChatCompletion(
+        id="chatcmpl-y", model="qwen3-coder-next",
+        choices=[Choice(
+            index=0,
+            message=ResponseMessage(
+                role="assistant", content=None,
+                tool_calls=[ToolCall(
+                    id="call_42", type="function",
+                    function=FunctionCall(name="search", arguments='{"q":"x"}'),
+                )],
+            ),
+            finish_reason="tool_calls",
+        )],
+        usage=Usage(prompt_tokens=5, completion_tokens=2, total_tokens=7),
+    )
+    app = build_app(adapter=_StubAdapter(completion))
+
+    resp = await _post(app, {"model": "m", "input": "find x"})
+
+    assert resp.status_code == 200
+    fcs = [o for o in resp.json()["output"] if o["type"] == "function_call"]
+    assert len(fcs) == 1
+    assert fcs[0]["name"] == "search"
+    assert fcs[0]["arguments"] == '{"q":"x"}'
+    assert fcs[0]["call_id"] == "call_42"
+
+
+async def test_streaming_not_yet_supported_returns_501() -> None:
+    app = build_app(adapter=_StubAdapter(_text_completion("x")))
+    resp = await _post(app, {"model": "m", "input": "hi", "stream": True})
+    assert resp.status_code == 501

--- a/tests/test_translation_openai_responses.py
+++ b/tests/test_translation_openai_responses.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""Responses API ↔ internal Chat translation (Phase 1, non-streaming)."""
+
+from __future__ import annotations
+
+from modelmeld.api.schemas import (
+    AssistantMessage,
+    ChatCompletion,
+    Choice,
+    FunctionCall,
+    ResponseMessage,
+    SystemMessage,
+    ToolCall,
+    Usage,
+    UserMessage,
+)
+from modelmeld.api.schemas_responses import ResponsesRequest
+from modelmeld.translation.openai_responses import (
+    from_responses_request,
+    to_responses_response,
+)
+
+# ---------------------------------------------------------------------------
+# Inbound: Responses request → ChatCompletionRequest
+# ---------------------------------------------------------------------------
+
+def test_string_input_becomes_single_user_message() -> None:
+    req = ResponsesRequest(model="anthropic/modelmeld-auto", input="hello there")
+    out = from_responses_request(req)
+    assert out.model == "anthropic/modelmeld-auto"
+    assert len(out.messages) == 1
+    assert isinstance(out.messages[0], UserMessage)
+    assert out.messages[0].content == "hello there"
+
+
+def test_instructions_become_system_message_and_roles_map() -> None:
+    req = ResponsesRequest(
+        model="m",
+        instructions="You are terse.",
+        input=[
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hey"},
+            {"role": "developer", "content": "be careful"},  # developer → system
+        ],
+    )
+    out = from_responses_request(req)
+    assert isinstance(out.messages[0], SystemMessage)
+    assert out.messages[0].content == "You are terse."
+    assert isinstance(out.messages[1], UserMessage)
+    assert isinstance(out.messages[2], AssistantMessage)
+    assert isinstance(out.messages[3], SystemMessage)  # developer mapped to system
+
+
+def test_content_parts_text_is_extracted() -> None:
+    req = ResponsesRequest(
+        model="m",
+        input=[{"role": "user", "content": [
+            {"type": "input_text", "text": "part one "},
+            {"type": "input_text", "text": "part two"},
+        ]}],
+    )
+    out = from_responses_request(req)
+    assert out.messages[0].content == "part one part two"
+
+
+def test_responses_function_tool_becomes_chat_tool_shape() -> None:
+    req = ResponsesRequest(
+        model="m",
+        input="x",
+        tools=[{
+            "type": "function",
+            "name": "get_weather",
+            "description": "Look up weather",
+            "parameters": {"type": "object", "properties": {}},
+        }],
+    )
+    out = from_responses_request(req)
+    assert out.tools is not None and len(out.tools) == 1
+    tool = out.tools[0]
+    # Chat shape nests under `function`.
+    assert tool.type == "function"
+    assert tool.function.name == "get_weather"
+
+
+def test_non_function_tools_are_dropped() -> None:
+    req = ResponsesRequest(
+        model="m", input="x",
+        tools=[{"type": "web_search"}],  # no Chat-Completions equivalent
+    )
+    out = from_responses_request(req)
+    assert out.tools is None
+
+
+# ---------------------------------------------------------------------------
+# Outbound: ChatCompletion → Responses result
+# ---------------------------------------------------------------------------
+
+def _completion(message: ResponseMessage, *, model: str = "qwen3-coder-next") -> ChatCompletion:
+    return ChatCompletion(
+        id="chatcmpl-abc", model=model,
+        choices=[Choice(index=0, message=message, finish_reason="stop")],
+        usage=Usage(prompt_tokens=11, completion_tokens=7, total_tokens=18),
+    )
+
+
+def test_text_completion_becomes_message_output_item() -> None:
+    resp = to_responses_response(
+        _completion(ResponseMessage(role="assistant", content="the answer")),
+        model="qwen3-coder-next",
+    )
+    assert resp.object == "response"
+    assert resp.status == "completed"
+    assert resp.model == "qwen3-coder-next"
+    assert len(resp.output) == 1
+    item = resp.output[0]
+    assert item.type == "message"
+    assert item.content[0].type == "output_text"
+    assert item.content[0].text == "the answer"
+    assert resp.usage.input_tokens == 11
+    assert resp.usage.output_tokens == 7
+    assert resp.usage.total_tokens == 18
+
+
+def test_tool_calls_become_function_call_items() -> None:
+    msg = ResponseMessage(
+        role="assistant", content=None,
+        tool_calls=[ToolCall(
+            id="call_1", type="function",
+            function=FunctionCall(name="get_weather", arguments='{"city":"SF"}'),
+        )],
+    )
+    resp = to_responses_response(_completion(msg), model="m")
+    fcs = [o for o in resp.output if o.type == "function_call"]
+    assert len(fcs) == 1
+    assert fcs[0].name == "get_weather"
+    assert fcs[0].arguments == '{"city":"SF"}'
+    assert fcs[0].call_id == "call_1"
+
+
+def test_empty_completion_emits_one_empty_message_item() -> None:
+    resp = to_responses_response(
+        _completion(ResponseMessage(role="assistant", content=None)),
+        model="m",
+    )
+    assert len(resp.output) == 1
+    assert resp.output[0].type == "message"
+    assert resp.output[0].content[0].text == ""


### PR DESCRIPTION
## Summary
  Adds the OpenAI Responses API as a third wire format at `POST /v1/responses`, so  Codex CLI can target the gateway on the standard `/v1` base URL. Covers
  non-streaming and streaming (text). Reuses the chat pipeline (routing, BYOK,  Codex subscription passthrough, PII scrub, capability routing, audit headers,
  memory, canonical-model pin) with Responses↔Chat translation on each edge.

  ## Type of change
  - [x] New feature (non-breaking change that adds capability)

  ## Test plan
  - Translation units: both directions, instructions→system, content parts,
    function-tool shape, tool_calls→function_call.
  - Streaming translator: full event sequence, monotonic sequence numbers, usage,
    idempotent finalize, and **every emitted event validated against the OpenAI
    SDK's own Pydantic event models**.
  - e2e: non-streaming text round-trip + audit headers, instructions→system, tool
    calls→function_call, and the streaming SSE lifecycle.
  - Full suite: 1111 passed, 11 skipped. ruff + pyright clean; boundary verify passes.

  ## Linked issues
  N/A (internal tracker)

  ## Checklist
  - [x] Tests added or updated and they actually exercise the change
  - [x] `pytest` passes (full suite)
  - [x] All commits have DCO signoff
  - [x] Read `docs/open-core-boundary.md` (no boundary impact)

  ## Additional context
  Text streaming only (Phase 2a); **tool-call streaming** (function_call items +
  `response.function_call_arguments.*`) is a 2b follow-up — non-streaming already
  handles tool calls. Event shapes are SDK-validated, but a **real Codex CLI
  session remains the manual acceptance gate** before claiming "Codex works."