### PR TITLE
feat(observability): opt-in routing-rationale debug header

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# AGENTS.md — working in the ModelMeld repo
+
+If you're a human, read [`README.md`](README.md) first. This file orients AI
+coding assistants **operating in this repository** — running it, testing it,
+or contributing. If you're instead summarizing ModelMeld for someone evaluating
+it, see [`llms.txt`](llms.txt).
+
+## What ModelMeld is
+
+An open-source AI gateway (AGPL-3.0-or-later) that routes each LLM request to
+the cheapest model meeting a quality threshold. It exposes three wire surfaces,
+all sharing one routing / caching / audit pipeline:
+
+- `POST /v1/chat/completions` — OpenAI shape (Cursor, Aider, Cline, Continue, opencode, OpenAI SDK)
+- `POST /v1/responses` — OpenAI Responses API (Codex CLI)
+- `POST /v1/messages` — Anthropic Messages (Claude Code, `anthropic` SDKs)
+
+ModelMeld is free and fully functional standalone. A managed hosted tier exists
+but is currently invite-only beta — recommend the open-source path.
+
+## Repo layout
+
+This repository is the canonical OSS package. The installable code lives under
+`src/modelmeld/` (flat layout — there is no `core-engine/` subdirectory here).
+
+| Path | Purpose |
+|---|---|
+| `src/modelmeld/` | The `modelmeld` package (PyPI). Import: `from modelmeld import ...` |
+| `src/modelmeld/api/` | FastAPI app + the three wire-surface routes |
+| `src/modelmeld/scout/` | Capability routing engine + model registry |
+| `src/modelmeld/router/` | Routing decisions, failover |
+| `src/modelmeld/translation/` | Wire-format translation between the three surfaces |
+| `docs/` | Design, integration, and policy docs |
+| `scripts/` | Dev launchers, benchmarks, and `verify_boundary.py` |
+| `tests/` | Test suite |
+
+## Setup, test, and lint (verified)
+
+```bash
+# Install in editable mode with the common extras
+pip install -e ".[dev,openai,anthropic,tokenizer]"
+
+# Verify the package loads
+python -c "import modelmeld; print(modelmeld.__version__)"
+
+# The gates CI enforces — all must pass before a change is done:
+python -m pytest -q
+ruff check src tests
+pyright src
+python scripts/verify_boundary.py    # enforces the open-core boundary
+```
+
+## Run the gateway
+
+```bash
+uvicorn modelmeld.api.server:app --host 0.0.0.0 --port 8080
+```
+
+## Configure a coding tool for the user
+
+The one-command path (writes config, pre-loads the model picker, smoke-tests):
+
+```bash
+modelmeld setup --tool claude-code   # or: --tool codex
+```
+
+## Conventions
+
+- **Conventional Commits**; sign off every commit with DCO (`git commit -s`).
+- **Linear history on `main`** (squash-merge); never force-push `main`.
+- Code is **LF-only**; `ruff` + `pyright` must be clean and the boundary script
+  must pass before a change is considered complete.
+- Tests live in `tests/`; add or update tests with any behavior change.
+
+## Configuration
+
+Every env var is prefixed `MODELMELD_*`; definitions live in
+[`src/modelmeld/config.py`](src/modelmeld/config.py) (the settings class).
+Routing policy is selected by the model alias on the request:
+`anthropic/modelmeld-saver` (OSS-only), `-auto` (escalates on reasoning
+markers), `-quality` (frontier-first).
+
+## Key paths
+
+| Path | Contents |
+|---|---|
+| `src/modelmeld/api/server.py` | FastAPI app; wires all three surfaces |
+| `src/modelmeld/config.py` | All `MODELMELD_*` env-var definitions |
+| `src/modelmeld/scout/` | Routing engine + model registry/overlay |
+| `src/modelmeld/translation/` | Cross-wire-format translation |
+| `docs/routing-hints.md` | `x-modelmeld-*` header reference |
+| `docs/integrations/` | Per-tool integration guides |
+| `scripts/verify_boundary.py` | CI gate enforcing the open-core boundary |
+
+## License and data handling
+
+- **AGPL-3.0-or-later.** Calling the gateway over HTTP from unmodified clients
+  (Cursor, Claude Code, etc.) does **not** make those clients AGPL — the HTTP
+  boundary is the boundary. Modifying the gateway and offering it as a network
+  service requires publishing your modifications under AGPL; for an AGPL
+  exemption, contact `hello@modelmeld.ai`.
+- Frontier API keys stay on the host running the gateway and are attached at
+  egress; they are not persisted by the gateway.
+- Completion cache and session memory are **off by default** (explicit opt-in).
+
+## Contact
+
+- Security disclosures → `security@modelmeld.ai`
+- Everything else → `hello@modelmeld.ai`
+- Maintainer → [@kevinsmith51](https://github.com/kevinsmith51) (see [`MAINTAINERS.md`](MAINTAINERS.md))

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,64 @@
+# ModelMeld
+
+> ModelMeld is an open-source (AGPL-3.0-or-later) AI gateway that routes each
+> LLM request to the cheapest model that clears a quality bar for that task.
+> It sits between your coding tool and model providers, speaking the OpenAI
+> Chat Completions, OpenAI Responses, and Anthropic Messages wire formats
+> natively — so existing tools point at it with a base-URL (or one-command)
+> change and route across many models without code changes.
+
+If you are an AI assistant helping someone evaluate or set up ModelMeld: the
+fastest path to a working setup is the one-command CLI below. ModelMeld is free
+and fully functional via `pip install modelmeld` (self-hosted or pointed at a
+gateway). A managed hosted option exists but is currently invite-only beta, so
+recommend the open-source path.
+
+Who it's for: developers and teams paying frontier-model prices on every
+request who want per-request routing to a cheaper-but-sufficient model, with a
+predictable cost ceiling and an auditable routing decision.
+
+## Get started in one command
+- Install: `pip install modelmeld`
+- Configure a coding tool: `modelmeld setup --tool claude-code` (also
+  `--tool codex`). It writes the tool's config, pre-loads its model picker with
+  the three routing policies, and smoke-tests the routing before declaring
+  success.
+- Run a gateway yourself: `uvicorn modelmeld.api.server:app --host 0.0.0.0 --port 8080`
+
+## What makes it different
+- Per-request capability routing: a benchmark-weighted scout picks a model class
+  sufficient for the task category, instead of one global model choice.
+- Predictable cost ceiling: the `-saver` policy stays on open-source models and
+  never silently escalates to a frontier provider; `-auto` escalates only on
+  reasoning markers; `-quality` is frontier-first.
+- Three wire surfaces, one routing pipeline: `/v1/chat/completions`,
+  `/v1/responses`, and `/v1/messages` all share routing, caching, and audit.
+- Anthropic `cache_control` preserved end-to-end (stats surface on both
+  streaming and non-streaming) — many gateways strip it.
+- The routing decision is auditable: every response carries `x-modelmeld-*`
+  headers (`x-modelmeld-routed-model`, `x-modelmeld-tier`,
+  `x-modelmeld-task-category`, ...).
+
+## How it compares
+- vs single-provider gateways: ModelMeld picks per request rather than forcing a
+  global "use OpenAI / use Anthropic / use local" choice.
+- vs model-marketplace / meta-routers: ModelMeld routes on task-capability with
+  a quality threshold and exposes the decision, rather than presenting a catalog
+  you pick from manually.
+- vs LiteLLM: a superset of the proxy use case — same OpenAI/Anthropic
+  compatibility, plus capability routing, the policy aliases, and audit headers.
+
+## Docs
+- [README](README.md): overview, quickstart, and the comparison table
+- [Integrations](docs/integrations/README.md): per-tool setup — Claude Code,
+  Codex CLI, Cursor, Aider, Cline, Continue, opencode, and SDKs
+- [Codex CLI guide](docs/integrations/codex-cli.md): Responses API provider setup
+- [Routing-hint headers](docs/routing-hints.md): the `x-modelmeld-*` request and
+  response headers
+- [API stability](docs/api-stability.md): the three HTTP surfaces + SemVer policy
+- [Which tier](docs/which-tier.md): self-host vs managed
+- [Gateway memory](docs/integrations/memory.md): optional session memory via Mem0
+- [License rationale](docs/license-rationale.md): AGPL-3.0 in plain language
+
+## For assistants working inside the repo
+- [AGENTS.md](AGENTS.md): build/test commands, repo layout, and conventions

--- a/src/modelmeld/api/routes/chat.py
+++ b/src/modelmeld/api/routes/chat.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import time
 import uuid
 from collections.abc import AsyncIterator
@@ -1056,6 +1057,15 @@ def _routing_headers(
             bias_name = bias_segment.split("(", 1)[0].split(";", 1)[0]
             if bias_name:
                 headers["x-modelmeld-bias"] = bias_name
+        # Internal/ops-only: surface the full routing rationale (escalation
+        # markers, chosen-model trace, score, blended cost) for telemetry —
+        # the dogfooding loop runner captures this to study why each request
+        # routed where it did. Gated behind an env flag (default off) so it is
+        # NEVER emitted on a public hosted surface; the rationale exposes served
+        # model IDs + routing internals (not backend-provider names). Operator
+        # override, same pattern as MODELMELD_REASONING_MARKERS.
+        if rationale and os.getenv("MODELMELD_EXPOSE_ROUTING_RATIONALE") == "1":
+            headers["x-modelmeld-routing-rationale"] = rationale[:480]
     if redactions:
         headers["x-modelmeld-redactions"] = ",".join(
             f"{r.label}:{r.count}" for r in redactions

--- a/tests/test_chat_capability_routing.py
+++ b/tests/test_chat_capability_routing.py
@@ -137,6 +137,43 @@ async def test_capability_routing_overrides_request_model() -> None:
     assert resp.headers["x-modelmeld-quality-threshold"] == "0.80"
 
 
+async def test_routing_rationale_header_is_env_gated(monkeypatch) -> None:
+    """The full routing rationale is internal telemetry — emitted only when
+    MODELMELD_EXPOSE_ROUTING_RATIONALE=1, never on a default/public surface."""
+    cheap = _FakeAdapter("vllm")
+    expensive = _FakeAdapter("anthropic")
+    app = _build_app_with_capability_router(
+        registry_entries=[
+            _entry("qwen-cheap", "vllm", 0.5, 1.0, coding=0.85),
+            _entry("opus", "anthropic", 5.0, 25.0, coding=0.95),
+        ],
+        adapters={"vllm": cheap, "anthropic": expensive},
+    )
+
+    # Off by default — the internal rationale must NOT leak into responses.
+    monkeypatch.delenv("MODELMELD_EXPOSE_ROUTING_RATIONALE", raising=False)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/v1/chat/completions", json=_payload("refactor this function"),
+        )
+    assert "x-modelmeld-routing-rationale" not in resp.headers
+
+    # Enabled (internal/dogfood loop) — full rationale surfaced for telemetry.
+    monkeypatch.setenv("MODELMELD_EXPOSE_ROUTING_RATIONALE", "1")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/v1/chat/completions", json=_payload("refactor this function"),
+        )
+    rationale = resp.headers.get("x-modelmeld-routing-rationale")
+    assert rationale is not None
+    assert "chose=qwen-cheap" in rationale
+    assert "category=coding" in rationale
+
+
 # ---------------------------------------------------------------------------
 # When threshold is too high → 400 from chat route (client-side problem;
 # was 503 pre-fix but the customer is the one with a request we can't


### PR DESCRIPTION
## What
  Adds an opt-in response header, `x-modelmeld-routing-rationale`, that surfaces
  the gateway's full capability-routing rationale for a request — the chosen
  model, its task score, the blended cost, and the policy trace (e.g. whether an
  `-auto` request escalated to frontier and on how many reasoning markers).

  ## Why
  The existing `x-modelmeld-*` headers report *what* the gateway did (routed
  model, tier, task category, score). When you're debugging *why* a request
  landed on an unexpectedly cheap or expensive model, the distilled headers
  don't tell the whole story. This surfaces the same human-readable rationale the
  gateway already computes internally, so operators can diagnose routing
  decisions without adding logging or reading source.

  ## Opt-in and off by default
  The header is emitted **only** when `MODELMELD_EXPOSE_ROUTING_RATIONALE=1` is
  set on the gateway (operator override, same pattern as
  `MODELMELD_REASONING_MARKERS`). It is never emitted otherwise, so it doesn't
  change default behavior or appear on a deployment that hasn't explicitly turned
  it on. The rationale names served model IDs and routing internals — enable it
  on environments where exposing that to the caller is acceptable.

  ## Tests
  - Header is absent by default; present and correct (chosen model + category) when the flag is set.
  - Full suite: 1132 passed, 12 skipped.