### PR TITLE
feat(scout): fingerprint Codex CLI in the DevTool detector

### DIFF
--- a/src/modelmeld/scout/devtool.py
+++ b/src/modelmeld/scout/devtool.py
@@ -4,8 +4,9 @@
 """Dev-tool fingerprinter.
 
 Identifies which client tool likely originated a request — Cursor, Claude Code,
-Aider, Cline, or generic OpenAI/Anthropic SDK usage. Detection is best-effort
-regex matching against message text; false positives and negatives are expected.
+Codex, Aider, Cline, or generic OpenAI/Anthropic SDK usage. Detection is
+best-effort regex matching against message text; false positives and negatives
+are expected.
 
 Used for:
     - Per-tool savings benchmarks (deferred work)
@@ -39,6 +40,7 @@ class DevTool(str, Enum):
 
     CURSOR = "cursor"
     CLAUDE_CODE = "claude_code"
+    CODEX = "codex"
     AIDER = "aider"
     CLINE = "cline"
     OPENCODE = "opencode"
@@ -109,6 +111,20 @@ _DEFAULT_PATTERNS: dict[DevTool, list[re.Pattern[str]]] = {
         re.compile(r"\bI am Cline\b", re.IGNORECASE),
         re.compile(r"<read_file>|<execute_command>|<write_to_file>", re.IGNORECASE),
         re.compile(r"You are Cline\b", re.IGNORECASE),
+    ],
+    # Codex CLI (github.com/openai/codex). Reaches the gateway via the
+    # /v1/responses surface; its `developer` instructions translate to a system
+    # message carrying a distinctive sandbox/escalation harness block. The HTTP
+    # `originator: codex_cli_rs` header is a stronger signal but this
+    # fingerprinter only sees message text, so we key off the prompt content.
+    DevTool.CODEX: [
+        re.compile(r"\bYou are Codex\b", re.IGNORECASE),
+        re.compile(r"Filesystem sandboxing defines which files", re.IGNORECASE),
+        re.compile(
+            r"sandbox_mode`?\s+is\s+`?(?:workspace-write|read-only|danger-full-access)",
+            re.IGNORECASE,
+        ),
+        re.compile(r"#\s*Escalation Requests", re.IGNORECASE),
     ],
     # opencode (github.com/sst/opencode) — SST's terminal coding agent.
     # Known limitation: opencode actively spoofs the upstream provider's

--- a/tests/test_devtool_fingerprinter.py
+++ b/tests/test_devtool_fingerprinter.py
@@ -49,6 +49,34 @@ def test_detects_claude_code(fingerprinter: Fingerprinter) -> None:
     assert fp.confidence >= 0.6
 
 
+def test_detects_codex(fingerprinter: Fingerprinter) -> None:
+    # Codex reaches the gateway via /v1/responses; its `developer` instructions
+    # translate to a system message carrying this sandbox/escalation block.
+    fp = fingerprinter.identify(
+        _req(
+            system=(
+                "<permissions instructions>\n"
+                "Filesystem sandboxing defines which files can be read or "
+                "written. `sandbox_mode` is `workspace-write`: The sandbox "
+                "permits reading files, and editing files in cwd.\n"
+                "# Escalation Requests\n"
+                "Commands are run outside the sandbox if approved by the user."
+            ),
+            user="explain this codebase",
+        )
+    )
+    assert fp.tool == DevTool.CODEX
+    assert fp.confidence >= 0.6
+
+
+def test_codex_not_confused_with_other_tools(fingerprinter: Fingerprinter) -> None:
+    """Codex's sandbox block shouldn't tag as Cline/Cursor/etc."""
+    fp = fingerprinter.identify(
+        _req(system="You are Codex, a coding agent.", user="hi")
+    )
+    assert fp.tool == DevTool.CODEX
+
+
 def test_detects_aider_from_search_replace(fingerprinter: Fingerprinter) -> None:
     fp = fingerprinter.identify(
         _req(


### PR DESCRIPTION
Codex reaches the gateway via `/v1/responses`; its `developer` instructions
  translate to a system message carrying a distinctive sandbox/escalation harness
  block. Add a `DevTool.CODEX` value plus text patterns keyed off that block
  ("Filesystem sandboxing defines which files…", `sandbox_mode` is
  `workspace-write`, "# Escalation Requests") and the "You are Codex" identity
  line, so Codex traffic is self-identifying in routing + audit
  (`x-modelmeld-devtool`) like the other coding agents.

  The stronger `originator: codex_cli_rs` HTTP header is noted in-code as a future
  signal — this text-based fingerprinter only inspects message content.

  ## Tests
  - Detects Codex from the sandbox/permissions block and from the identity line
  - Confirms no cross-contamination with other tools
  - Full suite: 1127 passed, 11 skipped

  Closes #33.