### PR TITLE
fix(api): log full credential-redacted upstream error on 5xx failover

### DIFF
--- a/src/modelmeld/api/_safe_error_detail.py
+++ b/src/modelmeld/api/_safe_error_detail.py
@@ -33,20 +33,37 @@ _SENSITIVE_PATTERNS: tuple[re.Pattern[str], ...] = (
 _MAX_DETAIL_LEN = 240
 
 
+def redact_sensitive(text: str) -> str:
+    """Strip credential-shape substrings from a string. No length bound.
+
+    For SERVER-SIDE logs, where an operator needs the full upstream detail
+    (e.g. a provider's complete `invalid_parameter` message) but secrets must
+    still never be written to disk. Do NOT echo the result into an HTTP
+    response body — use `safe_error_detail` for anything client-facing.
+    """
+    for pattern in _SENSITIVE_PATTERNS:
+        text = pattern.sub("[REDACTED]", text)
+    return text
+
+
 def safe_error_detail(error: object, default: str = "upstream error") -> str:
     """Return a sanitized error-detail string for HTTP response echo.
 
     - Coerces `error` to string
     - Replaces credential-shape substrings with "[REDACTED]"
-    - Truncates to a fixed max length to bound unbounded leakage
+    - Truncates to a fixed max length to bound unbounded leakage into the
+      response body, which an unauthenticated caller may observe
     - Falls back to `default` for empty input
+
+    The length bound is a deliberate security measure; when you need the full
+    detail for diagnosis, log `redact_sensitive(str(error))` server-side
+    instead of widening this.
     """
     text = str(error) if error is not None else ""
     if not text:
         return default
 
-    for pattern in _SENSITIVE_PATTERNS:
-        text = pattern.sub("[REDACTED]", text)
+    text = redact_sensitive(text)
 
     if len(text) > _MAX_DETAIL_LEN:
         text = text[: _MAX_DETAIL_LEN - 16] + "...[truncated]"

--- a/src/modelmeld/api/routes/messages.py
+++ b/src/modelmeld/api/routes/messages.py
@@ -32,7 +32,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from modelmeld.adapters import AdapterError
 from modelmeld.adapters.anthropic_adapter import AnthropicAdapter
-from modelmeld.api._safe_error_detail import safe_error_detail
+from modelmeld.api._safe_error_detail import redact_sensitive, safe_error_detail
 from modelmeld.api.auth_detection import AuthKind, classify_authorization
 from modelmeld.api.byok import (
     build_byok_adapters,
@@ -553,6 +553,10 @@ async def anthropic_messages(
     except AdapterError as primary:
         fallback = await rt.route_after_failure(decision, outgoing, error=primary)
         if fallback is None:
+            logger.warning(
+                "chat failed, no fallback available: %s",
+                redact_sensitive(str(primary)),
+            )
             await _fire_failure(
                 hooks, request_id, started, outgoing, decision, redactions, None,
                 primary, "adapter_error", identity,
@@ -565,6 +569,10 @@ async def anthropic_messages(
                 decision.adapter, outgoing, decision, body, extra_anthropic_headers,
             )
         except AdapterError as secondary:
+            logger.warning(
+                "chat primary + fallback both failed: primary=%s; fallback=%s",
+                redact_sensitive(str(primary)), redact_sensitive(str(secondary)),
+            )
             await _fire_failure(
                 hooks, request_id, started, outgoing, decision, redactions,
                 failover_from, secondary, "adapter_error", identity,
@@ -770,6 +778,14 @@ async def _stream_messages_with_failover(
         )
         if fallback is None:
             err = primary_error or AdapterError("primary stream open failed")
+            # Log the FULL (credential-redacted) upstream error server-side; the
+            # client only gets the length-bounded safe_error_detail below, which
+            # can truncate away the provider's real reason (e.g. an upstream
+            # invalid_parameter message). The log is the diagnostic record.
+            logger.warning(
+                "stream open failed, no fallback available: %s",
+                redact_sensitive(str(err)),
+            )
             await _fire_failure(
                 hooks, request_id, started, request, decision, redactions, None,
                 err, "adapter_error", identity,
@@ -777,7 +793,7 @@ async def _stream_messages_with_failover(
             raise HTTPException(status_code=502, detail=safe_error_detail(err))
         failover_from = str(decision.tier)
         decision = fallback
-        primary_aiter, first_chunk, _ = await _try_open_stream_native(
+        primary_aiter, first_chunk, fallback_error = await _try_open_stream_native(
             decision.adapter,
             _apply_model_override(request, decision),
             native_request,  # type: ignore[arg-type]
@@ -785,9 +801,14 @@ async def _stream_messages_with_failover(
             model_override=decision.model_id_override,
         )
         if primary_aiter is None and first_chunk is None:
+            fb_err = fallback_error or AdapterError("fallback stream open failed")
+            logger.warning(
+                "fallback stream open also failed: %s",
+                redact_sensitive(str(fb_err)),
+            )
             await _fire_failure(
                 hooks, request_id, started, request, decision, redactions,
-                failover_from, AdapterError("fallback stream open failed"),
+                failover_from, fb_err,
                 "adapter_error", identity,
             )
             raise HTTPException(status_code=502, detail="fallback stream open failed")

--- a/tests/test_safe_error_detail.py
+++ b/tests/test_safe_error_detail.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""Tests for error-detail sanitization.
+
+`safe_error_detail` is client-facing: it redacts credentials AND bounds length
+(an unauthenticated caller may observe the response body). `redact_sensitive`
+is the server-side-log variant: it redacts credentials but does NOT truncate,
+so operators get the provider's full error (e.g. a complete upstream
+`invalid_parameter` message) in the logs without secrets leaking to disk.
+"""
+
+from __future__ import annotations
+
+from modelmeld.api._safe_error_detail import (
+    _MAX_DETAIL_LEN,
+    redact_sensitive,
+    safe_error_detail,
+)
+
+
+def test_redact_sensitive_strips_credentials() -> None:
+    text = "auth failed for sk-ant-api03-" + "A" * 40 + " on request"
+    out = redact_sensitive(text)
+    assert "sk-ant" not in out
+    assert "[REDACTED]" in out
+
+
+def test_redact_sensitive_does_not_truncate() -> None:
+    # The whole point of the log variant: full length preserved so the
+    # provider's real reason survives.
+    long_detail = "InternalError.Algo.InvalidParameter: " + "x" * 5000
+    out = redact_sensitive(long_detail)
+    assert len(out) == len(long_detail)
+    assert "[truncated]" not in out
+
+
+def test_safe_error_detail_still_truncates() -> None:
+    out = safe_error_detail("y" * (_MAX_DETAIL_LEN + 500))
+    assert len(out) <= _MAX_DETAIL_LEN
+    assert out.endswith("...[truncated]")
+
+
+def test_safe_error_detail_redacts_then_bounds() -> None:
+    out = safe_error_detail("key sk-proj-" + "B" * 60 + " rejected")
+    assert "sk-proj" not in out
+    assert "[REDACTED]" in out
+
+
+def test_safe_error_detail_empty_falls_back_to_default() -> None:
+    assert safe_error_detail("") == "upstream error"
+    assert safe_error_detail(None) == "upstream error"
+    assert safe_error_detail("", default="custom") == "custom"


### PR DESCRIPTION
## Summary

  When an upstream provider rejects a request, the gateway echoed only
  `safe_error_detail()` into the 502 body — which is deliberately length-bounded
  (240 chars) because an unauthenticated caller can observe the response. That
  bound truncates away the provider's actual reason (e.g. a strict
  OpenAI-compatible backend's full `invalid_parameter` message), leaving operators
  no diagnostic record of why a failover exhausted. This adds `redact_sensitive()`
  (same credential redaction, no length bound) and logs the full redacted upstream
  error server-side at each 5xx failover site (streaming + non-streaming), keeping
  the client response bounded. Also captures the previously-discarded
  fallback-stream error so it's logged rather than a generic placeholder.

  ## Type of change

  - [x] Bug fix (non-breaking change that resolves an issue)

  ## Test plan

  - New `tests/test_safe_error_detail.py`: redaction strips credentials, the log
    variant does NOT truncate, the client variant still truncates + redacts, empty
    falls back to default. Full suite: 1155 passed, 12 skipped. ruff + pyright +
    boundary clean.