### PR TITLE
fix(anthropic): drop client thinking config on model substitution

### DIFF
--- a/src/modelmeld/adapters/anthropic_adapter.py
+++ b/src/modelmeld/adapters/anthropic_adapter.py
@@ -310,13 +310,23 @@ class AnthropicAdapter(ProviderAdapter):
             elif params.get("model") is None:
                 # Defense in depth — Anthropic SDK requires `model`.
                 params["model"] = request.model
+            extras = dict(native_request.model_extra or {})
+            # Model substitution: capability/alias routing rewrote the internal
+            # request.model to the scout's pick, while native_request.model is
+            # still what the client asked for. When they differ, drop client
+            # `thinking` config — it was tuned for the requested model and may be
+            # unsupported on the one we routed to (Anthropic 400 "adaptive
+            # thinking is not supported on this model"). See projectplan backlog
+            # B-3 for the capability-aware refinement (forward when supported).
+            if request.model and native_request.model != request.model:
+                params.pop("thinking", None)
+                extras.pop("thinking", None)
             # Fields the client sent that aren't declared on our schema
             # (extra="allow") — e.g. Claude Code's `context_management` — are NOT
             # valid keyword args for the SDK's create(); passing them raises
             # "unexpected keyword argument". Route them through `extra_body` so
             # the SDK still forwards them to the API verbatim (passthrough
             # intent preserved) without choking on unknown kwargs.
-            extras = dict(native_request.model_extra or {})
             if extras:
                 for key in extras:
                     params.pop(key, None)

--- a/tests/test_adapter_anthropic.py
+++ b/tests/test_adapter_anthropic.py
@@ -487,6 +487,63 @@ async def test_native_passthrough_routes_unknown_fields_to_extra_body() -> None:
     }
 
 
+async def test_thinking_dropped_when_model_substituted() -> None:
+    """Capability/alias routing serves a different model than the client asked
+    for. Client `thinking` config is tuned for the requested model and may be
+    unsupported on the routed one ("adaptive thinking is not supported on this
+    model"), so it's dropped on substitution. Regression for the loop's 400.
+    """
+    from modelmeld.api.schemas_anthropic import AnthropicMessagesRequest
+
+    body = AnthropicMessagesRequest.model_validate({
+        "model": "anthropic/modelmeld-auto",   # alias the client requested
+        "max_tokens": 64,
+        "messages": [{"role": "user", "content": "hi"}],
+        "thinking": {"type": "adaptive"},
+    })
+    adapter = AnthropicAdapter(api_key="test-key")
+    mock_create = AsyncMock(return_value=_fake_sdk_message())
+    adapter._client.messages.create = mock_create  # type: ignore[method-assign]
+
+    await adapter.chat(
+        ChatCompletionRequest(  # routing substituted the model
+            model="claude-sonnet-4-6", messages=[{"role": "user", "content": "x"}],
+        ),
+        native_request=body,
+    )
+
+    ck = mock_create.call_args.kwargs
+    assert "thinking" not in ck
+    assert "thinking" not in (ck.get("extra_body") or {})
+
+
+async def test_thinking_preserved_when_no_substitution() -> None:
+    """When the served model equals what the client requested (no substitution),
+    the client's thinking config is forwarded verbatim via extra_body."""
+    from modelmeld.api.schemas_anthropic import AnthropicMessagesRequest
+
+    thinking = {"type": "enabled", "budget_tokens": 1024}
+    body = AnthropicMessagesRequest.model_validate({
+        "model": "claude-sonnet-4-6",
+        "max_tokens": 64,
+        "messages": [{"role": "user", "content": "hi"}],
+        "thinking": thinking,
+    })
+    adapter = AnthropicAdapter(api_key="test-key")
+    mock_create = AsyncMock(return_value=_fake_sdk_message())
+    adapter._client.messages.create = mock_create  # type: ignore[method-assign]
+
+    await adapter.chat(
+        ChatCompletionRequest(
+            model="claude-sonnet-4-6", messages=[{"role": "user", "content": "x"}],
+        ),
+        native_request=body,
+    )
+
+    ck = mock_create.call_args.kwargs
+    assert (ck.get("extra_body") or {}).get("thinking") == thinking
+
+
 async def test_chat_falls_back_to_translation_when_no_native_request() -> None:
     """/v1/chat/completions callers don't supply native_request; the adapter
     must still work via the translation path (existing behavior unchanged).


### PR DESCRIPTION
## Problem
  Driving Claude Code through `anthropic/modelmeld-auto`, every turn 502'd with
  Anthropic 400 `adaptive thinking is not supported on this model`. Claude Code
  sends a `thinking: {type: adaptive}` config tuned for the model it requested;
  capability/alias routing serves a *different* model (the scout's pick), which
  may not support that thinking mode.

  ## Fix
  When the served model differs from what the client requested
  (`native_request.model != request.model`), drop the client `thinking` config.
  When there's no substitution, it's forwarded verbatim via `extra_body`.
  Capability-aware gating (forward when the routed model supports it) is tracked
  as a follow-up. Tests cover both paths.