### PR TITLE
docs: correct Codex setup and refresh stale claims after 0.8-0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,19 +118,15 @@ Honest non-coverage list for the v1 OSS API surface:
 - **Anthropic image content blocks** (vision input) — deferred. Claude
   Code doesn't use vision; documented as a known gap rather than
   silently failing.
-- **Streaming `cache_control` stats** — non-streaming responses surface
-  `cache_creation_input_tokens` / `cache_read_input_tokens` correctly
-  (see the screenshot above). The streaming-translation pipeline
-  doesn't yet propagate the upstream `message_start` event's cache
-  counts; tracked.
 
 ## What's in the package
 
-- **Two API surfaces, one routing pipeline.** OpenAI-compatible at
-  `/v1/chat/completions` (drop-in for any OpenAI-wire-format client).
-  Anthropic-compatible at `/v1/messages` (drop-in for Claude Code,
-  `anthropic-sdk-python`, `@anthropic-ai/sdk`). Both surfaces stream
-  via SSE, share the same router / memory / cache pipeline, and emit
+- **Three API surfaces, one routing pipeline.** OpenAI-compatible at
+  `/v1/chat/completions` (drop-in for any OpenAI-wire-format client),
+  the OpenAI Responses API at `/v1/responses` (drop-in for Codex CLI),
+  and Anthropic-compatible at `/v1/messages` (drop-in for Claude Code,
+  `anthropic-sdk-python`, `@anthropic-ai/sdk`). All three stream via
+  SSE, share the same router / memory / cache pipeline, and emit
   identical `x-modelmeld-*` audit headers.
 - **Provider adapters** — OpenAI, Anthropic (with full schema
   translation in both directions), vLLM, TensorRT-LLM. Each adapter

--- a/README.md
+++ b/README.md
@@ -87,11 +87,12 @@ logged.
 
 ## Works with
 
-Drop-in for any tool that speaks OpenAI Chat Completions or Anthropic
-Messages.
+Drop-in for any tool that speaks OpenAI Chat Completions, OpenAI Responses,
+or Anthropic Messages.
 
 **Validated end-to-end:**
 [Claude Code](docs/integrations/claude-code.md) ·
+[Codex CLI](docs/integrations/codex-cli.md) ·
 [opencode](docs/integrations/opencode.md) ·
 [Aider](docs/integrations/aider.md) ·
 [AutoGen](docs/integrations/autogen.md) ·
@@ -103,8 +104,7 @@ OpenAI SDK · `anthropic-sdk-python` · `@anthropic-ai/sdk`
 **Should work, not yet live-tested:**
 [Cursor](docs/integrations/cursor.md) ·
 [Cline](docs/integrations/cline.md) ·
-[Continue](docs/integrations/continue.md) ·
-Codex CLI
+[Continue](docs/integrations/continue.md)
 
 Frameworks can declare task category + agent role explicitly via
 `x-modelmeld-task-category` / `x-modelmeld-agent-role` headers — bypasses
@@ -115,10 +115,6 @@ request represents. See [routing hints](docs/routing-hints.md).
 
 Honest non-coverage list for the v1 OSS API surface:
 
-- **OpenAI Responses API** (`/v1/responses`) — on the roadmap, not v1.
-  Current Codex CLI still uses `/v1/chat/completions` and works
-  through ModelMeld today; the newer Responses surface is the path
-  for clients adopting OpenAI's stateful agent loop.
 - **Anthropic image content blocks** (vision input) — deferred. Claude
   Code doesn't use vision; documented as a known gap rather than
   silently failing.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,10 +22,11 @@ the most concrete; longer-range items are directional.
 Themes likely to land within the next 2–3 minor versions. Subject to
 revision based on contributor feedback + dogfooding signal.
 
-- **Postgres-backed memory store.** OSS users currently get the
-  in-process `InMemoryMemoryStore`; a Postgres implementation lands
-  next, behind an optional install extra so the default install stays
-  light.
+- **Durable memory backends.** Gateway-native semantic memory shipped
+  via the optional Mem0 provider (`pip install 'modelmeld[mem0]'`,
+  `MODELMELD_MEMORY_BACKEND=mem0`); the default remains the in-process
+  tiered store. A Postgres-backed durable store for the default path is
+  still open.
 - **Google Gemini adapter.** Capability registry already lists Gemini
   models. Only the wire-format adapter is missing.
 - **Streaming-failover refinements.** Better handling when an upstream
@@ -36,9 +37,6 @@ revision based on contributor feedback + dogfooding signal.
   classifier has known coverage gaps (e.g. `"reason through"` vs
   `"reason about"`). A lighter-weight statistical classifier is the
   most likely successor.
-- **Richer integration guides.** Cursor / Claude Code / Aider / Cline
-  guides to join the existing AutoGen / CrewAI / LangGraph / OpenClaw
-  set.
 
 ## Future themes (directional)
 

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -17,7 +17,7 @@ Three distinct surfaces, with three different stability levels:
 
 | Surface | Audience | Stability |
 |---|---|---|
-| HTTP routes (`/v1/chat/completions`, `/v1/messages`, `/v1/models`, `/healthz`) | API consumers (Cursor, Claude Code, framework integrations, etc.) | SemVer-stable from 0.1.0; breaking changes are major-version bumps |
+| HTTP routes (`/v1/chat/completions`, `/v1/responses`, `/v1/messages`, `/v1/models`, `/healthz`) | API consumers (Cursor, Claude Code, Codex CLI, framework integrations, etc.) | SemVer-stable from 0.1.0; breaking changes are major-version bumps |
 | Top-level Python imports (`from modelmeld.X import Y`) for non-underscore names listed in this doc | Python integrators embedding the gateway in their own apps | SemVer-stable from 1.0.0; pre-1.0 may break with clear changelog entries |
 | Internal symbols (anything with `_` prefix, anything in `_internal.*`, plus per-module helpers not listed here) | Project maintainers only | No stability guarantees, change without notice |
 
@@ -40,6 +40,11 @@ require a major-version bump.
   breakpoints are forwarded verbatim to the upstream call via
   native-shape passthrough. Out of scope for v1: image content blocks.
   Same non-breaking / breaking rules as `/v1/chat/completions`.
+- `POST /v1/responses` — OpenAI Responses API shape (the Codex CLI
+  surface). Streaming via SSE as typed Responses events (`response.*`),
+  including `function_call` output items. Accepts multi-turn input
+  (`message` / `function_call` / `function_call_output` / `reasoning`
+  items). Same non-breaking / breaking rules as `/v1/chat/completions`.
 - `GET /v1/models` — returns the configured `available_models` list in
   OpenAI shape.
 - `GET /healthz` — liveness probe; returns 200 on a running gateway.

--- a/docs/design-anthropic-messages-api.md
+++ b/docs/design-anthropic-messages-api.md
@@ -14,7 +14,7 @@ The endpoint must support enough of Anthropic's Messages API surface that Claude
 
 ## Non-goals (v1)
 
-- Anthropic prompt caching (`cache_control` blocks) — accept the field, ignore it; document as known limitation
+- ~~Anthropic prompt caching (`cache_control` blocks)~~ — **now supported** (shipped post-v1): breakpoints are forwarded verbatim to the upstream call via native-shape passthrough, and cache stats (`cache_creation_input_tokens` / `cache_read_input_tokens`) surface on both the streaming and non-streaming paths.
 - Anthropic Beta features (computer-use, multi-document, code-execution) — not in scope
 - Anthropic's `count_tokens` endpoint — separate work item
 - Anthropic's `models` listing endpoint — already covered by existing `/v1/models` (OpenAI shape); cross-API model discovery is a separate concern
@@ -184,7 +184,7 @@ class OpenAIToAnthropicStreamTranslator:
 | `tool_choice` `{type:"any"}` | `"required"` | Map literal |
 | `tool_choice` `{type:"tool",name}` | `{type:"function",function:{name}}` | Specific tool |
 | `metadata` | (ignored, accepted) | Anthropic carries `user_id`; not used by our routing yet |
-| `cache_control` blocks | (ignored, accepted) | Document as known limitation |
+| `cache_control` blocks | Forwarded verbatim (native-shape passthrough) | Cache stats surfaced on both streaming + non-streaming paths (shipped post-v1) |
 
 ### Response: OpenAI → Anthropic
 

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -46,7 +46,7 @@ Drop-in setup for the coding agents customers actually run day to day:
 - [**Continue.dev**](continue.md) — VS Code/JetBrains with per-role models
 - [**opencode**](opencode.md) — SST's terminal coding agent with a native provider system
 - [**Zed**](zed.md) — editor agent panel via OpenAI-compatible provider
-- [**Codex CLI**](codex-cli.md) — OpenAI terminal agent via OpenAI-compatible provider
+- [**Codex CLI**](codex-cli.md) — OpenAI terminal agent via the Responses API (`/v1/responses`)
 
 ## Agent framework guides
 

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -193,9 +193,9 @@ If pre-writing the cache file is too fiddly, you can add a single
 ModelMeld auto-route alias to the picker via the supported manual API:
 
 ```bash
-export ANTHROPIC_CUSTOM_MODEL_OPTION=anthropic/modelmeld-coding
-export ANTHROPIC_CUSTOM_MODEL_OPTION_NAME="ModelMeld Coding"
-export ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION="Auto-routed across OSS coding-tuned models"
+export ANTHROPIC_CUSTOM_MODEL_OPTION=anthropic/modelmeld-saver
+export ANTHROPIC_CUSTOM_MODEL_OPTION_NAME="ModelMeld Saver"
+export ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION="Auto-routed across OSS models (max savings, predictable ceiling)"
 ```
 
 This adds one entry to `/model` without touching the cache file — a

--- a/docs/integrations/codex-cli.md
+++ b/docs/integrations/codex-cli.md
@@ -1,51 +1,85 @@
 # Codex CLI -> ModelMeld
 
 [Codex CLI](https://github.com/openai/codex) is OpenAI's open-source
-terminal coding agent. It speaks OpenAI's `/v1/chat/completions` natively,
-so pointing it at ModelMeld is a base-URL override and an API-key swap.
-ModelMeld then picks the cheapest capable backend per request and records
-the routing decision in response headers.
+terminal coding agent. Current Codex (v0.137+) talks the **OpenAI Responses
+API** (`/v1/responses`), so you point it at ModelMeld by adding a custom
+model provider in its config file. ModelMeld then picks the cheapest capable
+backend per request and records the routing decision in response headers.
 
-## Minimal setup
+> **Why a config block, not just `OPENAI_BASE_URL`?** Older OpenAI-compatible
+> clients use `/v1/chat/completions` and read a base URL from the
+> environment. Current Codex speaks the Responses API and discovers providers
+> through `~/.codex/config.toml`. The environment-variable shortcut does
+> **not** work for the Responses path — use the provider block below.
 
-Install Codex CLI, then set two environment variables before launching it:
+## Setup
+
+### 1. Add a ModelMeld provider to `~/.codex/config.toml`
+
+```toml
+model = "anthropic/modelmeld-saver"
+model_provider = "modelmeld"
+
+[model_providers.modelmeld]
+name = "ModelMeld"
+base_url = "https://api.modelmeld.ai/v1"
+env_key = "MODELMELD_API_KEY"
+wire_api = "responses"
+```
+
+- `wire_api = "responses"` is required — it tells Codex to use `/v1/responses`.
+- `env_key` names the environment variable Codex reads your key from (below).
+- The provider id (`modelmeld` here) is yours to choose, but `openai`,
+  `ollama`, and `lmstudio` are reserved — don't reuse them.
+- Keep `/v1` on the `base_url`; Codex appends the Responses path to it.
+
+### 2. Export your ModelMeld key
 
 ```sh
-export OPENAI_BASE_URL="https://api.modelmeld.ai/v1"
-export OPENAI_API_KEY="gws_<your-modelmeld-key>"
+export MODELMELD_API_KEY="gws_<your-modelmeld-key>"
 codex
 ```
 
 On Windows PowerShell:
 
 ```powershell
-$env:OPENAI_BASE_URL = "https://api.modelmeld.ai/v1"
-$env:OPENAI_API_KEY = "gws_<your-modelmeld-key>"
+$env:MODELMELD_API_KEY = "gws_<your-modelmeld-key>"
 codex
 ```
 
-Codex CLI reads these environment variables automatically — no config file
-edits needed. Send a small prompt to verify the connection works.
+Send a small prompt to verify the connection, then ask Codex to read a file
+so you exercise its tool calls — both stream through the gateway.
+
+## Choosing a routing policy
+
+Set `model` to one of ModelMeld's three policy aliases (in `config.toml`, via
+`/model` in the TUI, or `--config model=...` at launch):
+
+| Model | Policy |
+| ----- | ------ |
+| `anthropic/modelmeld-saver` | OSS-only auto-route. Never escalates to a frontier model — a predictable cost ceiling. Best default for an agentic session. |
+| `anthropic/modelmeld-auto` | Smart escalation: starts on OSS models, escalates to frontier only when the request shows reasoning markers. |
+| `anthropic/modelmeld-quality` | Frontier-first, with downgrade for trivial turns. |
+
+Use the canonical `anthropic/`-prefixed names — these are what `/v1/models`
+advertises, so Codex's `/model` picker can resolve them.
+
+> Frontier escalation (`-auto` / `-quality`) needs a frontier key. Supply one
+> per request with a `x-modelmeld-byok-<provider>` header to stretch your own
+> frontier budget through ModelMeld's routing; without one, stay on `-saver`.
 
 ## Optional routing check
 
-Codex CLI does not show HTTP response headers in the terminal. To confirm
-that the gateway is routing requests, run a direct request with the same
-key:
+Codex CLI doesn't surface HTTP response headers in the terminal. To confirm
+the gateway is routing, send a direct Responses request with the same key:
 
 ```sh
-curl -i https://api.modelmeld.ai/v1/chat/completions \
-  -H "authorization: Bearer $OPENAI_API_KEY" \
+curl -i https://api.modelmeld.ai/v1/responses \
+  -H "authorization: Bearer $MODELMELD_API_KEY" \
   -H "content-type: application/json" \
   -d '{
-    "model": "gpt-5.5",
-    "messages": [
-      {
-        "role": "user",
-        "content": "Reply with one sentence about ModelMeld routing."
-      }
-    ],
-    "max_tokens": 80
+    "model": "anthropic/modelmeld-saver",
+    "input": "Reply with one sentence about ModelMeld routing."
   }'
 ```
 
@@ -53,34 +87,34 @@ Look for these response headers:
 
 | Header | What to check |
 | ------ | ------------- |
-| `x-modelmeld-routed-model` | The actual model selected by the gateway. |
-| `x-modelmeld-tier` | The serving tier used for the request. |
-| `x-modelmeld-task-category` | The inferred task category, unless you supplied a hint through another client. |
+| `x-modelmeld-routed-model` | The canonical model the gateway selected for the request. |
+| `x-modelmeld-tier` | The serving tier used. |
+| `x-modelmeld-task-category` | The inferred task category (present when capability routing ran). |
 
-For the full list of response headers and their meanings, see the [Routing-hint headers reference](../routing-hints.md).
+For the full list of response headers and their meanings, see the
+[Routing-hint headers reference](../routing-hints.md).
 
 ## Common gotchas
 
-- **Use `OPENAI_BASE_URL`, not a config file**. Codex CLI reads the
-  OpenAI-compatible base URL from the environment variable. There is no
-  settings file for provider configuration.
-- **Keep `/v1` in the base URL**. Codex appends chat-completions paths to
-  that base URL. If you omit `/v1`, requests will 404.
-- **Codex uses `gpt-5.5` by default**. ModelMeld will route this to the
-  cheapest capable model. If you want a specific model, pass `--model`
-  or set `OPENAI_MODEL` in the environment.
-- **Codex's sandbox mode is independent of ModelMeld**. Codex has its own
-  sandbox for shell commands. ModelMeld only handles LLM routing — it does
-  not affect Codex's sandbox behavior.
-- **Rate limits come from ModelMeld, not OpenAI**. If you hit rate limits,
-  check your ModelMeld dashboard, not your OpenAI account.
+- **`wire_api = "responses"` is mandatory.** Without it Codex tries
+  `/v1/chat/completions` against a provider configured for Responses and the
+  session won't work as expected.
+- **Key var must match `env_key`.** Codex reads the key from the variable you
+  named (`MODELMELD_API_KEY`), not `OPENAI_API_KEY`.
+- **Keep `/v1` in `base_url`.** Omitting it 404s.
+- **"Model metadata not found" on startup is cosmetic.** Codex doesn't ship
+  context-window metadata for ModelMeld aliases; it falls back to defaults and
+  runs fine. Using the canonical `anthropic/modelmeld-*` names minimizes it.
+- **Codex's sandbox is independent of ModelMeld.** Codex sandboxes shell
+  commands itself; ModelMeld only handles LLM routing.
+- **Rate limits come from ModelMeld, not OpenAI.** Check your ModelMeld
+  dashboard if you hit one.
 
 ## Advanced: custom routing headers
 
-To send custom routing hints (e.g., force a specific tier or task category),
-you can use a local proxy that injects `x-modelmeld-*` headers and point
-`OPENAI_BASE_URL` at that proxy. See the [Routing-hint headers reference](../routing-hints.md)
-for accepted values.
+To force a tier or task category, run a local proxy that injects
+`x-modelmeld-*` headers and point `base_url` at it. See the
+[Routing-hint headers reference](../routing-hints.md) for accepted values.
 
 ## See also
 

--- a/docs/integrations/memory.md
+++ b/docs/integrations/memory.md
@@ -105,7 +105,9 @@ auth enabled in production.
 | `MODELMELD_MEM0_LLM_MODEL` | `gpt-5-mini` | Extraction model. |
 | `MODELMELD_MEM0_EMBEDDER_MODEL` | `text-embedding-3-small` | Embedding model. |
 | `MODELMELD_MEM0_VECTOR_STORE_URL` | — | qdrant server URL (shared, per-tenant collection). |
+| `MODELMELD_MEM0_VECTOR_STORE_API_KEY` | — | API key for a remote qdrant endpoint (optional). |
 | `MODELMELD_MEM0_VECTOR_STORE_PATH` | — | Embedded on-disk qdrant (per-tenant subdir). |
+| `MODELMELD_MEM0_EMBEDDING_DIMS` | `1536` | Embedding vector dimensions (match your embedder model). |
 
 ## Limitations
 

--- a/docs/subscription-passthrough.md
+++ b/docs/subscription-passthrough.md
@@ -77,11 +77,14 @@ llm -m gpt-5.4 "summarize this readme"
 - The bearer is never persisted to the gateway's disk; no log line
   contains the token bytes (only a length-preserving redaction).
 
-**What does NOT work yet (in v0.4.0):**
-- Native Codex CLI plug-and-play: Codex CLI hardcodes the
-  `/responses` endpoint (no `/v1` prefix). Until ModelMeld exposes
-  that surface (tracked separately), use the `llm-openai-via-codex`
-  pattern above.
+**Native Codex CLI:**
+- ModelMeld now exposes the OpenAI Responses API at `/v1/responses`, so
+  Codex CLI can point directly at the gateway via a custom provider
+  (`wire_api = "responses"`) — see the
+  [Codex CLI guide](integrations/codex-cli.md) — instead of the
+  `llm-openai-via-codex` pattern above. When the bearer is a Codex
+  OAuth JWT and passthrough is enabled, the Responses route resolves
+  the same `CodexPassthroughAdapter` described here.
 
 ## Path 2: Claude Max via the Anthropic Messages API
 


### PR DESCRIPTION
Two docs commits, one theme: the docs had drifted behind the 0.8-0.10
  releases (Mem0 memory, streaming cache_control stats, the /v1/responses  surface).
  ## Codex CLI guide rewrite
  The guide described a `/v1/chat/completions` + `OPENAI_BASE_URL` setup that
  current Codex (v0.137+) doesn't use -- it speaks the Responses API and
  configures providers via `~/.codex/config.toml`. Rewritten around the real
  `config.toml` provider block (`wire_api = "responses"`), the canonical
  `anthropic/modelmeld-{saver,auto,quality}` aliases, and a routing-header
  check using `x-modelmeld-routed-model` / `-tier`.

  ## Docs accuracy sweep
  - **README:** drop the "streaming cache_control stats" non-coverage bullet
    (shipped 0.8.2); "two API surfaces" -> three (adds `/v1/responses`); Codex
    moved to validated-end-to-end.
  - **ROADMAP:** Postgres-memory item -> shipped Mem0 status; drop the
    "richer integration guides" item (those guides now exist).
  - **api-stability:** list `/v1/responses` among SemVer-stable HTTP routes.
  - **design-anthropic-messages-api:** `cache_control` is no longer a non-goal --
    forwarded verbatim, stats surface on both streaming and non-streaming.
  - **memory:** document `MODELMELD_MEM0_VECTOR_STORE_API_KEY` and
    `MODELMELD_MEM0_EMBEDDING_DIMS`.
  - **claude-code:** use the canonical `-saver` alias, not the legacy `-coding`.
  - **subscription-passthrough:** native Codex CLI now works via `/v1/responses`.

  Docs-only; no code or test changes.