### PR TITLE
feat(api): add GET /metrics local request/spend observability surface

### DIFF
--- a/src/modelmeld/api/routes/chat.py
+++ b/src/modelmeld/api/routes/chat.py
@@ -10,7 +10,9 @@ import os
 import time
 import uuid
 from collections.abc import AsyncIterator
+from contextvars import ContextVar
 from datetime import datetime, timezone
+from typing import NamedTuple
 
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import StreamingResponse
@@ -60,13 +62,94 @@ from modelmeld.memory import (
     extract_memory_identity,
     inject_into_request,
 )
+from modelmeld.metrics import MetricsCollector
 from modelmeld.privacy import Redaction, Scrubber
 from modelmeld.router import Router, RouterError, RoutingDecision
+from modelmeld.scout.registry import ModelRegistry
 from modelmeld.tokens import TokenCounter
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+class _MetricsContext(NamedTuple):
+    """Request-scoped sink for the in-process metrics collector.
+
+    Set at each route entry (chat / messages / responses) and read by the
+    success-firing helpers, so they can record metrics WITHOUT going through
+    the hook system — hooks are the enterprise seam and stay zero-subscriber by
+    default in OSS, but metrics is a built-in local surface that must record on
+    every successful request regardless.
+    """
+
+    collector: MetricsCollector
+    registry: ModelRegistry | None
+    wire_format: str
+
+
+_metrics_sink: ContextVar[_MetricsContext | None] = ContextVar(
+    "modelmeld_metrics_sink", default=None,
+)
+
+
+def set_metrics_context(
+    collector: MetricsCollector | None,
+    registry: ModelRegistry | None,
+    wire_format: str,
+) -> None:
+    """Install the per-request metrics sink. No-op when metrics isn't configured
+    (e.g. an app built without `app.state.metrics`). Call once at route entry."""
+    if collector is None:
+        return
+    _metrics_sink.set(_MetricsContext(collector, registry, wire_format))
+
+
+def _resolve_model_served(
+    request: ChatCompletionRequest, decision: RoutingDecision | None,
+) -> str:
+    """Canonical id of the model actually served — the capability-routing
+    override when one was applied, else the requested model."""
+    if decision is not None and decision.model_id_override:
+        return decision.model_id_override
+    return request.model
+
+
+def _record_metrics(
+    request: ChatCompletionRequest,
+    decision: RoutingDecision | None,
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    total_tokens: int,
+) -> None:
+    """Record one successful request into the per-request metrics sink, if set.
+
+    Actual blended cost = (total_tokens / 1M) * the routed model's registry
+    rate; 0.0 when the rate is unknown. Best-effort — never raises into the
+    request path.
+    """
+    ctx = _metrics_sink.get()
+    if ctx is None:
+        return
+    try:
+        model_id = _resolve_model_served(request, decision) or (
+            decision.adapter.name if decision is not None else ""
+        )
+        cost = 0.0
+        if ctx.registry is not None and model_id:
+            entry = ctx.registry.get(model_id)
+            if entry is not None:
+                cost = (total_tokens / 1_000_000.0) * entry.blended_cost_per_m()
+        ctx.collector.record(
+            wire_format=ctx.wire_format,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            model_id=model_id,
+            cost_usd=cost,
+        )
+    except Exception:
+        logger.exception("metrics recording failed")
 
 
 @router.post("/chat/completions", response_model=None)
@@ -78,6 +161,11 @@ async def chat_completions(
     rt: Router = fastapi_request.app.state.router
     scrubber: Scrubber | None = fastapi_request.app.state.scrubber
     hooks: HookRegistry = fastapi_request.app.state.hooks
+    set_metrics_context(
+        getattr(fastapi_request.app.state, "metrics", None),
+        getattr(fastapi_request.app.state, "model_registry", None),
+        "chat_completions",
+    )
     provider: MemoryProvider | None = getattr(fastapi_request.app.state, "memory_provider", None)
     token_counter: TokenCounter | None = getattr(fastapi_request.app.state, "token_counter", None)
     completion_cache: CompletionCache | None = getattr(
@@ -788,14 +876,24 @@ async def _fire_success(
     identity: dict[str, str | None] | None,
     cache_status: str | None = None,
 ) -> None:
+    usage = completion.usage
+    in_tok = usage.prompt_tokens if usage else 0
+    out_tok = usage.completion_tokens if usage else 0
+    total = usage.total_tokens if usage else 0
+    # Record local metrics regardless of hook subscribers (hooks are the
+    # enterprise seam; metrics is a built-in surface). Cheap; runs before the
+    # subscriber_count early-return that gates the more expensive event build.
+    _record_metrics(
+        request, decision,
+        input_tokens=in_tok, output_tokens=out_tok, total_tokens=total,
+    )
     if not hooks.subscriber_count:
         return
-    usage = completion.usage
     event = _build_event(
         request_id, started, request, decision, redactions, failover_from,
-        input_tokens=usage.prompt_tokens if usage else 0,
-        output_tokens=usage.completion_tokens if usage else 0,
-        total_tokens=usage.total_tokens if usage else 0,
+        input_tokens=in_tok,
+        output_tokens=out_tok,
+        total_tokens=total,
         error=None,
         error_type=None,
         identity=identity,
@@ -816,8 +914,6 @@ async def _fire_success_stream(
     last_usage: object | None,
     identity: dict[str, str | None] | None,
 ) -> None:
-    if not hooks.subscriber_count:
-        return
     if last_usage is not None:
         in_tok = last_usage.prompt_tokens  # type: ignore[attr-defined]
         out_tok = last_usage.completion_tokens  # type: ignore[attr-defined]
@@ -826,6 +922,13 @@ async def _fire_success_stream(
         in_tok = 0
         out_tok = estimated_output_tokens
         total = estimated_output_tokens
+    # Record local metrics regardless of hook subscribers (see _fire_success).
+    _record_metrics(
+        request, decision,
+        input_tokens=in_tok, output_tokens=out_tok, total_tokens=total,
+    )
+    if not hooks.subscriber_count:
+        return
     event = _build_event(
         request_id, started, request, decision, redactions, failover_from,
         input_tokens=in_tok,
@@ -889,12 +992,10 @@ def _build_event(
     routed_to = decision.adapter.name if decision is not None else ""
     tier = str(decision.tier) if decision is not None else ""
     # Capability routing fields (FinOps consumes these for savings math).
-    model_served = request.model
+    model_served = _resolve_model_served(request, decision)
     task_category = None
     quality_threshold: float | None = None
     if decision is not None:
-        if decision.model_id_override:
-            model_served = decision.model_id_override
         cap = getattr(decision, "capability_decision", None)
         if cap is not None:
             task_category = getattr(cap, "task_category", None)

--- a/src/modelmeld/api/routes/messages.py
+++ b/src/modelmeld/api/routes/messages.py
@@ -55,6 +55,7 @@ from modelmeld.api.routes.chat import (
     _routing_headers,
     _write_memory_turns,
     _write_memory_turns_streaming,
+    set_metrics_context,
 )
 from modelmeld.api.routing_hints import (
     RoutingHintError,
@@ -294,6 +295,11 @@ async def anthropic_messages(
     rt: Router = fastapi_request.app.state.router
     scrubber: Scrubber | None = fastapi_request.app.state.scrubber
     hooks: HookRegistry = fastapi_request.app.state.hooks
+    set_metrics_context(
+        getattr(fastapi_request.app.state, "metrics", None),
+        getattr(fastapi_request.app.state, "model_registry", None),
+        "messages",
+    )
     provider: MemoryProvider | None = getattr(
         fastapi_request.app.state, "memory_provider", None,
     )

--- a/src/modelmeld/api/routes/metrics.py
+++ b/src/modelmeld/api/routes/metrics.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""GET /metrics — process-local request/spend observability surface.
+
+Returns the current snapshot of the app's in-process MetricsCollector
+(`app.state.metrics`) as JSON. Basic single-process surface; no enterprise
+features (multi-tenant / per-key / persisted analytics stay enterprise).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from modelmeld.metrics import MetricsCollector, MetricsSnapshot
+
+router = APIRouter()
+
+
+def _serialize(snap: MetricsSnapshot) -> dict:
+    return {
+        "chat_completions_count": snap.chat_completions_count,
+        "messages_count": snap.messages_count,
+        "responses_count": snap.responses_count,
+        "total_request_count": snap.total_request_count,
+        "total_input_tokens": snap.total_input_tokens,
+        "total_output_tokens": snap.total_output_tokens,
+        "total_tokens": snap.total_tokens,
+        "total_cost_usd": snap.total_cost_usd,
+        "per_model": {
+            model_id: {
+                "request_count": m.request_count,
+                "input_tokens": m.input_tokens,
+                "output_tokens": m.output_tokens,
+                "total_tokens": m.total_tokens,
+                "cost_usd": m.cost_usd,
+            }
+            for model_id, m in snap.per_model.items()
+        },
+    }
+
+
+@router.get("/metrics")
+async def get_metrics(request: Request) -> dict:
+    """Return the current process-local metrics snapshot as JSON."""
+    collector: MetricsCollector | None = getattr(request.app.state, "metrics", None)
+    if collector is None:
+        # Defensive: build_app always installs one, but never 500 if absent.
+        return _serialize(MetricsCollector().snapshot())
+    return _serialize(collector.snapshot())

--- a/src/modelmeld/api/routes/responses.py
+++ b/src/modelmeld/api/routes/responses.py
@@ -44,6 +44,7 @@ from modelmeld.api.routes.chat import (
     _routing_headers,
     _try_open_stream,
     _write_memory_turns_streaming,
+    set_metrics_context,
 )
 from modelmeld.api.routing_hints import RoutingHintError, extract_hints_from_headers
 from modelmeld.api.schemas_responses import ResponsesRequest
@@ -83,6 +84,11 @@ async def responses(
     rt: Router = fastapi_request.app.state.router
     scrubber: Scrubber | None = fastapi_request.app.state.scrubber
     hooks: HookRegistry = fastapi_request.app.state.hooks
+    set_metrics_context(
+        getattr(fastapi_request.app.state, "metrics", None),
+        getattr(fastapi_request.app.state, "model_registry", None),
+        "responses",
+    )
     provider: MemoryProvider | None = getattr(
         fastapi_request.app.state, "memory_provider", None,
     )

--- a/src/modelmeld/api/server.py
+++ b/src/modelmeld/api/server.py
@@ -23,6 +23,7 @@ from modelmeld.memory import (
     PostgresMemoryStore,
     TieredMemoryProvider,
 )
+from modelmeld.metrics import MetricsCollector
 from modelmeld.privacy import Scrubber, build_scrubber
 from modelmeld.router import Router, SingleAdapterRouter, build_router
 from modelmeld.scout import ModelRegistry, Scout, build_scout
@@ -95,6 +96,11 @@ def build_app(
     # resolvers already prefer its `all_entries_multi`, so this is strictly
     # more correct for every consumer.
     app.state.model_registry = model_registry or default_multi_provider_registry()
+
+    # In-process request/spend metrics collector (GET /metrics). One per app so
+    # a freshly built app starts zeroed. Updated directly from the route success
+    # paths (not via the HookRegistry, which is the enterprise seam).
+    app.state.metrics = MetricsCollector()
     # Tiered memory. Default: in-process backend for dev/tests; operators can
     # opt into a SQL-backed store with MODELMELD_MEMORY_BACKEND=postgres.
     if memory_store is not None:
@@ -142,6 +148,7 @@ def build_app(
         chat,
         healthz,
         messages,
+        metrics,
         models,
         responses,
         version,
@@ -149,6 +156,7 @@ def build_app(
 
     app.include_router(healthz.router)
     app.include_router(version.router)
+    app.include_router(metrics.router)
     app.include_router(models.router, prefix="/v1")
     app.include_router(chat.router, prefix="/v1")
     app.include_router(messages.router, prefix="/v1")

--- a/src/modelmeld/metrics.py
+++ b/src/modelmeld/metrics.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""In-process request/spend metrics — a basic local observability surface.
+
+Thread-safe collector that accumulates, since process start: request count
+(broken down by inbound wire format), summed prompt/completion/total tokens, a
+per-routed-model breakdown, and summed *actual* blended cost (the routed
+model's registry rate times its tokens). One collector instance lives on
+`app.state.metrics`; `GET /metrics` returns its snapshot.
+
+Deliberately minimal and single-process. Multi-tenant, per-API-key, RBAC-gated,
+or persisted analytics are out of scope (those are enterprise concerns). This
+module imports nothing from the API or enterprise packages.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+
+# Inbound wire formats we break request counts down by.
+WIRE_FORMATS: tuple[str, ...] = ("chat_completions", "messages", "responses")
+
+
+@dataclass(frozen=True)
+class ModelMetrics:
+    """Accumulated metrics for a single routed model id."""
+
+    request_count: int
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    cost_usd: float
+
+
+@dataclass(frozen=True)
+class MetricsSnapshot:
+    """Immutable point-in-time view of the collector."""
+
+    chat_completions_count: int
+    messages_count: int
+    responses_count: int
+    total_request_count: int
+
+    total_input_tokens: int
+    total_output_tokens: int
+    total_tokens: int
+
+    total_cost_usd: float
+
+    per_model: dict[str, ModelMetrics]
+
+
+class MetricsCollector:
+    """Thread-safe in-process metrics accumulator.
+
+    One instance per app (on `app.state.metrics`), so a freshly built app
+    starts with zeroed counters — important for test isolation and for
+    not leaking state across processes.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._wire_counts: dict[str, int] = {fmt: 0 for fmt in WIRE_FORMATS}
+        self._input_tokens = 0
+        self._output_tokens = 0
+        self._cost_usd = 0.0
+        # model_id -> [count, input_tokens, output_tokens, cost_usd]
+        self._model_stats: dict[str, list[float]] = {}
+
+    def record(
+        self,
+        *,
+        wire_format: str,
+        input_tokens: int,
+        output_tokens: int,
+        model_id: str,
+        cost_usd: float,
+    ) -> None:
+        """Record one completed request. `cost_usd` is the caller-computed
+        actual blended cost (tokens x the routed model's rate); pass 0.0 when
+        no rate is known for the routed model."""
+        with self._lock:
+            self._wire_counts[wire_format] = self._wire_counts.get(wire_format, 0) + 1
+            self._input_tokens += input_tokens
+            self._output_tokens += output_tokens
+            self._cost_usd += cost_usd
+
+            key = model_id or "unknown"
+            stats = self._model_stats.get(key)
+            if stats is None:
+                stats = [0, 0, 0, 0.0]
+                self._model_stats[key] = stats
+            stats[0] += 1
+            stats[1] += input_tokens
+            stats[2] += output_tokens
+            stats[3] += cost_usd
+
+    def snapshot(self) -> MetricsSnapshot:
+        with self._lock:
+            per_model = {
+                model_id: ModelMetrics(
+                    request_count=int(s[0]),
+                    input_tokens=int(s[1]),
+                    output_tokens=int(s[2]),
+                    total_tokens=int(s[1]) + int(s[2]),
+                    cost_usd=float(s[3]),
+                )
+                for model_id, s in self._model_stats.items()
+            }
+            return MetricsSnapshot(
+                chat_completions_count=self._wire_counts.get("chat_completions", 0),
+                messages_count=self._wire_counts.get("messages", 0),
+                responses_count=self._wire_counts.get("responses", 0),
+                # Sum ALL buckets (not just the three named) so an unexpected
+                # wire_format can't desync the total from the per-format counts.
+                total_request_count=sum(self._wire_counts.values()),
+                total_input_tokens=self._input_tokens,
+                total_output_tokens=self._output_tokens,
+                total_tokens=self._input_tokens + self._output_tokens,
+                total_cost_usd=self._cost_usd,
+                per_model=per_model,
+            )

--- a/tests/test_route_metrics.py
+++ b/tests/test_route_metrics.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""Integration tests for the GET /metrics observability surface (A-1).
+
+Drives the in-process app with a mock adapter (no real backend) and asserts the
+collector reflects requests across wire formats, plus a focused unit test of the
+collector's accounting. Cost is asserted as a non-negative float end-to-end (the
+exact rate depends on registry contents); the cost arithmetic itself is pinned
+in the collector unit test.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import httpx
+
+from modelmeld.adapters.base import ProviderAdapter
+from modelmeld.api.schemas import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionRequest,
+    Choice,
+    ResponseMessage,
+    Usage,
+)
+from modelmeld.api.server import build_app
+from modelmeld.metrics import MetricsCollector
+
+
+class _EchoAdapter(ProviderAdapter):
+    name = "mock-echo"
+    is_egress = False
+
+    async def chat(self, request: ChatCompletionRequest) -> ChatCompletion:
+        return ChatCompletion(
+            model=request.model,
+            choices=[Choice(
+                index=0,
+                message=ResponseMessage(content="echo"),
+                finish_reason="stop",
+            )],
+            usage=Usage(prompt_tokens=12, completion_tokens=8, total_tokens=20),
+        )
+
+    async def stream_chat(
+        self, request: ChatCompletionRequest,
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        if False:
+            yield  # pragma: no cover
+
+    async def health(self) -> bool:
+        return True
+
+
+def _client(app) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    )
+
+
+async def test_fresh_app_has_zeroed_metrics() -> None:
+    app = build_app(adapter=_EchoAdapter())
+    async with _client(app) as client:
+        resp = await client.get("/metrics")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["chat_completions_count"] == 0
+    assert body["messages_count"] == 0
+    assert body["responses_count"] == 0
+    assert body["total_request_count"] == 0
+    assert body["total_input_tokens"] == 0
+    assert body["total_output_tokens"] == 0
+    assert body["total_tokens"] == 0
+    assert body["total_cost_usd"] == 0.0
+    assert body["per_model"] == {}
+
+
+async def test_chat_and_messages_requests_update_metrics() -> None:
+    app = build_app(adapter=_EchoAdapter())
+    async with _client(app) as client:
+        r1 = await client.post("/v1/chat/completions", json={
+            "model": "claude-haiku-4-5-20251001",
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+        r2 = await client.post("/v1/messages", json={
+            "model": "claude-haiku-4-5-20251001",
+            "max_tokens": 256,
+            "messages": [{"role": "user", "content": "hello"}],
+        })
+        metrics = await client.get("/metrics")
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    body = metrics.json()
+
+    # Wire-format breakdown reflects one of each.
+    assert body["chat_completions_count"] == 1
+    assert body["messages_count"] == 1
+    assert body["responses_count"] == 0
+    assert body["total_request_count"] == 2
+
+    # Token totals are the sum of both echo responses (12 in / 8 out each).
+    assert body["total_input_tokens"] == 24
+    assert body["total_output_tokens"] == 16
+    assert body["total_tokens"] == 40
+
+    # Cost is a non-negative float (actual rate depends on registry contents).
+    assert isinstance(body["total_cost_usd"], (int, float))
+    assert body["total_cost_usd"] >= 0.0
+
+    # Per-model entry for the served model, with summed tokens across both calls.
+    per_model = body["per_model"]
+    assert "claude-haiku-4-5-20251001" in per_model
+    entry = per_model["claude-haiku-4-5-20251001"]
+    assert entry["request_count"] == 2
+    assert entry["input_tokens"] == 24
+    assert entry["output_tokens"] == 16
+    assert entry["total_tokens"] == 40
+
+
+async def test_metrics_json_shape() -> None:
+    app = build_app(adapter=_EchoAdapter())
+    async with _client(app) as client:
+        body = (await client.get("/metrics")).json()
+    for key in (
+        "chat_completions_count", "messages_count", "responses_count",
+        "total_request_count", "total_input_tokens", "total_output_tokens",
+        "total_tokens", "total_cost_usd", "per_model",
+    ):
+        assert key in body, f"missing key: {key}"
+    assert isinstance(body["per_model"], dict)
+
+
+def test_collector_accounting_and_cost() -> None:
+    """Unit-test the collector's sums + per-model breakdown directly, including
+    the caller-supplied cost (the route computes tokens x rate; here we pin the
+    accumulation)."""
+    c = MetricsCollector()
+    c.record(wire_format="messages", input_tokens=100, output_tokens=50,
+             model_id="qwen3-coder-next", cost_usd=0.012)
+    c.record(wire_format="messages", input_tokens=10, output_tokens=5,
+             model_id="qwen3-coder-next", cost_usd=0.001)
+    c.record(wire_format="chat_completions", input_tokens=7, output_tokens=3,
+             model_id="claude-haiku-4-5", cost_usd=0.0)
+
+    snap = c.snapshot()
+    assert snap.messages_count == 2
+    assert snap.chat_completions_count == 1
+    assert snap.total_request_count == 3
+    assert snap.total_input_tokens == 117
+    assert snap.total_output_tokens == 58
+    assert snap.total_tokens == 175
+    assert abs(snap.total_cost_usd - 0.013) < 1e-9
+
+    qwen = snap.per_model["qwen3-coder-next"]
+    assert qwen.request_count == 2
+    assert qwen.input_tokens == 110
+    assert qwen.output_tokens == 55
+    assert qwen.total_tokens == 165
+    assert abs(qwen.cost_usd - 0.013) < 1e-9


### PR DESCRIPTION
## Summary

  ModelMeld OSS exposed no way to see what it's doing — no request volume, token
  usage, or routed-model spend. Competing OSS routers ship a local metrics view and
  it's a strong adoption hook (a user immediately sees routing working and what it
  costs). This adds a process-local `GET /metrics` surface. The data already existed
  per request (routing decisions carry the served model; responses carry usage) — it
  was just never aggregated.

  ## What's added

  - **`modelmeld/metrics.py`** — thread-safe `MetricsCollector` accumulating, since
    process start: request count by inbound wire format
    (`chat_completions`/`messages`/`responses`), summed prompt/completion/total
    tokens, a per-routed-model breakdown, and summed **actual** blended cost
    (`total_tokens × the routed model's registry rate`). One instance per app
    (`app.state.metrics`) so a fresh app starts zeroed.
  - **`GET /metrics`** — returns the snapshot as JSON, root-mounted like `/healthz`
    and `/version`.
  - **Wiring** — recorded from the existing `_fire_success` / `_fire_success_stream`
    helpers (before their `subscriber_count` early-return), via a request-scoped
    sink installed at each route entry. **Deliberately not via `HookRegistry`** —
    hooks are the enterprise extension seam and stay zero-subscriber by default;
    metrics must record on every successful request regardless. The hook system is
    untouched (its zero-subscriber tests still pass).

  ## Type of change

  - [x] New feature (non-breaking change that adds capability)

  ## Test plan

  - `tests/test_route_metrics.py`: fresh app is zeroed; one `/v1/chat/completions`
    + one `/v1/messages` update the wire-format counts, token totals, and per-model
    entry; JSON shape; a collector unit test pinning the sums and cost accumulation.
  - Full suite: **1159 passed, 12 skipped**. `ruff check src tests`, `pyright src`,
    `scripts/verify_boundary.py` all green (no `modelmeld_enterprise` import).

  ## Scope / non-goals

  Single-process surface only. Multi-tenant, per-API-key, RBAC-gated, and persisted
  analytics are intentionally out of scope. No new runtime dependencies. Reports
  **actual** spend only — no "savings vs frontier" figure (that needs a defined
  baseline + methodology and is separate).