### PR TITLE
fix(messages): strip output_config (nested effort) on model substitution

### DIFF
--- a/src/modelmeld/api/routes/messages.py
+++ b/src/modelmeld/api/routes/messages.py
@@ -175,7 +175,11 @@ def _collect_oauth_camouflage_headers(
 # by Claude Code's beta endpoint tuned for the model it asked for. Dropped on
 # substitution; forwarded verbatim when there's none. B-3 (capability-aware
 # gating) is the real fix: forward each when the routed model supports it.
-_MODEL_TUNED_FIELDS = ("thinking", "effort")
+#
+# `output_config` is the wrapper Claude Code nests `effort` inside (top-level
+# `effort` is null; the param lives at output_config.effort), so the whole
+# object is dropped on substitution — confirmed via request-shape capture.
+_MODEL_TUNED_FIELDS = ("thinking", "effort", "output_config")
 
 
 def _native_body_for_upstream(

--- a/tests/test_route_messages.py
+++ b/tests/test_route_messages.py
@@ -986,16 +986,18 @@ def test_native_body_drops_thinking_on_substitution() -> None:
         "max_tokens": 64,
         "messages": [{"role": "user", "content": "hi"}],
         "thinking": {"type": "adaptive"},
-        "effort": "high",
+        # Claude Code nests `effort` inside output_config (top-level effort is
+        # null) — captured from a real request via the proxy request-shape log.
+        "output_config": {"effort": "high"},
     })
     out = _native_body_for_upstream(body, "claude-sonnet-4-6")
     assert out.model == "claude-sonnet-4-6"
-    # Both model-tuned controls dropped (each 400'd on the substituted model).
+    # All model-tuned controls dropped (each 400'd on the substituted model).
     assert "thinking" not in (out.model_extra or {})
-    assert "effort" not in (out.model_extra or {})
+    assert "output_config" not in (out.model_extra or {})
     # Original body untouched (no mutation of the caller's object).
     assert (body.model_extra or {}).get("thinking") == {"type": "adaptive"}
-    assert (body.model_extra or {}).get("effort") == "high"
+    assert (body.model_extra or {}).get("output_config") == {"effort": "high"}
 
 
 def test_native_body_preserves_thinking_when_no_substitution() -> None:


### PR DESCRIPTION
Request-shape capture from a real Claude Code request showed `effort` is `null`  at the top level — it's actually nested inside `output_config`. The top-level
  `effort` strip never reached it, so the substituted model kept returning 400
  "does not support the effort parameter". Add `output_config` to the
  dropped-on-substitution set (`_MODEL_TUNED_FIELDS`). Capability-aware gating
  (B-3) remains the proper fix. Found + pinpointed by the dogfooding loop.