### PR TITLE
fix(anthropic): hoist system-role messages to top-level system in passthrough

### DIFF
--- a/src/modelmeld/adapters/anthropic_adapter.py
+++ b/src/modelmeld/adapters/anthropic_adapter.py
@@ -37,6 +37,54 @@ _ANTHROPIC_API_VERSION = "2023-06-01"
 _DEFAULT_BASE_URL = "https://api.anthropic.com"
 
 
+def _block_text(content: object) -> str:
+    """Flatten a message content (str or list of blocks) to its text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            b.get("text", "") for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        )
+    return ""
+
+
+def _hoist_system_messages(params: dict) -> None:
+    """Move any `role: "system"` entries out of `messages[]` into the top-level
+    `system` field, in place.
+
+    Anthropic's API rejects system-role messages in the array ("role 'system'
+    is not supported on this model") — system must be top-level. Real clients
+    (Claude Code) put system-role messages in the array, and native passthrough
+    forwards them verbatim, so hoist them here. The existing top-level `system`
+    is preserved structurally (incl. cache_control on its blocks); hoisted text
+    is appended.
+    """
+    msgs = params.get("messages")
+    if not isinstance(msgs, list):
+        return
+    hoisted: list[str] = []
+    kept: list = []
+    for m in msgs:
+        if isinstance(m, dict) and m.get("role") == "system":
+            text = _block_text(m.get("content"))
+            if text:
+                hoisted.append(text)
+        else:
+            kept.append(m)
+    if not hoisted:
+        return
+    params["messages"] = kept
+    existing = params.get("system")
+    if existing is None:
+        params["system"] = "\n\n".join(hoisted)
+    elif isinstance(existing, str):
+        params["system"] = "\n\n".join([existing, *hoisted])
+    elif isinstance(existing, list):
+        # Append as text blocks; existing blocks (with any cache_control) intact.
+        params["system"] = [*existing, *({"type": "text", "text": t} for t in hoisted)]
+
+
 class AnthropicAdapter(ProviderAdapter):
     name = "anthropic"
     is_egress = True
@@ -331,6 +379,7 @@ class AnthropicAdapter(ProviderAdapter):
                 for key in extras:
                     params.pop(key, None)
                 params["extra_body"] = {**(params.get("extra_body") or {}), **extras}
+            _hoist_system_messages(params)
             return params
         # Translation path (the existing /v1/chat/completions behavior).
         request = self._apply_served_model(request)

--- a/tests/test_adapter_anthropic.py
+++ b/tests/test_adapter_anthropic.py
@@ -544,6 +544,46 @@ async def test_thinking_preserved_when_no_substitution() -> None:
     assert (ck.get("extra_body") or {}).get("thinking") == thinking
 
 
+async def test_native_passthrough_hoists_system_messages_to_top_level() -> None:
+    """Anthropic rejects role:"system" in messages[] ("role 'system' is not
+    supported on this model"); native passthrough hoists them into the
+    top-level system field, preserving the existing system. Regression for the
+    loop's 400.
+    """
+    from modelmeld.api.schemas_anthropic import AnthropicMessagesRequest
+
+    body = AnthropicMessagesRequest.model_validate({
+        "model": "claude-sonnet-4-6",
+        "max_tokens": 64,
+        "system": "Base system.",
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "Mid-convo system note."},
+        ],
+    })
+    adapter = AnthropicAdapter(api_key="test-key")
+    mock_create = AsyncMock(return_value=_fake_sdk_message())
+    adapter._client.messages.create = mock_create  # type: ignore[method-assign]
+
+    await adapter.chat(
+        ChatCompletionRequest(
+            model="claude-sonnet-4-6", messages=[{"role": "user", "content": "x"}],
+        ),
+        native_request=body,
+    )
+
+    ck = mock_create.call_args.kwargs
+    # No system-role message left in the array.
+    assert all(m.get("role") != "system" for m in ck["messages"])
+    # Hoisted text merged into the top-level system, original preserved.
+    sys = ck["system"]
+    sys_text = sys if isinstance(sys, str) else " ".join(
+        b.get("text", "") for b in sys
+    )
+    assert "Base system." in sys_text
+    assert "Mid-convo system note." in sys_text
+
+
 async def test_chat_falls_back_to_translation_when_no_native_request() -> None:
     """/v1/chat/completions callers don't supply native_request; the adapter
     must still work via the translation path (existing behavior unchanged).


### PR DESCRIPTION
## Problem  Native passthrough (Anthropic→Anthropic) forwards the request verbatim, so a
  `role: "system"` message in `messages[]` reached Anthropic, which rejects it
  ("role 'system' is not supported on this model"). The inbound-schema fix (#64)
  only covered the translation path; the passthrough path was still affected.

  ## Fix
  Hoist any `role: "system"` entries out of `messages[]` into the top-level
  `system` field in the adapter's native param-build, preserving the existing
  `system` structure (incl. `cache_control` on its blocks). Added a regression
  test. Found by the dogfooding loop.