### PR TITLE
fix(api): coerce routing-header values to latin-1 to avoid 500

### DIFF
--- a/src/modelmeld/api/routes/chat.py
+++ b/src/modelmeld/api/routes/chat.py
@@ -1004,6 +1004,15 @@ def _canonical_model_id_for_header(
     return served_model_id
 
 
+def _latin1_safe(value: str) -> str:
+    """HTTP header values must be latin-1-encodable; any other character makes
+    Starlette raise UnicodeEncodeError → 500. Routing-header values can contain
+    non-latin-1 chars (e.g. a `→` in the free-form routing rationale), so coerce
+    every value to latin-1, replacing what doesn't fit. Cheap no-op for ASCII.
+    """
+    return value.encode("latin-1", "replace").decode("latin-1")
+
+
 def _routing_headers(
     decision: RoutingDecision,
     redactions: list[Redaction],
@@ -1072,4 +1081,6 @@ def _routing_headers(
         )
     if failover_from is not None:
         headers["x-modelmeld-failover-from"] = str(failover_from)
-    return headers
+    # Every value must be latin-1-encodable or Starlette 500s when it sets the
+    # header (the rationale header can carry a `→`, etc.).
+    return {k: _latin1_safe(v) for k, v in headers.items()}

--- a/tests/test_chat_capability_routing.py
+++ b/tests/test_chat_capability_routing.py
@@ -174,6 +174,19 @@ async def test_routing_rationale_header_is_env_gated(monkeypatch) -> None:
     assert "category=coding" in rationale
 
 
+def test_latin1_safe_coerces_non_latin1_header_values() -> None:
+    """HTTP header values must be latin-1-encodable or Starlette 500s. Routing
+    header values (e.g. the free-form rationale) can carry a `→`; coerce them.
+    Regression for the dogfooding 500 (UnicodeEncodeError on '\\u2192')."""
+    from modelmeld.api.routes.chat import _latin1_safe
+
+    out = _latin1_safe("chose=x→y;policy=auto")
+    out.encode("latin-1")  # must NOT raise
+    assert "→" not in out
+    # ASCII passes through untouched.
+    assert _latin1_safe("category=coding") == "category=coding"
+
+
 # ---------------------------------------------------------------------------
 # When threshold is too high → 400 from chat route (client-side problem;
 # was 503 pre-fix but the customer is the one with a request we can't


### PR DESCRIPTION
HTTP header values must be latin-1-encodable; Starlette raises  UnicodeEncodeError (→ 500) otherwise. A routing-header value can contain a
  non-latin-1 character — e.g. a `→` (U+2192) in the free-form
  `x-modelmeld-routing-rationale` header — which crashed the response. Coerce
  every value returned by `_routing_headers` to latin-1 (replace what doesn't
  fit; no-op for ASCII). Regression test on the coercion. Found by the dogfooding
  loop (intermittent 500s on `/v1/messages`; the agent retried past them).