### PR TITLE
fix(adapters): wrap stream-iteration errors as AdapterError so failover engages

### DIFF
--- a/src/modelmeld/adapters/anthropic_adapter.py
+++ b/src/modelmeld/adapters/anthropic_adapter.py
@@ -281,11 +281,22 @@ class AnthropicAdapter(ProviderAdapter):
                 e, "Anthropic stream_chat call failed",
             ) from e
 
+        # Wrap iteration errors as AdapterError too (a stream that opens 200
+        # then errors mid-flight). Unwrapped, they escape past
+        # `_try_open_stream_native` — which only catches AdapterError — and
+        # bypass the router's failover, surfacing as a 500 instead of a clean
+        # 502/failover. GeneratorExit / CancelledError are BaseException, so
+        # consumer-side close/cancel is not swallowed.
         translator = AnthropicStreamTranslator()
-        async for event in stream:
-            chunk = translator.translate_event(event.model_dump())
-            if chunk is not None:
-                yield chunk
+        try:
+            async for event in stream:
+                chunk = translator.translate_event(event.model_dump())
+                if chunk is not None:
+                    yield chunk
+        except Exception as e:
+            raise wrap_as_adapter_error(
+                e, "Anthropic stream_chat stream interrupted",
+            ) from e
 
     async def _stream_chat_via_oauth(
         self,

--- a/src/modelmeld/adapters/openai_adapter.py
+++ b/src/modelmeld/adapters/openai_adapter.py
@@ -111,8 +111,21 @@ class OpenAIAdapter(ProviderAdapter):
             raise wrap_as_adapter_error(
                 e, "OpenAI stream_chat call failed",
             ) from e
-        async for chunk in stream:
-            yield ChatCompletionChunk.model_validate(chunk.model_dump())
+        # Errors raised DURING iteration (e.g. a provider that opens the stream
+        # 200 then injects an SSE error event, which the SDK re-raises as a bare
+        # APIError) must also be wrapped as AdapterError. Otherwise they escape
+        # uncaught past `_try_open_stream_native` (which only catches
+        # AdapterError), bypassing the router's failover and surfacing as a 500
+        # instead of a clean 502/failover. GeneratorExit / CancelledError are
+        # BaseException, not Exception, so consumer-side close/cancel passes
+        # through untouched.
+        try:
+            async for chunk in stream:
+                yield ChatCompletionChunk.model_validate(chunk.model_dump())
+        except Exception as e:
+            raise wrap_as_adapter_error(
+                e, "OpenAI stream_chat stream interrupted",
+            ) from e
 
     async def health(self) -> bool:
         try:

--- a/tests/test_adapter_anthropic.py
+++ b/tests/test_adapter_anthropic.py
@@ -173,6 +173,43 @@ async def test_stream_chat_wraps_upstream_error() -> None:
             pass
 
 
+class _FakeStreamRaisingMidway:
+    """Opens fine, yields one event, then raises during iteration."""
+
+    def __init__(self, event: SimpleNamespace, exc: Exception) -> None:
+        self._event = event
+        self._exc = exc
+        self._yielded = False
+
+    def __aiter__(self) -> _FakeStreamRaisingMidway:
+        return self
+
+    async def __anext__(self) -> SimpleNamespace:
+        if not self._yielded:
+            self._yielded = True
+            return self._event
+        raise self._exc
+
+
+async def test_stream_chat_wraps_mid_stream_errors_in_adapter_error() -> None:
+    # Regression: an error raised DURING iteration (stream opened 200, then
+    # errored) must be wrapped as AdapterError, not escape uncaught past
+    # `_try_open_stream_native` and surface as a 500 instead of failover.
+    adapter = AnthropicAdapter(api_key="test-key")
+    start = _event({
+        "type": "message_start",
+        "message": {"id": "msg_s_1", "model": "claude-sonnet-4-6"},
+    })
+    adapter._client.messages.create = AsyncMock(  # type: ignore[method-assign]
+        return_value=_FakeStreamRaisingMidway(
+            start, RuntimeError("anthropic mid-stream overloaded"),
+        )
+    )
+    with pytest.raises(AdapterError, match="stream interrupted"):
+        async for _ in adapter.stream_chat(_request()):
+            pass
+
+
 # ---------------------------------------------------------------------------
 # Health
 # ---------------------------------------------------------------------------

--- a/tests/test_adapter_openai.py
+++ b/tests/test_adapter_openai.py
@@ -125,6 +125,68 @@ async def test_stream_chat_yields_converted_chunks() -> None:
     assert collected[-1].choices[0].finish_reason == "stop"
 
 
+class _FakeAsyncStreamRaisingMidway:
+    """Opens fine, yields one chunk, then raises during iteration — models a
+    provider that returns 200 then injects an SSE error event."""
+
+    def __init__(self, chunk: SDKChatCompletionChunk, exc: Exception) -> None:
+        self._chunk = chunk
+        self._exc = exc
+        self._yielded = False
+
+    def __aiter__(self) -> _FakeAsyncStreamRaisingMidway:
+        return self
+
+    async def __anext__(self) -> SDKChatCompletionChunk:
+        if not self._yielded:
+            self._yielded = True
+            return self._chunk
+        raise self._exc
+
+
+async def test_stream_chat_wraps_mid_stream_errors_in_adapter_error() -> None:
+    # Regression: an error raised DURING stream iteration (not at open) must be
+    # wrapped as AdapterError so it can fail over instead of escaping as a 500.
+    adapter = OpenAIAdapter(api_key="test-key")
+    first = SDKChatCompletionChunk.model_validate({
+        "id": "chatcmpl-x", "object": "chat.completion.chunk", "created": 1,
+        "model": "gpt-4o-mini",
+        "choices": [{"index": 0, "delta": {"role": "assistant", "content": "Hi"},
+                     "finish_reason": None}],
+    })
+    adapter._client.chat.completions.create = AsyncMock(  # type: ignore[method-assign]
+        return_value=_FakeAsyncStreamRaisingMidway(
+            first, RuntimeError("Provider returned error"),
+        )
+    )
+
+    with pytest.raises(AdapterError, match="stream interrupted"):
+        async for _ in adapter.stream_chat(_request()):
+            pass
+
+
+async def test_stream_chat_error_on_first_chunk_wraps_as_adapter_error() -> None:
+    # The failover-critical case: the error surfaces on the FIRST __anext__()
+    # (what `_try_open_stream_native` awaits), so it must be an AdapterError for
+    # the router to catch it and route to a fallback rather than 500.
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    class _RaisesImmediately:
+        def __aiter__(self) -> _RaisesImmediately:
+            return self
+
+        async def __anext__(self) -> SDKChatCompletionChunk:
+            raise RuntimeError("Provider returned error")
+
+    adapter._client.chat.completions.create = AsyncMock(  # type: ignore[method-assign]
+        return_value=_RaisesImmediately()
+    )
+
+    agen = adapter.stream_chat(_request())
+    with pytest.raises(AdapterError, match="stream interrupted"):
+        await agen.__anext__()
+
+
 async def test_health_true_on_success() -> None:
     adapter = OpenAIAdapter(api_key="test-key")
     adapter._client.models.list = AsyncMock(return_value=MagicMock())  # type: ignore[method-assign]


### PR DESCRIPTION
## Summary

  `OpenAIAdapter.stream_chat` and `AnthropicAdapter.stream_chat` only wrapped
  errors from *opening* the stream; an error raised *during* iteration escaped
  uncaught. A provider can open the stream 200 and then inject an SSE error event,
  which the SDK re-raises as a bare `APIError` mid-iteration. That exception
  propagated past `_try_open_stream_native` — which only catches `AdapterError` —
  bypassing the router's failover and surfacing as a 500 instead of a clean
  502/failover. This wraps the iteration loop in both adapters so those errors are
  classified and the router can fail over.

  ## Type of change

  - [x] Bug fix (non-breaking change that resolves an issue)

  ## Test plan

  - `tests/test_adapter_openai.py`, `tests/test_adapter_anthropic.py` — new tests:
    an error mid-iteration and an error on the first chunk both surface as
    `AdapterError` (the first-chunk case is what `_try_open_stream_native` awaits,
    so it's the failover-critical one). Existing happy-path stream tests unchanged.
  - Confirmed `GeneratorExit`/`CancelledError` (BaseException) are *not* swallowed,
    so consumer-side close/cancel still propagates.
  - Full suite passes: 1150 passed, 12 skipped. ruff + pyright + boundary clean.