### PR TITLE
feat(responses): stream tool calls as function_call items

### DIFF
--- a/src/modelmeld/api/routes/responses.py
+++ b/src/modelmeld/api/routes/responses.py
@@ -10,9 +10,9 @@ through `_completion_with_failover`; streaming emits Responses SSE events via
 `ResponsesStreamTranslator`. Audit headers, hooks, and memory write-back are
 shared with the chat route.
 
-Streaming covers text (Phase 2a). Tool-call streaming (function_call items +
-response.function_call_arguments.* events) is a 2b follow-up; non-streaming
-already handles tool calls.
+Streaming covers both assistant text and tool calls: the translator opens a
+`message` item for text and a `function_call` item per tool call, emitting
+`response.function_call_arguments.*` events as argument fragments arrive.
 """
 
 from __future__ import annotations

--- a/src/modelmeld/translation/responses_stream.py
+++ b/src/modelmeld/translation/responses_stream.py
@@ -3,38 +3,35 @@
 
 """Internal Chat chunk stream → OpenAI Responses API SSE events.
 
-The Responses streaming protocol is a lifecycle of typed events, each with a
-monotonic `sequence_number`:
+The Responses stream is a lifecycle of typed events with a monotonic
+`sequence_number`. Output is an ordered set of items — a `message` item for
+assistant text, and one `function_call` item per tool call — each opened lazily
+at its own `output_index` as it first appears in the chunk stream:
 
     response.created
-    response.output_item.added        (the assistant message item)
-    response.content_part.added       (an output_text part)
-    response.output_text.delta × N    (the text, chunk by chunk)
-    response.output_text.done
-    response.content_part.done
-    response.output_item.done
-    response.completed                (terminal; carries usage)
+    (text)  output_item.added(message) → content_part.added
+            → output_text.delta × N
+    (tool)  output_item.added(function_call)
+            → function_call_arguments.delta × N
+    (close, in output_index order)
+            text:  output_text.done → content_part.done → output_item.done
+            tool:  function_call_arguments.done → output_item.done
+    response.completed   (terminal; carries the full output + usage)
 
-Phase 2a handles text. Tool-call streaming (function_call items +
-response.function_call_arguments.delta/done) is a 2b follow-up; the
-non-streaming path already covers tool calls.
-
-Events are emitted as plain dicts shaped to the wire format. They are validated
-against the OpenAI SDK's own event models in the tests, so "matches the SDK" ==
-"matches what Codex parses."
+Events are emitted as dicts shaped to the wire format and validated against the
+OpenAI SDK's own event models in the tests, so "matches the SDK" == "matches
+what Codex parses."
 """
 
 from __future__ import annotations
 
 import json
 import time
-from collections.abc import Iterable
 from typing import Any
 from uuid import uuid4
 
 from modelmeld.api.schemas import ChatCompletionChunk
 
-_OUTPUT_INDEX = 0
 _CONTENT_INDEX = 0
 
 
@@ -49,12 +46,22 @@ class ResponsesStreamTranslator:
     def __init__(self, model: str, *, response_id: str | None = None) -> None:
         self.model = model
         self.response_id = response_id or f"resp_{uuid4().hex[:24]}"
-        self.item_id = f"msg_{uuid4().hex[:24]}"
         self._created_at = int(time.time())
         self._seq = 0
-        self._started = False
+        self._created_emitted = False
         self._finished = False
+        self._next_output_index = 0
+
+        # Text (message) item — opened lazily on the first text delta.
+        self._text_open = False
+        self._text_index = 0
+        self._text_item_id = ""
         self._text_parts: list[str] = []
+
+        # Tool (function_call) items, keyed by the OpenAI tool_call index.
+        # value: {output_index, item_id, call_id, name, args: list[str]}
+        self._tools: dict[int, dict[str, Any]] = {}
+
         self._input_tokens = 0
         self._output_tokens = 0
 
@@ -62,21 +69,33 @@ class ResponsesStreamTranslator:
 
     def translate_chunk(self, chunk: ChatCompletionChunk) -> list[dict[str, Any]]:
         events: list[dict[str, Any]] = []
-        if not self._started:
-            events.extend(self._start_events())
+        if not self._created_emitted:
+            self._created_emitted = True
+            events.append({
+                "type": "response.created",
+                "sequence_number": self._next_seq(),
+                "response": self._response_obj("in_progress", []),
+            })
+
         if chunk.choices:
             delta = chunk.choices[0].delta
             if delta.content:
+                if not self._text_open:
+                    events.extend(self._open_text())
                 self._text_parts.append(delta.content)
                 events.append({
                     "type": "response.output_text.delta",
                     "sequence_number": self._next_seq(),
-                    "item_id": self.item_id,
-                    "output_index": _OUTPUT_INDEX,
+                    "item_id": self._text_item_id,
+                    "output_index": self._text_index,
                     "content_index": _CONTENT_INDEX,
                     "delta": delta.content,
                     "logprobs": [],
                 })
+            if delta.tool_calls:
+                for tcd in delta.tool_calls:
+                    events.extend(self._handle_tool_delta(tcd))
+
         if chunk.usage is not None:
             self._output_tokens = chunk.usage.completion_tokens
             self._input_tokens = chunk.usage.prompt_tokens
@@ -88,33 +107,66 @@ class ResponsesStreamTranslator:
             return []
         self._finished = True
         events: list[dict[str, Any]] = []
-        if not self._started:
-            events.extend(self._start_events())
+        if not self._created_emitted:
+            self._created_emitted = True
+            events.append({
+                "type": "response.created",
+                "sequence_number": self._next_seq(),
+                "response": self._response_obj("in_progress", []),
+            })
 
-        full_text = "".join(self._text_parts)
-        part = {"type": "output_text", "text": full_text, "annotations": []}
-        events.append({
-            "type": "response.output_text.done",
-            "sequence_number": self._next_seq(),
-            "item_id": self.item_id, "output_index": _OUTPUT_INDEX,
-            "content_index": _CONTENT_INDEX, "text": full_text, "logprobs": [],
-        })
-        events.append({
-            "type": "response.content_part.done",
-            "sequence_number": self._next_seq(),
-            "item_id": self.item_id, "output_index": _OUTPUT_INDEX,
-            "content_index": _CONTENT_INDEX, "part": part,
-        })
-        done_item = self._message_item("completed", [part])
-        events.append({
-            "type": "response.output_item.done",
-            "sequence_number": self._next_seq(),
-            "output_index": _OUTPUT_INDEX, "item": done_item,
-        })
+        # Responses guarantees ≥1 output item; if the model produced neither
+        # text nor tool calls, emit an empty message.
+        if not self._text_open and not self._tools:
+            events.extend(self._open_text())
+
+        # Indexed list of completed items for the terminal response object.
+        completed_items: list[tuple[int, dict[str, Any]]] = []
+
+        if self._text_open:
+            full_text = "".join(self._text_parts)
+            part = {"type": "output_text", "text": full_text, "annotations": []}
+            events.append({
+                "type": "response.output_text.done",
+                "sequence_number": self._next_seq(),
+                "item_id": self._text_item_id, "output_index": self._text_index,
+                "content_index": _CONTENT_INDEX, "text": full_text, "logprobs": [],
+            })
+            events.append({
+                "type": "response.content_part.done",
+                "sequence_number": self._next_seq(),
+                "item_id": self._text_item_id, "output_index": self._text_index,
+                "content_index": _CONTENT_INDEX, "part": part,
+            })
+            done_item = self._message_item("completed", self._text_item_id, [part])
+            events.append({
+                "type": "response.output_item.done",
+                "sequence_number": self._next_seq(),
+                "output_index": self._text_index, "item": done_item,
+            })
+            completed_items.append((self._text_index, done_item))
+
+        for tool in sorted(self._tools.values(), key=lambda t: t["index"]):
+            full_args = "".join(tool["args"])
+            events.append({
+                "type": "response.function_call_arguments.done",
+                "sequence_number": self._next_seq(),
+                "item_id": tool["item_id"], "output_index": tool["index"],
+                "name": tool["name"], "arguments": full_args,
+            })
+            fc_item = self._function_call_item(tool, full_args)
+            events.append({
+                "type": "response.output_item.done",
+                "sequence_number": self._next_seq(),
+                "output_index": tool["index"], "item": fc_item,
+            })
+            completed_items.append((tool["index"], fc_item))
+
+        output = [item for _, item in sorted(completed_items, key=lambda x: x[0])]
         events.append({
             "type": "response.completed",
             "sequence_number": self._next_seq(),
-            "response": self._response_obj("completed", [done_item], self._usage()),
+            "response": self._response_obj("completed", output, self._usage()),
         })
         return events
 
@@ -125,31 +177,73 @@ class ResponsesStreamTranslator:
         self._seq += 1
         return n
 
-    def _start_events(self) -> Iterable[dict[str, Any]]:
-        self._started = True
-        yield {
-            "type": "response.created",
-            "sequence_number": self._next_seq(),
-            "response": self._response_obj("in_progress", []),
-        }
-        yield {
-            "type": "response.output_item.added",
-            "sequence_number": self._next_seq(),
-            "output_index": _OUTPUT_INDEX,
-            "item": self._message_item("in_progress", []),
-        }
-        yield {
-            "type": "response.content_part.added",
-            "sequence_number": self._next_seq(),
-            "item_id": self.item_id, "output_index": _OUTPUT_INDEX,
-            "content_index": _CONTENT_INDEX,
-            "part": {"type": "output_text", "text": "", "annotations": []},
+    def _open_text(self) -> list[dict[str, Any]]:
+        self._text_open = True
+        self._text_index = self._next_output_index
+        self._next_output_index += 1
+        self._text_item_id = f"msg_{uuid4().hex[:24]}"
+        return [
+            {
+                "type": "response.output_item.added",
+                "sequence_number": self._next_seq(),
+                "output_index": self._text_index,
+                "item": self._message_item("in_progress", self._text_item_id, []),
+            },
+            {
+                "type": "response.content_part.added",
+                "sequence_number": self._next_seq(),
+                "item_id": self._text_item_id, "output_index": self._text_index,
+                "content_index": _CONTENT_INDEX,
+                "part": {"type": "output_text", "text": "", "annotations": []},
+            },
+        ]
+
+    def _handle_tool_delta(self, tcd: Any) -> list[dict[str, Any]]:
+        events: list[dict[str, Any]] = []
+        idx = tcd.index
+        fn = getattr(tcd, "function", None)
+        if idx not in self._tools:
+            output_index = self._next_output_index
+            self._next_output_index += 1
+            item_id = f"fc_{uuid4().hex[:24]}"
+            tool = {
+                "output_index": output_index, "index": output_index,
+                "item_id": item_id,
+                "call_id": tcd.id or f"call_{uuid4().hex[:24]}",
+                "name": (fn.name if fn and fn.name else ""),
+                "args": [],
+            }
+            self._tools[idx] = tool
+            events.append({
+                "type": "response.output_item.added",
+                "sequence_number": self._next_seq(),
+                "output_index": output_index,
+                "item": self._function_call_item(tool, ""),
+            })
+        tool = self._tools[idx]
+        if fn and fn.name and not tool["name"]:
+            tool["name"] = fn.name
+        if fn and fn.arguments:
+            tool["args"].append(fn.arguments)
+            events.append({
+                "type": "response.function_call_arguments.delta",
+                "sequence_number": self._next_seq(),
+                "item_id": tool["item_id"], "output_index": tool["index"],
+                "delta": fn.arguments,
+            })
+        return events
+
+    def _message_item(self, status: str, item_id: str, content: list[dict[str, Any]]) -> dict[str, Any]:
+        return {
+            "type": "message", "id": item_id, "status": status,
+            "role": "assistant", "content": content,
         }
 
-    def _message_item(self, status: str, content: list[dict[str, Any]]) -> dict[str, Any]:
+    def _function_call_item(self, tool: dict[str, Any], arguments: str) -> dict[str, Any]:
         return {
-            "type": "message", "id": self.item_id, "status": status,
-            "role": "assistant", "content": content,
+            "type": "function_call", "id": tool["item_id"],
+            "call_id": tool["call_id"], "name": tool["name"],
+            "arguments": arguments, "status": "completed",
         }
 
     def _usage(self) -> dict[str, Any]:
@@ -164,14 +258,12 @@ class ResponsesStreamTranslator:
     def _response_obj(
         self, status: str, output: list[dict[str, Any]], usage: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        obj: dict[str, Any] = {
+        return {
             "id": self.response_id, "object": "response",
             "created_at": self._created_at, "model": self.model,
             "status": status, "output": output,
             "error": None, "incomplete_details": None, "instructions": None,
             "metadata": {}, "parallel_tool_calls": True,
             "temperature": None, "top_p": None,
-            "tool_choice": "auto", "tools": [],
+            "tool_choice": "auto", "tools": [], "usage": usage,
         }
-        obj["usage"] = usage
-        return obj

--- a/tests/test_responses_stream.py
+++ b/tests/test_responses_stream.py
@@ -15,13 +15,22 @@ from openai.types.responses import (
     ResponseContentPartAddedEvent,
     ResponseContentPartDoneEvent,
     ResponseCreatedEvent,
+    ResponseFunctionCallArgumentsDeltaEvent,
+    ResponseFunctionCallArgumentsDoneEvent,
     ResponseOutputItemAddedEvent,
     ResponseOutputItemDoneEvent,
     ResponseTextDeltaEvent,
     ResponseTextDoneEvent,
 )
 
-from modelmeld.api.schemas import ChatCompletionChunk, ChoiceDelta, ChunkChoice, Usage
+from modelmeld.api.schemas import (
+    ChatCompletionChunk,
+    ChoiceDelta,
+    ChunkChoice,
+    FunctionCallDelta,
+    ToolCallDelta,
+    Usage,
+)
 from modelmeld.translation.responses_stream import (
     ResponsesStreamTranslator,
     format_responses_sse,
@@ -35,8 +44,29 @@ _SDK_EVENT = {
     "response.output_text.done": ResponseTextDoneEvent,
     "response.content_part.done": ResponseContentPartDoneEvent,
     "response.output_item.done": ResponseOutputItemDoneEvent,
+    "response.function_call_arguments.delta": ResponseFunctionCallArgumentsDeltaEvent,
+    "response.function_call_arguments.done": ResponseFunctionCallArgumentsDoneEvent,
     "response.completed": ResponseCompletedEvent,
 }
+
+
+def _tool_open(idx: int, call_id: str, name: str) -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id="c", created=0, model="qwen",
+        choices=[ChunkChoice(index=0, delta=ChoiceDelta(tool_calls=[
+            ToolCallDelta(index=idx, id=call_id, type="function",
+                          function=FunctionCallDelta(name=name, arguments="")),
+        ]))],
+    )
+
+
+def _tool_args(idx: int, frag: str) -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id="c", created=0, model="qwen",
+        choices=[ChunkChoice(index=0, delta=ChoiceDelta(tool_calls=[
+            ToolCallDelta(index=idx, function=FunctionCallDelta(arguments=frag)),
+        ]))],
+    )
 
 
 def _chunk(content: str | None = None, *, usage: Usage | None = None) -> ChatCompletionChunk:
@@ -107,3 +137,67 @@ def test_sse_frame_format() -> None:
     frame = format_responses_sse({"type": "response.completed", "sequence_number": 0})
     assert frame.startswith("event: response.completed\ndata: ")
     assert frame.endswith("\n\n")
+
+
+# ---------------------------------------------------------------------------
+# Tool-call streaming (2b)
+# ---------------------------------------------------------------------------
+
+def _validate_all(events: list[dict]) -> None:
+    for event in events:
+        _SDK_EVENT[event["type"]].model_validate(event)
+
+
+def test_tool_call_streaming_lifecycle_and_sdk_shapes() -> None:
+    t = ResponsesStreamTranslator(model="qwen3-coder-next")
+    events: list[dict] = []
+    events += t.translate_chunk(_tool_open(0, "call_1", "get_weather"))
+    events += t.translate_chunk(_tool_args(0, '{"city":'))
+    events += t.translate_chunk(_tool_args(0, '"SF"}'))
+    events += t.finalize()
+
+    types = [e["type"] for e in events]
+    assert types[0] == "response.created"
+    assert "response.output_item.added" in types          # function_call item opened
+    assert types.count("response.function_call_arguments.delta") == 2
+    assert "response.function_call_arguments.done" in types
+    assert types[-1] == "response.completed"
+    _validate_all(events)
+
+    fc = next(o for o in events[-1]["response"]["output"] if o["type"] == "function_call")
+    assert fc["name"] == "get_weather"
+    assert fc["arguments"] == '{"city":"SF"}'
+    assert fc["call_id"] == "call_1"
+
+
+def test_mixed_text_then_tool_call_indices() -> None:
+    t = ResponsesStreamTranslator(model="m")
+    events: list[dict] = []
+    events += t.translate_chunk(_chunk("Let me check. "))
+    events += t.translate_chunk(_tool_open(0, "call_9", "search"))
+    events += t.translate_chunk(_tool_args(0, '{"q":"x"}'))
+    events += t.finalize()
+
+    _validate_all(events)
+    output = events[-1]["response"]["output"]
+    # Message item at index 0, function_call at index 1 (order of appearance).
+    assert output[0]["type"] == "message"
+    assert output[0]["content"][0]["text"] == "Let me check. "
+    assert output[1]["type"] == "function_call"
+    assert output[1]["name"] == "search"
+    assert output[1]["arguments"] == '{"q":"x"}'
+
+
+def test_two_parallel_tool_calls_get_distinct_items() -> None:
+    t = ResponsesStreamTranslator(model="m")
+    events: list[dict] = []
+    events += t.translate_chunk(_tool_open(0, "call_a", "alpha"))
+    events += t.translate_chunk(_tool_open(1, "call_b", "beta"))
+    events += t.translate_chunk(_tool_args(0, "{}"))
+    events += t.translate_chunk(_tool_args(1, "{}"))
+    events += t.finalize()
+
+    _validate_all(events)
+    fcs = [o for o in events[-1]["response"]["output"] if o["type"] == "function_call"]
+    assert [f["name"] for f in fcs] == ["alpha", "beta"]
+    assert len({f["call_id"] for f in fcs}) == 2

--- a/tests/test_route_responses.py
+++ b/tests/test_route_responses.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (c) 2026 ModelMeld.
 
-"""End-to-end /v1/responses (Phase 1, non-streaming)."""
+"""End-to-end /v1/responses (non-streaming, streaming text, streaming tools)."""
 
 from __future__ import annotations
 
@@ -19,9 +19,11 @@ from modelmeld.api.schemas import (
     ChoiceDelta,
     ChunkChoice,
     FunctionCall,
+    FunctionCallDelta,
     ResponseMessage,
     SystemMessage,
     ToolCall,
+    ToolCallDelta,
     Usage,
     UserMessage,
 )
@@ -172,3 +174,59 @@ async def test_streaming_emits_responses_sse_lifecycle() -> None:
     text = "".join(e["delta"] for e in events if e["type"] == "response.output_text.delta")
     assert text == "Hello world"
     assert events[-1]["response"]["status"] == "completed"
+
+
+class _ToolStreamAdapter(ProviderAdapter):
+    """Streams a single tool call: open + argument fragments + finish."""
+
+    name = "stub-tool-stream"
+    is_egress = False
+
+    async def chat(self, request: ChatCompletionRequest) -> ChatCompletion:
+        raise NotImplementedError("streaming-only fixture")
+
+    async def stream_chat(
+        self, request: ChatCompletionRequest,
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        yield ChatCompletionChunk(
+            id="c", created=0, model=request.model,
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(tool_calls=[
+                ToolCallDelta(index=0, id="call_1", type="function",
+                              function=FunctionCallDelta(name="get_weather", arguments="")),
+            ]))],
+        )
+        yield ChatCompletionChunk(
+            id="c", created=0, model=request.model,
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(tool_calls=[
+                ToolCallDelta(index=0, function=FunctionCallDelta(arguments='{"city":"SF"}')),
+            ]))],
+        )
+        yield ChatCompletionChunk(
+            id="c", created=0, model=request.model,
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(), finish_reason="tool_calls")],
+        )
+
+    async def health(self) -> bool:
+        return True
+
+
+async def test_streaming_tool_call_emits_function_call_events() -> None:
+    app = build_app(adapter=_ToolStreamAdapter())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/v1/responses",
+            json={"model": "anthropic/modelmeld-auto", "input": "weather in SF?", "stream": True},
+        )
+
+    assert resp.status_code == 200
+    events = _parse_responses_sse(resp.text)
+    types = [e["type"] for e in events]
+    assert "response.function_call_arguments.delta" in types
+    assert "response.function_call_arguments.done" in types
+    completed = next(e for e in events if e["type"] == "response.completed")
+    fc = next(o for o in completed["response"]["output"] if o["type"] == "function_call")
+    assert fc["name"] == "get_weather"
+    assert fc["arguments"] == '{"city":"SF"}'
+    assert fc["call_id"] == "call_1"


### PR DESCRIPTION
Completes streaming support for `/v1/responses`: tool calls now stream
  as `function_call` output items, alongside assistant text.

  The SSE translator opens a `function_call` item per tool call (lazily, at
  its own `output_index`) and emits `response.function_call_arguments.delta`
  as argument fragments arrive, then `.done` + `output_item.done` at close.
  Text and tool-call items coexist in one stream; parallel tool calls each
  get a distinct item. Non-streaming tool calls were already handled.

  Emitted event dicts are validated against the OpenAI SDK's own Responses
  event models in tests, so the wire shapes match what a Responses client parses.

  ## Tests
  - Tool-call streaming lifecycle + SDK-shape validation
  - Mixed text-then-tool-call ordering
  - Two parallel tool calls get distinct items
  - End-to-end `/v1/responses` streaming tool-call route test
  - Full suite: 1115 passed, 11 skipped