### PR TITLE
fix(anthropic): forward unknown native passthrough fields via extra_body

### DIFF
--- a/src/modelmeld/adapters/anthropic_adapter.py
+++ b/src/modelmeld/adapters/anthropic_adapter.py
@@ -310,6 +310,17 @@ class AnthropicAdapter(ProviderAdapter):
             elif params.get("model") is None:
                 # Defense in depth — Anthropic SDK requires `model`.
                 params["model"] = request.model
+            # Fields the client sent that aren't declared on our schema
+            # (extra="allow") — e.g. Claude Code's `context_management` — are NOT
+            # valid keyword args for the SDK's create(); passing them raises
+            # "unexpected keyword argument". Route them through `extra_body` so
+            # the SDK still forwards them to the API verbatim (passthrough
+            # intent preserved) without choking on unknown kwargs.
+            extras = dict(native_request.model_extra or {})
+            if extras:
+                for key in extras:
+                    params.pop(key, None)
+                params["extra_body"] = {**(params.get("extra_body") or {}), **extras}
             return params
         # Translation path (the existing /v1/chat/completions behavior).
         request = self._apply_served_model(request)

--- a/tests/test_adapter_anthropic.py
+++ b/tests/test_adapter_anthropic.py
@@ -452,6 +452,41 @@ async def test_chat_preserves_cache_control_when_native_request_supplied() -> No
     assert first_user_content[0]["cache_control"] == {"type": "ephemeral"}
 
 
+async def test_native_passthrough_routes_unknown_fields_to_extra_body() -> None:
+    """Fields the client sends that aren't on our schema (extra="allow") — e.g.
+    Claude Code's `context_management` — must go via `extra_body`, not as
+    top-level kwargs the SDK rejects ("unexpected keyword argument"). Regression
+    for the streaming 502 the dogfooding loop surfaced.
+    """
+    from modelmeld.api.schemas_anthropic import AnthropicMessagesRequest
+
+    body = AnthropicMessagesRequest.model_validate({
+        "model": "claude-sonnet-4-6",
+        "max_tokens": 64,
+        "messages": [{"role": "user", "content": "hi"}],
+        "context_management": {"edits": [{"type": "clear_tool_uses_20250919"}]},
+    })
+    adapter = AnthropicAdapter(api_key="test-key")
+    mock_create = AsyncMock(return_value=_fake_sdk_message())
+    adapter._client.messages.create = mock_create  # type: ignore[method-assign]
+
+    await adapter.chat(
+        ChatCompletionRequest(
+            model="claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "ignored"}],
+        ),
+        native_request=body,
+    )
+
+    call_kwargs = mock_create.call_args.kwargs
+    # Not a top-level kwarg (that's what raised the SDK TypeError) ...
+    assert "context_management" not in call_kwargs
+    # ... forwarded via extra_body instead, preserving passthrough intent.
+    assert call_kwargs["extra_body"]["context_management"] == {
+        "edits": [{"type": "clear_tool_uses_20250919"}]
+    }
+
+
 async def test_chat_falls_back_to_translation_when_no_native_request() -> None:
     """/v1/chat/completions callers don't supply native_request; the adapter
     must still work via the translation path (existing behavior unchanged).


### PR DESCRIPTION
## Problem
  Routing a `/v1/messages` request to an Anthropic upstream 502'd on the
  streaming path with `AsyncMessages.create() got an unexpected keyword argument
  'context_management'`. Native passthrough does `native_request.model_dump()`
  and passes the result as keyword args to the SDK's `create()`. Because the
  request schema is `extra="allow"`, any field the client sends that we don't
  declare — e.g. Claude Code's `context_management` — became a top-level kwarg the
  SDK rejects, breaking every streaming Anthropic request (the default Claude Code
  path; non-streaming was hit too whenever the field was present).

  ## Fix
  Move extra (`model_extra`) fields into `extra_body`, which the SDK forwards to
  the API verbatim — passthrough intent preserved, no unknown-kwarg crash. Adds a
  regression test (`context_management` → `extra_body`, not a top-level kwarg).