### PR TITLE
fix(routing): keep default agentic routing off llama-3.3-70b (hallucinated completion)

### DIFF
--- a/src/modelmeld/scout/data/default_overlay.json
+++ b/src/modelmeld/scout/data/default_overlay.json
@@ -38,8 +38,8 @@
       "context_window": 131072,
       "cost_per_m_input": 0.1,
       "cost_per_m_output": 0.32,
-      "task_scores": {"tool_use": 0.81},
-      "source": "modelmeld_tool_eval_v1_2026_06_07"
+      "task_scores": {"tool_use": 0.55},
+      "source": "modelmeld_agentic_obs_2026_06_08"
     },
     {
       "model_id": "deepseek-v4-pro",

--- a/tests/test_multi_provider_registry.py
+++ b/tests/test_multi_provider_registry.py
@@ -311,6 +311,28 @@ def test_tool_use_routing_keeps_agentic_off_gpt_oss() -> None:
             assert entry.task_scores["tool_use"] < 0.80
 
 
+def test_default_threshold_agentic_routing_avoids_sustain_failers() -> None:
+    """Out-of-box guard: at the DEFAULT quality threshold (0.70), a tool-bearing
+    request must not route to a model observed to fail sustained agentic work.
+    gpt-oss-120b (eval ~0.1) and llama-3.3-70b (hallucinated completion on a real
+    ticket) are both demoted below 0.70 for tool_use, so the default pick is a
+    sustain-capable coder. Prevents the footgun where -saver/-auto silently sent
+    agentic coding to a model that declares victory without doing the work."""
+    reg = MultiProviderModelRegistry.load_default()
+    hosted = frozenset({"fireworks", "together", "openrouter"})
+    pick = reg.pick(
+        "tool_use", quality_threshold=0.70,
+        require_tool_support=True, eligible_providers=hosted,
+    )
+    assert pick is not None
+    assert pick.model_id not in {"gpt-oss-120b", "llama-3.3-70b-instruct"}
+    # llama keeps a usable non-agentic (coding) score — only tool_use is demoted.
+    for entry in reg.all_entries_multi():
+        if entry.model_id == "llama-3.3-70b-instruct" and entry.provider == "openrouter":
+            assert entry.task_scores["tool_use"] < 0.70
+            assert entry.task_scores["coding"] >= 0.70
+
+
 def test_load_default_overlay_supports_tools_inherits_from_base() -> None:
     """Conservative AND: if base says no-tools, overlay row also says no-tools."""
     reg = MultiProviderModelRegistry.load_default()


### PR DESCRIPTION
## Summary

  Dogfooding `-saver` on a real ticket (after the 0.12.0 overlay-loading fix)
  surfaced an out-of-box footgun: `llama-3.3-70b`/openrouter is the cheapest
  `tool_use` passer at the default 0.70 threshold, so `-saver`/`-auto` silently
  routed agentic coding to it — and it **hallucinated completion** (2 turns, zero
  edits, returned a confident summary claiming it ran the gates and passed the
  suite). The v1 tool-use eval over-rated it (0.95) because single tool-call
  correctness does not predict sustained multi-turn agentic completion.

  This demotes `llama-3.3-70b`/openrouter's `tool_use` to 0.55 (below the 0.70
  floor) so default agentic routing skips it, mirroring the earlier gpt-oss-120b
  correction. Its coding/reasoning scores are preserved via the per-key overlay
  merge, so it stays usable for non-agentic work. At the default threshold a
  tool-bearing request now routes to `qwen3-coder-next`, which was verified to
  implement a real ticket end-to-end (160 turns, all gates green).

  This is provisional and conservative — based on a single real-ticket
  observation. The failure mode (a model that fabricates completion) is severe and
  the demotion is the safe direction, so it is warranted now; a measured
  agentic-sustain signal will replace this estimate.

  ## Type of change

  - [x] Bug fix (non-breaking change that resolves an issue)
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Test-only change
  - [ ] Build / CI / tooling

  ## Test plan

  - `tests/test_multi_provider_registry.py`: added
    `test_default_threshold_agentic_routing_avoids_sustain_failers` — at the
    default 0.70 threshold a tool-bearing request routes to neither gpt-oss-120b
    nor llama-3.3-70b, and llama retains a usable coding score (only `tool_use` is
    demoted).
  - Full suite: **1144 passed, 12 skipped**. `ruff`, `pyright`, and
    `verify_boundary.py` clean.
  - Manual: `registry.pick("tool_use", 0.70, require_tool_support=True, …)` now
    returns `qwen3-coder-next`; llama rows are excluded at the default floor.

  ## Linked issues

  _None._

  ## Checklist

  - [x] Tests added/updated
  - [x] Full suite + lint/type/boundary gates pass locally
  - [x] No breaking API/contract changes (routing decision improves)