### PR TITLE
fix(messages): drop context_management with the thinking cluster on substitution

### DIFF
--- a/src/modelmeld/api/routes/messages.py
+++ b/src/modelmeld/api/routes/messages.py
@@ -176,10 +176,13 @@ def _collect_oauth_camouflage_headers(
 # substitution; forwarded verbatim when there's none. B-3 (capability-aware
 # gating) is the real fix: forward each when the routed model supports it.
 #
+# These form an INTERDEPENDENT cluster and must be dropped atomically — e.g.
+# `context_management`'s `clear_thinking_*` strategy requires `thinking` to be
+# enabled, so dropping `thinking` while keeping `context_management` yields an
+# incoherent request (400 "clear_thinking strategy requires thinking …").
 # `output_config` is the wrapper Claude Code nests `effort` inside (top-level
-# `effort` is null; the param lives at output_config.effort), so the whole
-# object is dropped on substitution — confirmed via request-shape capture.
-_MODEL_TUNED_FIELDS = ("thinking", "effort", "output_config")
+# `effort` is null). All confirmed via request-shape capture from the loop.
+_MODEL_TUNED_FIELDS = ("thinking", "effort", "output_config", "context_management")
 
 
 def _native_body_for_upstream(

--- a/tests/test_route_messages.py
+++ b/tests/test_route_messages.py
@@ -989,15 +989,20 @@ def test_native_body_drops_thinking_on_substitution() -> None:
         # Claude Code nests `effort` inside output_config (top-level effort is
         # null) — captured from a real request via the proxy request-shape log.
         "output_config": {"effort": "high"},
+        # Coupled to thinking: clear_thinking requires thinking to exist, so it
+        # must be dropped atomically with thinking, not left dangling.
+        "context_management": {"edits": [{"type": "clear_thinking_20251015"}]},
     })
     out = _native_body_for_upstream(body, "claude-sonnet-4-6")
     assert out.model == "claude-sonnet-4-6"
-    # All model-tuned controls dropped (each 400'd on the substituted model).
-    assert "thinking" not in (out.model_extra or {})
-    assert "output_config" not in (out.model_extra or {})
+    # The whole interdependent cluster is dropped on substitution.
+    extra = out.model_extra or {}
+    assert "thinking" not in extra
+    assert "output_config" not in extra
+    assert "context_management" not in extra
     # Original body untouched (no mutation of the caller's object).
     assert (body.model_extra or {}).get("thinking") == {"type": "adaptive"}
-    assert (body.model_extra or {}).get("output_config") == {"effort": "high"}
+    assert (body.model_extra or {}).get("context_management") is not None
 
 
 def test_native_body_preserves_thinking_when_no_substitution() -> None:


### PR DESCRIPTION
## Problem  Cascading 400: "`clear_thinking_20251015` strategy requires `thinking` to be
  enabled or adaptive". We strip `thinking` on substitution but were still
  forwarding `context_management` (which referenced `clear_thinking`) → an
  incoherent request.

  ## Fix
  Claude Code's beta controls (`thinking`, `output_config`/`effort`,
  `context_management`) form an **interdependent cluster** and must be dropped
  **atomically** on substitution, not piecemeal. Add `context_management` to
  `_MODEL_TUNED_FIELDS`. The proper fix (B-3) is to forward the whole cluster iff
  the served model supports it; until then, drop the cluster so the substituted
  model gets a coherent vanilla request. Found by the dogfooding loop.