### PR TITLE
fix(messages): accept system-role messages, hoist to system prompt

### DIFF
--- a/src/modelmeld/api/schemas_anthropic.py
+++ b/src/modelmeld/api/schemas_anthropic.py
@@ -118,9 +118,15 @@ AnthropicResponseContentBlock = Annotated[
 # ---------------------------------------------------------------------------
 
 class AnthropicMessage(BaseModel):
-    """A single message in the conversation history."""
+    """A single message in the conversation history.
+
+    Anthropic's own API restricts `messages[].role` to user/assistant (system
+    is a top-level field). But real clients — notably Claude Code in headless
+    (`-p`) mode — put a `system`-role message in the array. We accept it and
+    hoist it to the system prompt during translation rather than 422 the
+    request (see `from_anthropic_request`)."""
     model_config = ConfigDict(extra="allow")
-    role: Literal["user", "assistant"]
+    role: Literal["user", "assistant", "system"]
     content: str | list[AnthropicRequestContentBlock]
 
 

--- a/src/modelmeld/translation/openai_anthropic.py
+++ b/src/modelmeld/translation/openai_anthropic.py
@@ -553,6 +553,17 @@ def _anthropic_message_to_openai(msg: AnthropicMessage) -> list[Message]:
         return _anthropic_user_to_openai(msg)
     if msg.role == "assistant":
         return [_anthropic_assistant_to_openai(msg)]
+    if msg.role == "system":
+        # Non-standard for Anthropic's own API, but real clients (Claude Code
+        # headless) send it. Hoist to a SystemMessage; the egress translator
+        # folds all SystemMessages back into the top-level system prompt.
+        if isinstance(msg.content, str):
+            text = msg.content
+        else:
+            text = "\n".join(
+                t for b in msg.content if (t := getattr(b, "text", ""))
+            )
+        return [SystemMessage(role="system", content=text)]
     # Pydantic literal validation should prevent reaching here.
     raise TranslationError(f"Unsupported message role: {msg.role!r}")
 

--- a/tests/test_translation_anthropic_to_openai.py
+++ b/tests/test_translation_anthropic_to_openai.py
@@ -62,6 +62,23 @@ def test_minimal_request_round_trips_through_translation() -> None:
     assert user.content == "Hello"
 
 
+def test_system_role_message_in_array_is_hoisted() -> None:
+    # Claude Code headless (`-p`) puts a system-role message in messages[].
+    # Anthropic's own API forbids it, but we accept it (constructing this
+    # request used to raise a pydantic ValidationError → 422 on the route) and
+    # hoist it to a SystemMessage rather than reject the request.
+    req = AnthropicMessagesRequest(
+        model="m", max_tokens=64,
+        messages=[
+            AnthropicMessage(role="user", content="hi"),
+            AnthropicMessage(role="system", content="Be terse."),
+        ],
+    )
+    out = from_anthropic_request(req)
+    systems = [m for m in out.messages if isinstance(m, SystemMessage)]
+    assert any(m.content == "Be terse." for m in systems)
+
+
 def test_top_level_scalars_pass_through() -> None:
     req = AnthropicMessagesRequest(
         model="m", max_tokens=10,


### PR DESCRIPTION
## Problem
  A `/v1/messages` request with a `system`-role message inside the `messages`
  array returns 422. Anthropic's own API allows only `user`/`assistant` there
  (system is a top-level field) and our schema enforced the same `Literal` — but
  real clients (Claude Code in headless `-p` mode) put a system-role message in
  the array, so those requests were rejected outright.

  ## Fix
  Accept `role: "system"` on `AnthropicMessage` and hoist it to a `SystemMessage`
  in `from_anthropic_request`. The egress translator already folds `SystemMessage`s
  back into the top-level `system` prompt, so routing to an Anthropic upstream is
  unchanged. Adds a translation test (system-in-array → hoisted).