### PR TITLE
fix(responses): accept multi-turn input with tool calls and results

### DIFF
--- a/src/modelmeld/api/schemas_responses.py
+++ b/src/modelmeld/api/schemas_responses.py
@@ -35,11 +35,26 @@ class ResponsesContentPart(BaseModel):
 
 
 class ResponsesInputItem(BaseModel):
-    """One role/content entry in the `input` array."""
+    """One entry in the `input` array.
+
+    The array is heterogeneous: a multi-turn client (e.g. Codex) replays the
+    whole conversation, so beyond role/content `message` items it also sends
+    `function_call` (a prior tool call), `function_call_output` (a tool result),
+    and `reasoning` items — none of which carry a `role`. Every field is
+    therefore optional and the item is keyed by `type`; the translator decides
+    what each item becomes (or skips it)."""
 
     model_config = ConfigDict(extra="allow")
-    role: str  # user | assistant | system | developer
-    content: str | list[ResponsesContentPart]
+    type: str | None = None
+    # message items
+    role: str | None = None  # user | assistant | system | developer
+    content: str | list[ResponsesContentPart] | None = None
+    # function_call items (assistant's prior tool invocation)
+    call_id: str | None = None
+    name: str | None = None
+    arguments: str | None = None
+    # function_call_output items (tool result fed back in)
+    output: Any | None = None
 
 
 class ResponsesRequest(BaseModel):

--- a/src/modelmeld/translation/openai_responses.py
+++ b/src/modelmeld/translation/openai_responses.py
@@ -25,15 +25,19 @@ from modelmeld.api.schemas import (
     AssistantMessage,
     ChatCompletion,
     ChatCompletionRequest,
+    FunctionCall,
     FunctionDef,
     Message,
     SystemMessage,
     Tool,
+    ToolCall,
+    ToolMessage,
     UserMessage,
 )
 from modelmeld.api.schemas_responses import (
     ResponsesContentPart,
     ResponsesFunctionCallItem,
+    ResponsesInputItem,
     ResponsesMessageItem,
     ResponsesOutputText,
     ResponsesRequest,
@@ -45,10 +49,28 @@ from modelmeld.api.schemas_responses import (
 # Inbound: Responses request → ChatCompletionRequest
 # ---------------------------------------------------------------------------
 
-def _item_text(content: str | list[ResponsesContentPart]) -> str:
+def _item_text(content: str | list[ResponsesContentPart] | None) -> str:
+    if content is None:
+        return ""
     if isinstance(content, str):
         return content
     return "".join(part.text for part in content if part.text)
+
+
+def _output_text(output: Any) -> str:
+    """A `function_call_output` carries its result in `output`, which may be a
+    plain string, a list of typed parts, or an object — normalize to text."""
+    if output is None:
+        return ""
+    if isinstance(output, str):
+        return output
+    if isinstance(output, list):
+        return "".join(
+            (p.get("text") or "") for p in output if isinstance(p, dict)
+        )
+    if isinstance(output, dict):
+        return output.get("text") or output.get("output") or ""
+    return str(output)
 
 
 def _to_message(role: str, text: str) -> Message:
@@ -58,6 +80,39 @@ def _to_message(role: str, text: str) -> Message:
     if role == "assistant":
         return AssistantMessage(role="assistant", content=text)
     return UserMessage(role="user", content=text)
+
+
+def _input_item_to_message(item: ResponsesInputItem) -> Message | None:
+    """Map one heterogeneous `input` item to a chat message, or None to skip.
+
+    Multi-turn Responses clients replay the full transcript, so the array mixes
+    role/content `message` items with `function_call` (assistant tool call),
+    `function_call_output` (tool result), and `reasoning` items."""
+    if item.type == "function_call":
+        # Assistant's prior tool invocation → assistant msg carrying the call.
+        return AssistantMessage(
+            role="assistant",
+            content=None,
+            tool_calls=[ToolCall(
+                id=item.call_id or "",
+                type="function",
+                function=FunctionCall(
+                    name=item.name or "", arguments=item.arguments or "",
+                ),
+            )],
+        )
+    if item.type == "function_call_output":
+        # Tool result fed back in → tool-role message keyed by call_id.
+        return ToolMessage(
+            role="tool",
+            tool_call_id=item.call_id or "",
+            content=_output_text(item.output),
+        )
+    # `reasoning` (and any other non-message type without a role) has no chat
+    # equivalent — drop it rather than 422.
+    if item.role is None:
+        return None
+    return _to_message(item.role, _item_text(item.content))
 
 
 def _to_chat_tools(tools: list[dict[str, Any]] | None) -> list[Tool] | None:
@@ -95,7 +150,9 @@ def from_responses_request(req: ResponsesRequest) -> ChatCompletionRequest:
         messages.append(UserMessage(role="user", content=req.input))
     else:
         for item in req.input:
-            messages.append(_to_message(item.role, _item_text(item.content)))
+            msg = _input_item_to_message(item)
+            if msg is not None:
+                messages.append(msg)
     return ChatCompletionRequest(
         model=req.model,
         messages=messages,

--- a/tests/test_route_responses.py
+++ b/tests/test_route_responses.py
@@ -142,6 +142,35 @@ async def test_tool_calls_surface_as_function_call_items() -> None:
     assert fcs[0]["call_id"] == "call_42"
 
 
+async def test_multi_turn_replay_input_does_not_422() -> None:
+    # Regression: the heterogeneous `input` array Codex replays after a tool
+    # round-trip (developer message + function_call + function_call_output +
+    # reasoning) used to fail request validation with a 422.
+    adapter = _StubAdapter(_text_completion("done"))
+    app = build_app(adapter=adapter)
+
+    resp = await _post(app, {
+        "model": "anthropic/modelmeld-auto",
+        "input": [
+            {"type": "message", "role": "developer",
+             "content": [{"type": "input_text", "text": "<permissions...>"}]},
+            {"type": "message", "role": "user",
+             "content": [{"type": "input_text", "text": "list files"}]},
+            {"type": "function_call", "call_id": "c1", "name": "ls", "arguments": "{}"},
+            {"type": "function_call_output", "call_id": "c1", "output": "a.py"},
+            {"type": "reasoning", "summary": []},
+            {"type": "message", "role": "user",
+             "content": [{"type": "input_text", "text": "read a.py"}]},
+        ],
+    })
+
+    assert resp.status_code == 200
+    # The tool result reached the adapter as a tool-role message.
+    roles = [type(m).__name__ for m in adapter.received.messages]
+    assert "ToolMessage" in roles
+    assert "AssistantMessage" in roles
+
+
 def _parse_responses_sse(raw: str) -> list[dict]:
     out: list[dict] = []
     for block in raw.split("\n\n"):

--- a/tests/test_translation_openai_responses.py
+++ b/tests/test_translation_openai_responses.py
@@ -13,6 +13,7 @@ from modelmeld.api.schemas import (
     ResponseMessage,
     SystemMessage,
     ToolCall,
+    ToolMessage,
     Usage,
     UserMessage,
 )
@@ -91,6 +92,106 @@ def test_non_function_tools_are_dropped() -> None:
     )
     out = from_responses_request(req)
     assert out.tools is None
+
+
+# -- Multi-turn replay: the heterogeneous `input` array a real agentic client
+#    (Codex) sends back after a tool round-trip. Regression for the 422 where
+#    function_call / function_call_output / reasoning items were rejected.
+
+def test_function_call_item_becomes_assistant_tool_call() -> None:
+    req = ResponsesRequest(
+        model="m",
+        input=[
+            {"type": "message", "role": "user",
+             "content": [{"type": "input_text", "text": "weather in SF?"}]},
+            {"type": "function_call", "call_id": "call_9",
+             "name": "get_weather", "arguments": '{"city":"SF"}'},
+        ],
+    )
+    out = from_responses_request(req)
+    assert isinstance(out.messages[0], UserMessage)
+    assert isinstance(out.messages[1], AssistantMessage)
+    tcs = out.messages[1].tool_calls
+    assert tcs is not None and len(tcs) == 1
+    assert tcs[0].id == "call_9"
+    assert tcs[0].function.name == "get_weather"
+    assert tcs[0].function.arguments == '{"city":"SF"}'
+
+
+def test_function_call_output_becomes_tool_message() -> None:
+    req = ResponsesRequest(
+        model="m",
+        input=[
+            {"type": "function_call", "call_id": "call_9",
+             "name": "get_weather", "arguments": "{}"},
+            {"type": "function_call_output", "call_id": "call_9",
+             "output": "72F and sunny"},
+        ],
+    )
+    out = from_responses_request(req)
+    assert isinstance(out.messages[1], ToolMessage)
+    assert out.messages[1].tool_call_id == "call_9"
+    assert out.messages[1].content == "72F and sunny"
+
+
+def test_function_call_output_list_form_is_flattened() -> None:
+    req = ResponsesRequest(
+        model="m",
+        input=[
+            {"type": "function_call_output", "call_id": "c1",
+             "output": [{"type": "output_text", "text": "ab"},
+                        {"type": "output_text", "text": "cd"}]},
+        ],
+    )
+    out = from_responses_request(req)
+    assert isinstance(out.messages[0], ToolMessage)
+    assert out.messages[0].content == "abcd"
+
+
+def test_reasoning_item_is_skipped_not_rejected() -> None:
+    req = ResponsesRequest(
+        model="m",
+        input=[
+            {"type": "reasoning", "summary": [], "id": "rs_1"},
+            {"type": "message", "role": "user",
+             "content": [{"type": "input_text", "text": "continue"}]},
+        ],
+    )
+    out = from_responses_request(req)
+    # Reasoning dropped; only the user message survives.
+    assert len(out.messages) == 1
+    assert isinstance(out.messages[0], UserMessage)
+    assert out.messages[0].content == "continue"
+
+
+def test_full_codex_replay_round_trips() -> None:
+    # The exact shape that 422'd against the hosted gateway: a developer
+    # message with input_text parts, a prior tool call, its output, and the
+    # next user turn — all in one `input` array.
+    req = ResponsesRequest(
+        model="m",
+        input=[
+            {"type": "message", "role": "developer",
+             "content": [{"type": "input_text", "text": "<permissions...>"}]},
+            {"type": "message", "role": "user",
+             "content": [{"type": "input_text", "text": "list files"}]},
+            {"type": "function_call", "call_id": "c1",
+             "name": "ls", "arguments": "{}"},
+            {"type": "function_call_output", "call_id": "c1", "output": "a.py\nb.py"},
+            {"type": "reasoning", "summary": []},
+            {"type": "message", "role": "user",
+             "content": [{"type": "input_text", "text": "now read a.py"}]},
+        ],
+    )
+    out = from_responses_request(req)
+    roles = [type(m).__name__ for m in out.messages]
+    assert roles == [
+        "SystemMessage",     # developer
+        "UserMessage",
+        "AssistantMessage",  # function_call
+        "ToolMessage",       # function_call_output
+        "UserMessage",       # reasoning dropped between them
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
  A multi-turn Responses client (e.g. Codex) replays the entire conversation
  in the `input` array on every turn. That array is heterogeneous: beyond
  role/content `message` items it contains `function_call` (a prior tool call),
  `function_call_output` (a tool result), and `reasoning` items — none of which
  carry a `role`. The request schema required `role` and `content` on every
  item, so the **second turn of any agentic session failed validation with a
  422** before reaching the handler. The first turn (a plain-string `input`)
  worked, which is why single-shot tests never caught it.

  ## Fix
  - Make every `input`-item field optional; key items by `type`.
  - Translate `function_call` → assistant message carrying the tool call,
    `function_call_output` → tool-role message keyed by `call_id`, and drop
    `reasoning` (no chat-completions equivalent).
  - Tool results now flow back to the model, so multi-step tool loops complete
    instead of stalling.

  ## Tests
  - Translation: function_call, function_call_output (string + list forms),
    reasoning-skip, and a full replayed-transcript round-trip.
  - Route: end-to-end POST of the heterogeneous replay array returns 200, and
    the tool result reaches the adapter as a tool-role message.
  - Full suite: 1121 passed, 11 skipped.