### PR TITLE
fix(responses): estimate token usage when streaming upstream omits it

### DIFF
--- a/src/modelmeld/api/routes/responses.py
+++ b/src/modelmeld/api/routes/responses.py
@@ -185,6 +185,21 @@ async def responses(
 # Streaming (Responses SSE)
 # ---------------------------------------------------------------------------
 
+def _estimate_input_tokens(
+    request, served_model: str, token_counter: TokenCounter | None,
+) -> int:
+    """Best-effort prompt-token count for streamed responses whose upstream
+    omitted usage. Uses the configured counter; falls back to ≈4 chars/token."""
+    messages = getattr(request, "messages", None) or []
+    if token_counter is not None:
+        return token_counter.count_messages(messages, served_model)
+    chars = 0
+    for m in messages:
+        content = getattr(m, "content", None)
+        if isinstance(content, str):
+            chars += len(content)
+    return max(1, chars // 4) if chars else 0
+
 async def _stream_responses_with_failover(
     rt: Router,
     decision,
@@ -290,7 +305,10 @@ async def _sse_responses(
 
     if error is None:
         # Responses SSE has no [DONE] terminator; response.completed ends it.
-        for event in translator.finalize():
+        # Supply an input-token estimate for the case where the upstream stream
+        # never reported usage (translator ignores it if real usage arrived).
+        input_estimate = _estimate_input_tokens(request, served_model, token_counter)
+        for event in translator.finalize(input_tokens=input_estimate):
             yield format_responses_sse(event)
         await _fire_success_stream(
             hooks, request_id, started, request, decision, redactions, failover_from,

--- a/src/modelmeld/translation/responses_stream.py
+++ b/src/modelmeld/translation/responses_stream.py
@@ -62,8 +62,14 @@ class ResponsesStreamTranslator:
         # value: {output_index, item_id, call_id, name, args: list[str]}
         self._tools: dict[int, dict[str, Any]] = {}
 
+        # Usage. OSS providers usually omit usage from stream chunks, so we
+        # track whether any real usage arrived; if none did, finalize() falls
+        # back to a char-based estimate (output accumulated here across both
+        # text and tool-call argument deltas; input supplied by the caller).
         self._input_tokens = 0
         self._output_tokens = 0
+        self._saw_usage = False
+        self._output_chars = 0
 
     # -- public API --------------------------------------------------------
 
@@ -83,6 +89,7 @@ class ResponsesStreamTranslator:
                 if not self._text_open:
                     events.extend(self._open_text())
                 self._text_parts.append(delta.content)
+                self._output_chars += len(delta.content)
                 events.append({
                     "type": "response.output_text.delta",
                     "sequence_number": self._next_seq(),
@@ -97,15 +104,26 @@ class ResponsesStreamTranslator:
                     events.extend(self._handle_tool_delta(tcd))
 
         if chunk.usage is not None:
+            self._saw_usage = True
             self._output_tokens = chunk.usage.completion_tokens
             self._input_tokens = chunk.usage.prompt_tokens
         return events
 
-    def finalize(self) -> list[dict[str, Any]]:
-        """Closing events. Idempotent — second call returns []."""
+    def finalize(self, *, input_tokens: int = 0) -> list[dict[str, Any]]:
+        """Closing events. Idempotent — second call returns [].
+
+        `input_tokens` is a caller-supplied estimate used only when the upstream
+        stream never reported real usage; output tokens are then estimated from
+        the accumulated text + tool-argument characters (≈4 chars/token).
+        """
         if self._finished:
             return []
         self._finished = True
+        if not self._saw_usage:
+            self._input_tokens = input_tokens
+            self._output_tokens = (
+                max(1, self._output_chars // 4) if self._output_chars else 0
+            )
         events: list[dict[str, Any]] = []
         if not self._created_emitted:
             self._created_emitted = True
@@ -225,6 +243,7 @@ class ResponsesStreamTranslator:
             tool["name"] = fn.name
         if fn and fn.arguments:
             tool["args"].append(fn.arguments)
+            self._output_chars += len(fn.arguments)
             events.append({
                 "type": "response.function_call_arguments.delta",
                 "sequence_number": self._next_seq(),

--- a/tests/test_responses_stream.py
+++ b/tests/test_responses_stream.py
@@ -188,6 +188,44 @@ def test_mixed_text_then_tool_call_indices() -> None:
     assert output[1]["arguments"] == '{"q":"x"}'
 
 
+def test_usage_estimated_when_upstream_omits_usage() -> None:
+    # No chunk carries usage (typical of OSS providers in streaming mode) →
+    # finalize falls back to char-based output estimate + caller's input count.
+    t = ResponsesStreamTranslator(model="m")
+    events: list[dict] = []
+    events += t.translate_chunk(_chunk("12345678"))  # 8 chars
+    events += t.translate_chunk(_chunk("abcd"))       # 4 chars → 12 total → 3 tok
+    events += t.finalize(input_tokens=7)
+
+    _validate_all(events)
+    usage = events[-1]["response"]["usage"]
+    assert usage["input_tokens"] == 7
+    assert usage["output_tokens"] == 3
+    assert usage["total_tokens"] == 10
+
+
+def test_tool_argument_chars_count_toward_output_estimate() -> None:
+    t = ResponsesStreamTranslator(model="m")
+    events: list[dict] = []
+    events += t.translate_chunk(_tool_open(0, "c1", "f"))
+    events += t.translate_chunk(_tool_args(0, '{"x":"yyyyyyyy"}'))  # 16 chars → 4 tok
+    events += t.finalize(input_tokens=0)
+
+    usage = events[-1]["response"]["usage"]
+    assert usage["output_tokens"] == 4
+
+
+def test_real_upstream_usage_overrides_estimate() -> None:
+    t = ResponsesStreamTranslator(model="m")
+    t.translate_chunk(_chunk("hello"))
+    t.translate_chunk(_chunk(usage=Usage(prompt_tokens=50, completion_tokens=9, total_tokens=59)))
+    events = t.finalize(input_tokens=999)  # estimate ignored — real usage won
+
+    usage = events[-1]["response"]["usage"]
+    assert usage["input_tokens"] == 50
+    assert usage["output_tokens"] == 9
+
+
 def test_two_parallel_tool_calls_get_distinct_items() -> None:
     t = ResponsesStreamTranslator(model="m")
     events: list[dict] = []

--- a/tests/test_route_responses.py
+++ b/tests/test_route_responses.py
@@ -239,6 +239,49 @@ class _ToolStreamAdapter(ProviderAdapter):
         return True
 
 
+class _NoUsageStreamAdapter(ProviderAdapter):
+    """Streams text but never reports usage — mirrors most OSS providers."""
+
+    name = "stub-no-usage"
+    is_egress = False
+
+    async def chat(self, request: ChatCompletionRequest) -> ChatCompletion:
+        raise NotImplementedError("streaming-only fixture")
+
+    async def stream_chat(
+        self, request: ChatCompletionRequest,
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        yield ChatCompletionChunk(
+            id="c", created=0, model=request.model,
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(role="assistant", content="hello world"))],
+        )
+        yield ChatCompletionChunk(
+            id="c", created=0, model=request.model,
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(), finish_reason="stop")],
+        )  # no usage on the terminal chunk
+
+    async def health(self) -> bool:
+        return True
+
+
+async def test_streaming_usage_is_estimated_when_upstream_omits_it() -> None:
+    app = build_app(adapter=_NoUsageStreamAdapter())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/v1/responses",
+            json={"model": "anthropic/modelmeld-auto", "input": "say hi", "stream": True},
+        )
+
+    assert resp.status_code == 200
+    events = _parse_responses_sse(resp.text)
+    usage = events[-1]["response"]["usage"]
+    # "hello world" → non-zero output estimate even with no upstream usage.
+    assert usage["output_tokens"] > 0
+    assert usage["total_tokens"] >= usage["output_tokens"]
+
+
 async def test_streaming_tool_call_emits_function_call_events() -> None:
     app = build_app(adapter=_ToolStreamAdapter())
     async with httpx.AsyncClient(


### PR DESCRIPTION
## Problem
  Most OSS providers omit `usage` from streaming chunks, so streamed
  `/v1/responses` replies reported `0/0/0` tokens in the terminal
  `response.completed` event — clients saw zero usage for every streamed call.

  ## Fix
  The stream translator now tracks whether any real usage arrived. If none did,
  it falls back to a char-based estimate (~4 chars/token):
  - **output** tokens accumulated across both text *and* tool-call argument deltas
  - **input** tokens supplied by the route from the prompt via the configured
    `TokenCounter` (char-based fallback when no counter is set)

  Real upstream usage, when present, always wins — the estimate only fills the gap.

  These are approximations, not exact tokenizer counts; suitable for display and
  rough cost signals, not exact billing.

  ## Tests
  - Translator: estimate path, tool-arg chars counted toward output, real usage
    overrides estimate
  - Route: end-to-end streamed response with a no-usage adapter reports non-zero
    usage
  - Full suite: 1125 passed, 11 skipped