### PR TITLE
fix(routing): load multi-provider overlay so cloud OSS providers are routable

### DIFF
--- a/src/modelmeld/api/server.py
+++ b/src/modelmeld/api/server.py
@@ -25,7 +25,8 @@ from modelmeld.memory import (
 )
 from modelmeld.privacy import Scrubber, build_scrubber
 from modelmeld.router import Router, SingleAdapterRouter, build_router
-from modelmeld.scout import ModelRegistry, Scout, build_scout, default_registry
+from modelmeld.scout import ModelRegistry, Scout, build_scout
+from modelmeld.scout.multi_provider_registry import default_multi_provider_registry
 from modelmeld.tokens import TokenCounter, build_token_counter
 
 
@@ -85,7 +86,15 @@ def build_app(
     # Allow explicit None to disable scrubbing in tests.
     app.state.scrubber = scrubber if scrubber is not None else build_scrubber(app.state.settings)
     app.state.hooks = hooks or HookRegistry()
-    app.state.model_registry = model_registry or default_registry()
+    # Default to the MULTI-provider registry (base + default_overlay) so the
+    # cloud OSS provider rows (fireworks/together/openrouter) are actually
+    # routable. Defaulting to the base registry here left OSS models only on
+    # their unreachable `vllm` rows, so capability routing saw no eligible OSS
+    # provider and fell back to frontier (-auto→Haiku) or 400'd (-saver). The
+    # multi-provider registry is a ModelRegistry subclass and the header
+    # resolvers already prefer its `all_entries_multi`, so this is strictly
+    # more correct for every consumer.
+    app.state.model_registry = model_registry or default_multi_provider_registry()
     # Tiered memory. Default: in-process backend for dev/tests; operators can
     # opt into a SQL-backed store with MODELMELD_MEMORY_BACKEND=postgres.
     if memory_store is not None:

--- a/src/modelmeld/scout/data/default_overlay.json
+++ b/src/modelmeld/scout/data/default_overlay.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "snapshot_release_date": "2026-05-30",
-  "notes": "Multi-provider availability overlay for canonical OSS coding models. Loaded automatically by MultiProviderModelRegistry.load_default() on top of the base default_registry.json. Each row adds one (model_id, provider) availability with its provider-specific model identifier and cost. Task scores are inherited from the base registry entry for the same model_id. Costs are per million tokens (USD), validated against the upstream providers' live model catalogs on the snapshot release date via scripts/validate_overlay.py for Together and OpenRouter; Fireworks catalog responses omit pricing, so Fireworks rows use the most recent published rate-card values and may drift first. The full curated lineup with weekly refresh and provider-reliability data is available via the live feed (MODELMELD_REGISTRY_FEED_URL + license key). See docs/registry-feed.md.",
+  "notes": "Multi-provider availability overlay for canonical OSS coding models. Loaded automatically by MultiProviderModelRegistry.load_default() on top of the base default_registry.json. Each row adds one (model_id, provider) availability with its provider-specific model identifier and cost. Task scores merge over the base registry entry for the same model_id (overlay row keys override base per-key; unspecified categories are inherited). Costs are per million tokens (USD), validated against the upstream providers' live model catalogs on the snapshot release date via scripts/validate_overlay.py for Together and OpenRouter; Fireworks catalog responses omit pricing, so Fireworks rows use the most recent published rate-card values and may drift first. tool_use scores sourced modelmeld_tool_eval_v1_2026_06_07 are MEASURED per (model, provider) on an agentic multi-step bug-fix eval, calibrated onto the registry scale by anchoring the eval's top frontier model (claude-sonnet-4-6, which scored 1.0 on the eval) to its registry tool_use of 0.85 (score = eval_pass_rate * 0.85); a model that ties sonnet on the eval is placed at sonnet, never above (the v1 toy-bug set cannot establish superiority over frontier). The full curated lineup with weekly refresh and provider-reliability data is available via the live feed (MODELMELD_REGISTRY_FEED_URL + license key). See docs/registry-feed.md.",
   "task_categories": [
     "coding",
     "reasoning",
@@ -17,8 +17,9 @@
       "context_window": 128000,
       "cost_per_m_input": 0.66,
       "cost_per_m_output": 1.0,
-      "task_scores": {},
-      "source": "oss_overlay_2026_05_30"
+      "task_scores": {"tool_use": 0.0},
+      "supports_tools": false,
+      "source": "modelmeld_tool_eval_v1_2026_06_07"
     },
     {
       "model_id": "llama-3.3-70b-instruct",
@@ -27,8 +28,8 @@
       "context_window": 131072,
       "cost_per_m_input": 1.04,
       "cost_per_m_output": 1.04,
-      "task_scores": {},
-      "source": "oss_overlay_2026_05_30"
+      "task_scores": {"tool_use": 0.3},
+      "source": "modelmeld_tool_eval_v1_2026_06_07"
     },
     {
       "model_id": "llama-3.3-70b-instruct",
@@ -37,8 +38,8 @@
       "context_window": 131072,
       "cost_per_m_input": 0.1,
       "cost_per_m_output": 0.32,
-      "task_scores": {},
-      "source": "oss_overlay_2026_05_30"
+      "task_scores": {"tool_use": 0.81},
+      "source": "modelmeld_tool_eval_v1_2026_06_07"
     },
     {
       "model_id": "deepseek-v4-pro",
@@ -57,8 +58,8 @@
       "context_window": 512000,
       "cost_per_m_input": 2.1,
       "cost_per_m_output": 4.4,
-      "task_scores": {},
-      "source": "oss_overlay_2026_05_30"
+      "task_scores": {"tool_use": 0.85},
+      "source": "modelmeld_tool_eval_v1_2026_06_07"
     },
     {
       "model_id": "deepseek-v4-pro",
@@ -67,8 +68,8 @@
       "context_window": 1048576,
       "cost_per_m_input": 0.44,
       "cost_per_m_output": 0.87,
-      "task_scores": {},
-      "source": "oss_overlay_2026_05_30"
+      "task_scores": {"tool_use": 0.85},
+      "source": "modelmeld_tool_eval_v1_2026_06_07"
     },
     {
       "model_id": "gpt-oss-120b",
@@ -77,8 +78,8 @@
       "context_window": 131072,
       "cost_per_m_input": 0.5,
       "cost_per_m_output": 0.5,
-      "task_scores": {},
-      "source": "oss_overlay_2026_05_30"
+      "task_scores": {"tool_use": 0.09},
+      "source": "modelmeld_tool_eval_v1_2026_06_07_inferred"
     },
     {
       "model_id": "gpt-oss-120b",
@@ -87,8 +88,8 @@
       "context_window": 131072,
       "cost_per_m_input": 0.15,
       "cost_per_m_output": 0.6,
-      "task_scores": {},
-      "source": "oss_overlay_2026_05_30"
+      "task_scores": {"tool_use": 0.09},
+      "source": "modelmeld_tool_eval_v1_2026_06_07"
     },
     {
       "model_id": "gpt-oss-120b",
@@ -97,8 +98,8 @@
       "context_window": 131072,
       "cost_per_m_input": 0.04,
       "cost_per_m_output": 0.18,
-      "task_scores": {},
-      "source": "oss_overlay_2026_05_30"
+      "task_scores": {"tool_use": 0.09},
+      "source": "modelmeld_tool_eval_v1_2026_06_07"
     },
     {
       "model_id": "kimi-k2.6",
@@ -107,8 +108,8 @@
       "context_window": 262144,
       "cost_per_m_input": 0.6,
       "cost_per_m_output": 0.6,
-      "task_scores": {},
-      "source": "oss_overlay_2026_05_30"
+      "task_scores": {"tool_use": 0.85},
+      "source": "modelmeld_tool_eval_v1_2026_06_07"
     },
     {
       "model_id": "kimi-k2.6",
@@ -117,8 +118,8 @@
       "context_window": 262144,
       "cost_per_m_input": 1.2,
       "cost_per_m_output": 4.5,
-      "task_scores": {},
-      "source": "oss_overlay_2026_05_30"
+      "task_scores": {"tool_use": 0.85},
+      "source": "modelmeld_tool_eval_v1_2026_06_07"
     },
     {
       "model_id": "phi-4",
@@ -127,8 +128,9 @@
       "context_window": 16384,
       "cost_per_m_input": 0.07,
       "cost_per_m_output": 0.14,
-      "task_scores": {},
-      "source": "oss_overlay_2026_05_30"
+      "task_scores": {"tool_use": 0.0},
+      "supports_tools": false,
+      "source": "modelmeld_tool_eval_v1_2026_06_07"
     },
     {
       "model_id": "qwen3-coder-next",
@@ -137,8 +139,8 @@
       "context_window": 262144,
       "cost_per_m_input": 0.11,
       "cost_per_m_output": 0.8,
-      "task_scores": {},
-      "source": "oss_overlay_2026_05_30"
+      "task_scores": {"tool_use": 0.85},
+      "source": "modelmeld_tool_eval_v1_2026_06_07"
     }
   ]
 }

--- a/src/modelmeld/scout/multi_provider_registry.py
+++ b/src/modelmeld/scout/multi_provider_registry.py
@@ -223,10 +223,16 @@ class MultiProviderModelRegistry(ModelRegistry):
         overlay_entries: list[ModelEntry] = []
         for row in overlay_payload.get("models", []):
             model_id = row["model_id"]
-            # Inherit task_scores: overlay row's own scores take
-            # precedence; otherwise inherit from base by model_id.
+            # Merge task_scores: start from the base entry's scores (by
+            # model_id) and let the overlay row OVERRIDE per-key. This lets a
+            # row supply a measured per-(model, provider) score (e.g. a
+            # tool_use score from the eval harness) without dropping the other
+            # categories it would otherwise inherit from base — a bare
+            # {"tool_use": x} row previously REPLACED all inherited scores,
+            # silently zeroing coding/reasoning for that row.
+            base_scores = scores_by_model.get(model_id, {})
             row_scores = dict(row.get("task_scores", {}))
-            scores = row_scores if row_scores else scores_by_model.get(model_id, {})
+            scores = {**base_scores, **row_scores}
             if not scores:
                 logger.warning(
                     "default_overlay: no task_scores available for %s "

--- a/tests/test_multi_provider_registry.py
+++ b/tests/test_multi_provider_registry.py
@@ -263,15 +263,52 @@ def test_load_default_overlay_models_have_multiple_providers() -> None:
 
 
 def test_load_default_overlay_task_scores_inherit_from_base() -> None:
-    """Overlay rows with empty task_scores inherit from base by model_id."""
+    """Overlay rows with empty task_scores inherit fully from base by model_id."""
     reg = MultiProviderModelRegistry.load_default()
-    # qwen3-coder-next@openrouter should inherit task_scores from the base
-    # qwen3-coder-next@vllm entry (overlay JSON has empty task_scores).
-    overlay_entry = reg.get_by_key("qwen3-coder-next", "openrouter")
-    base_entry = reg.get_by_key("qwen3-coder-next", "vllm")
+    # deepseek-v4-pro@fireworks has empty task_scores in the overlay JSON
+    # (eval was rate-limited there), so it inherits base scores wholesale.
+    overlay_entry = reg.get_by_key("deepseek-v4-pro", "fireworks")
+    base_entry = reg.get_by_key("deepseek-v4-pro", "vllm")
     assert overlay_entry is not None
     assert base_entry is not None
     assert overlay_entry.task_scores == base_entry.task_scores
+
+
+def test_load_default_overlay_task_scores_merge_over_base() -> None:
+    """A row's task_scores OVERRIDE base per-key; unspecified categories inherit.
+
+    Regression for the merge-semantics fix: a bare {"tool_use": x} row used to
+    REPLACE all inherited scores, silently zeroing coding/reasoning for that
+    (model, provider). It must now merge over base instead.
+    """
+    reg = MultiProviderModelRegistry.load_default()
+    # qwen3-coder-next@openrouter overrides tool_use (measured 0.85) but must
+    # still inherit coding/reasoning/etc from the base qwen3-coder-next@vllm.
+    overlay_entry = reg.get_by_key("qwen3-coder-next", "openrouter")
+    base_entry = reg.get_by_key("qwen3-coder-next", "vllm")
+    assert overlay_entry is not None and base_entry is not None
+    assert overlay_entry.task_scores["tool_use"] == 0.85  # overridden by measurement
+    assert overlay_entry.task_scores["tool_use"] != base_entry.task_scores["tool_use"]
+    assert overlay_entry.task_scores["coding"] == base_entry.task_scores["coding"]  # inherited
+    assert overlay_entry.task_scores["reasoning"] == base_entry.task_scores["reasoning"]
+
+
+def test_tool_use_routing_keeps_agentic_off_gpt_oss() -> None:
+    """Regression for the measured-overlay correction: agentic (tool_use) routing
+    must NOT land on gpt-oss-120b (measured ~0.1 on the eval) just because an
+    estimate said 0.8. Demoted below threshold on every hosted provider; the
+    pick goes to a model that actually passed the eval."""
+    reg = MultiProviderModelRegistry.load_default()
+    hosted = frozenset({"fireworks", "together", "openrouter"})
+    pick = reg.pick(
+        "tool_use", quality_threshold=0.80,
+        require_tool_support=True, eligible_providers=hosted,
+    )
+    assert pick is not None
+    assert pick.model_id != "gpt-oss-120b"
+    for entry in reg.all_entries_multi():
+        if entry.model_id == "gpt-oss-120b" and entry.provider in hosted:
+            assert entry.task_scores["tool_use"] < 0.80
 
 
 def test_load_default_overlay_supports_tools_inherits_from_base() -> None:

--- a/tests/test_server_registry_wiring.py
+++ b/tests/test_server_registry_wiring.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Regression: the gateway must default to the MULTI-provider registry.
+
+Defaulting `app.state.model_registry` to the base registry left OSS models on
+their unreachable `vllm` rows only, so capability routing saw no eligible OSS
+provider and fell back to frontier (-auto -> Haiku) or 400'd (-saver). The
+overlay that makes Fireworks/Together/OpenRouter routable was shipped but never
+loaded by the running app. This locks the wiring in place.
+"""
+from __future__ import annotations
+
+from modelmeld.api.server import build_app
+
+
+def test_default_app_loads_multi_provider_overlay() -> None:
+    app = build_app()
+    reg = app.state.model_registry
+
+    entries_fn = getattr(reg, "all_entries_multi", None)
+    assert entries_fn is not None, "default app must use a MultiProviderModelRegistry"
+
+    hosted = {"fireworks", "together", "openrouter"}
+    hosted_oss = {(e.model_id, e.provider) for e in entries_fn() if e.provider in hosted}
+
+    # The hosted OSS rows from the overlay must be present and routable.
+    assert ("deepseek-v4-pro", "openrouter") in hosted_oss
+    assert len(hosted_oss) >= 5, f"expected hosted OSS rows, got {sorted(hosted_oss)}"


### PR DESCRIPTION
## Summary

  The gateway shipped a multi-provider availability overlay (cloud OSS provider
  rows + costs) but never loaded it at runtime: `build_app()` defaulted
  `app.state.model_registry` to the base registry and passed it to `build_router`,
  so its "load the overlay when no registry is supplied" path never ran. OSS
  models existed only on their unreachable `vllm` rows, so capability routing had
  no eligible cloud OSS provider — `anthropic/modelmeld-auto` fell back to frontier
  (Haiku) and `anthropic/modelmeld-saver` returned `400 no_eligible_model`. This
  loads the overlay, fixes a score-merge bug it exposed, and replaces estimated
  `tool_use` scores with measured ones so routing picks OSS coders that actually
  complete multi-step agentic tool chains.

  ## Type of change

  - [x] Bug fix (non-breaking change that resolves an issue)
  - [x] New feature (measured per-provider `tool_use` scores; per-key score merge)
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Test-only change
  - [ ] Build / CI / tooling

  ## Test plan

  - `tests/test_server_registry_wiring.py` (new): the default app loads the
    multi-provider registry; cloud OSS rows are present and routable.
  - `tests/test_multi_provider_registry.py`: updated the inherit-from-base test for
    the new merge-over-base semantics; added a per-key override test (a row's
    `tool_use` overrides base while `coding`/`reasoning` are inherited, not wiped)
    and a regression test that a tool-bearing request does not route to
    gpt-oss-120b (measured ~0.1) and that it is demoted below threshold on every
    cloud provider.
  - Full suite: **1143 passed, 12 skipped**. `ruff check src tests`, `pyright src`,
    and `scripts/verify_boundary.py` all clean.
  - Manual: `registry.pick("tool_use", 0.80, require_tool_support=True, …)` now
    returns a strong OSS coder; previously it returned the weakest-measured model.

  ## Linked issues

  _None._

  ## Checklist

  - [x] Tests added/updated for the change
  - [x] Full suite + lint/type/boundary gates pass locally
  - [x] No breaking API/contract changes (routing decisions improve; wire formats unchanged)