### PR TITLE
feat(registry): B-3 Phase 1 — capability-aware substitution reconciliation

### DIFF
--- a/src/modelmeld/api/routes/messages.py
+++ b/src/modelmeld/api/routes/messages.py
@@ -91,6 +91,7 @@ from modelmeld.memory import (
 )
 from modelmeld.privacy import Scrubber
 from modelmeld.router import Router, RouterError
+from modelmeld.scout.registry import ModelEntry
 from modelmeld.tokens import TokenCounter
 from modelmeld.translation import (
     OpenAIToAnthropicStreamTranslator,
@@ -170,47 +171,73 @@ def _collect_oauth_camouflage_headers(
     return out
 
 
-# Client-specified, model-tuned controls that don't transfer across a model
-# substitution: the routed model may reject them (Anthropic 400 "… is not
-# supported on this model" / "does not support the … parameter"). They're sent
-# by Claude Code's beta endpoint tuned for the model it asked for. Dropped on
-# substitution; forwarded verbatim when there's none. B-3 (capability-aware
-# gating) is the real fix: forward each when the routed model supports it.
-#
-# These form an INTERDEPENDENT cluster and must be dropped atomically — e.g.
-# `context_management`'s `clear_thinking_*` strategy requires `thinking` to be
-# enabled, so dropping `thinking` while keeping `context_management` yields an
-# incoherent request (400 "clear_thinking strategy requires thinking …").
-# `output_config` is the wrapper Claude Code nests `effort` inside (top-level
-# `effort` is null). All confirmed via request-shape capture from the loop.
-_MODEL_TUNED_FIELDS = ("thinking", "effort", "output_config", "context_management")
+# Client model-tuned controls that don't transfer cleanly across a model
+# substitution (the routed model may 400 on them). Split into the reasoning
+# cluster — INTERDEPENDENT, must move atomically (context_management's
+# clear_thinking_* requires thinking; output_config wraps effort) — and the
+# context cluster, so B-3 can KEEP the reasoning controls when the served model
+# can take them ("anthropic_adaptive") instead of dropping everything blindly.
+_REASONING_TUNED_FIELDS = ("thinking", "effort", "output_config")
+_CONTEXT_TUNED_FIELDS = ("context_management",)
+_MODEL_TUNED_FIELDS = _REASONING_TUNED_FIELDS + _CONTEXT_TUNED_FIELDS
 
 
 def _native_body_for_upstream(
-    body: AnthropicMessagesRequest, served_model: str | None,
+    body: AnthropicMessagesRequest,
+    served_model: str | None,
+    served_entry: ModelEntry | None = None,
 ) -> AnthropicMessagesRequest:
-    """Build the native Anthropic body to send upstream.
+    """Build the native Anthropic body to send upstream after a substitution.
 
     When capability/alias routing serves a model different from what the client
-    requested, pin the body's `model` to the served pick AND drop client
-    model-tuned controls (`_MODEL_TUNED_FIELDS`) the routed model may reject. No
-    substitution → return `body` unchanged so those controls (and everything
-    else, incl. cache_control) pass through verbatim.
+    requested, pin the body's `model` to the served pick and reconcile the
+    client's model-tuned controls against the served model's capability metadata
+    (B-3) rather than dropping them wholesale:
 
-    The drop must happen here, not in the adapter: the adapter receives a body
-    whose `model` is already rewritten to the served pick, so it can no longer
-    tell that a substitution occurred.
+      - `max_tokens` is clamped to the served model's `max_output_tokens`.
+      - the reasoning cluster (thinking/effort/output_config) is KEPT when the
+        served model's `reasoning_interface` can take it ("anthropic_adaptive"),
+        else dropped atomically.
+      - `context_management` is always dropped (gateway-side emulation is a
+        later phase).
+
+    `served_entry` None (model not resolvable in the registry) → conservative
+    fallback: drop the whole cluster, as before, so we never forward a control
+    an unknown model might reject. No substitution → return `body` unchanged so
+    everything (incl. cache_control) passes through verbatim.
+
+    The reconciliation must happen here, not in the adapter: the adapter
+    receives a body whose `model` is already rewritten, so it can no longer tell
+    a substitution occurred.
     """
     if not served_model or served_model == body.model:
         return body
-    native_body = body.model_copy(update={"model": served_model})
+
+    update: dict[str, object] = {"model": served_model}
+    if (
+        served_entry is not None
+        and served_entry.max_output_tokens is not None
+        and body.max_tokens is not None
+        and body.max_tokens > served_entry.max_output_tokens
+    ):
+        update["max_tokens"] = served_entry.max_output_tokens
+    native_body = body.model_copy(update=update)
+
+    keep_reasoning = (
+        served_entry is not None
+        and served_entry.reasoning_interface == "anthropic_adaptive"
+    )
+    drop = set(_CONTEXT_TUNED_FIELDS)
+    if not keep_reasoning:
+        drop |= set(_REASONING_TUNED_FIELDS)
+
     extra = native_body.model_extra
-    if isinstance(extra, dict) and any(f in extra for f in _MODEL_TUNED_FIELDS):
+    if isinstance(extra, dict) and any(f in extra for f in drop):
         # Replace (not mutate) the extra dict so the original body is untouched.
         object.__setattr__(
             native_body,
             "__pydantic_extra__",
-            {k: v for k, v in extra.items() if k not in _MODEL_TUNED_FIELDS},
+            {k: v for k, v in extra.items() if k not in drop},
         )
     return native_body
 
@@ -251,6 +278,7 @@ async def _try_open_stream_native(
     body: AnthropicMessagesRequest,
     extra_headers: dict[str, str] | None = None,
     model_override: str | None = None,
+    served_entry: ModelEntry | None = None,
 ):
     """Open a stream with optional native-Anthropic passthrough + extra
     headers forwarding. Same return shape as chat._try_open_stream:
@@ -259,9 +287,11 @@ async def _try_open_stream_native(
     `model_override` (when set) rewrites the native body's `model` field
     so the upstream Anthropic call uses the scout's chosen model id
     rather than the original alias (which Anthropic would 404 on).
+    `served_entry` is that model's registry row, used to reconcile the
+    client's model-tuned controls against its capabilities (B-3).
     """
     if isinstance(adapter, AnthropicAdapter):
-        native_body = _native_body_for_upstream(body, model_override)
+        native_body = _native_body_for_upstream(body, model_override, served_entry)
         aiter = adapter.stream_chat(
             request, native_request=native_body, extra_headers=extra_headers,
         ).__aiter__()
@@ -770,12 +800,23 @@ async def _stream_messages_with_failover(
     calls. Non-Anthropic adapters ignore it.
     """
     failover_from: str | None = None
+
+    def _served_entry(d: Any) -> ModelEntry | None:
+        """Resolve the served model's registry row for capability-aware
+        substitution reconciliation (B-3). None when the registry is absent or
+        the model isn't found → conservative drop in _native_body_for_upstream."""
+        get = getattr(model_registry, "get", None)
+        if get is None or not d.model_id_override:
+            return None
+        return get(d.model_id_override)
+
     primary_aiter, first_chunk, primary_error = await _try_open_stream_native(
         decision.adapter,
         _apply_model_override(request, decision),
         native_request,  # type: ignore[arg-type]
         extra_anthropic_headers,
         model_override=decision.model_id_override,
+        served_entry=_served_entry(decision),
     )
 
     if first_chunk is None and primary_aiter is None:
@@ -805,6 +846,7 @@ async def _stream_messages_with_failover(
             native_request,  # type: ignore[arg-type]
             extra_anthropic_headers,
             model_override=decision.model_id_override,
+            served_entry=_served_entry(decision),
         )
         if primary_aiter is None and first_chunk is None:
             fb_err = fallback_error or AdapterError("fallback stream open failed")

--- a/src/modelmeld/scout/data/default_registry.json
+++ b/src/modelmeld/scout/data/default_registry.json
@@ -25,7 +25,9 @@
         "tool_use": 0.9
       },
       "last_updated": "2026-05-17T00:00:00Z",
-      "source": "manual_curation_2026_05_22"
+      "source": "manual_curation_2026_05_22",
+      "reasoning_interface": "anthropic_adaptive",
+      "max_output_tokens": 128000
     },
     {
       "model_id": "claude-sonnet-4-6",
@@ -41,7 +43,9 @@
         "tool_use": 0.85
       },
       "last_updated": "2026-05-17T00:00:00Z",
-      "source": "manual_curation_2026_05_22"
+      "source": "manual_curation_2026_05_22",
+      "reasoning_interface": "anthropic_adaptive",
+      "max_output_tokens": 64000
     },
     {
       "model_id": "claude-haiku-4-5",
@@ -57,7 +61,9 @@
         "tool_use": 0.75
       },
       "last_updated": "2026-05-17T00:00:00Z",
-      "source": "manual_curation_2026_05_22"
+      "source": "manual_curation_2026_05_22",
+      "reasoning_interface": "none",
+      "max_output_tokens": 64000
     },
     {
       "model_id": "gpt-5",

--- a/src/modelmeld/scout/multi_provider_registry.py
+++ b/src/modelmeld/scout/multi_provider_registry.py
@@ -208,11 +208,20 @@ class MultiProviderModelRegistry(ModelRegistry):
         # Index base entries for inheritance lookups.
         scores_by_model: dict[str, dict[str, float]] = {}
         supports_tools_by_model: dict[str, bool] = {}
+        reasoning_by_model: dict[str, str] = {}
+        max_output_by_model: dict[str, int | None] = {}
+        betas_by_model: dict[str, tuple[str, ...]] = {}
         for entry in base_entries:
             if entry.model_id not in scores_by_model and entry.task_scores:
                 scores_by_model[entry.model_id] = dict(entry.task_scores)
             if entry.model_id not in supports_tools_by_model:
                 supports_tools_by_model[entry.model_id] = entry.supports_tools
+            if entry.model_id not in reasoning_by_model and entry.reasoning_interface != "none":
+                reasoning_by_model[entry.model_id] = entry.reasoning_interface
+            if entry.model_id not in max_output_by_model and entry.max_output_tokens is not None:
+                max_output_by_model[entry.model_id] = entry.max_output_tokens
+            if entry.model_id not in betas_by_model and entry.supported_betas:
+                betas_by_model[entry.model_id] = entry.supported_betas
 
         # Load the overlay JSON shipped with the package.
         overlay_payload = json.loads(
@@ -245,6 +254,19 @@ class MultiProviderModelRegistry(ModelRegistry):
             row_supports_tools = bool(row.get("supports_tools", True))
             base_supports_tools = supports_tools_by_model.get(model_id, True)
             final_supports_tools = row_supports_tools and base_supports_tools
+            # Capability metadata: overlay row OVERRIDES base; inherit base when
+            # the row omits it (mirrors task_scores / supports_tools).
+            reasoning = row.get("reasoning_interface") or reasoning_by_model.get(
+                model_id, "none",
+            )
+            max_output = (
+                int(row["max_output_tokens"])
+                if row.get("max_output_tokens") is not None
+                else max_output_by_model.get(model_id)
+            )
+            betas = tuple(row["supported_betas"]) if row.get(
+                "supported_betas",
+            ) is not None else betas_by_model.get(model_id, ())
             overlay_entries.append(
                 ModelEntry(
                     model_id=model_id,
@@ -257,6 +279,9 @@ class MultiProviderModelRegistry(ModelRegistry):
                     source=row.get("source", "default_overlay"),
                     provider_model_id=row.get("provider_model_id", ""),
                     supports_tools=final_supports_tools,
+                    reasoning_interface=reasoning,
+                    max_output_tokens=max_output,
+                    supported_betas=betas,
                 )
             )
 

--- a/src/modelmeld/scout/registry.py
+++ b/src/modelmeld/scout/registry.py
@@ -63,6 +63,27 @@ class ModelEntry:
     # below 7B parameters). CapabilityScout filters by this field
     # when the incoming request has `tools=[...]`.
     supports_tools: bool = True
+    # --- Capability metadata for substitution-time feature reconciliation (B-3) ---
+    # When alias/capability routing serves a different model than the client
+    # tuned its request for, these tell the reconciler whether to forward,
+    # translate, or drop the client's model-tuned controls instead of the old
+    # blunt "drop everything" behavior.
+    #
+    # `reasoning_interface` — how this model exposes reasoning on its egress
+    # path; drives whether `thinking`/`effort` survive a substitution:
+    #   "none"               — no reasoning surface; drop reasoning controls
+    #   "anthropic_adaptive" — Claude adaptive thinking (native Anthropic path)
+    # Interfaces for OpenAI-compatible backends are added in a later phase.
+    # Default "none" is conservative (drop). Sourced from provider catalog
+    # parameter lists, or known constants for the native Anthropic models.
+    reasoning_interface: str = "none"
+    # Per-model max output tokens; clamps an inbound `max_tokens` that exceeds
+    # the served model's ceiling (a common substitution 400). None = no clamp.
+    max_output_tokens: int | None = None
+    # `anthropic-beta` features the served path honors (Anthropic-native only),
+    # e.g. context-management/compaction; decides which betas survive a
+    # Claude->Claude substitution.
+    supported_betas: tuple[str, ...] = ()
 
     def blended_cost_per_m(
         self,
@@ -118,6 +139,12 @@ class ModelRegistry:
                     source=row.get("source", ""),
                     provider_model_id=row.get("provider_model_id", ""),
                     supports_tools=bool(row.get("supports_tools", True)),
+                    reasoning_interface=str(row.get("reasoning_interface", "none")),
+                    max_output_tokens=(
+                        int(row["max_output_tokens"])
+                        if row.get("max_output_tokens") is not None else None
+                    ),
+                    supported_betas=tuple(row.get("supported_betas", ())),
                 )
             )
         return cls(entries)

--- a/tests/test_native_body_reconcile.py
+++ b/tests/test_native_body_reconcile.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""B-3 Phase 1: capability-aware reconciliation of model-tuned controls on a
+model substitution (`_native_body_for_upstream`).
+
+Replaces the old blunt "drop thinking/effort/output_config/context_management on
+every substitution" with: keep the reasoning cluster when the served model can
+take it (`reasoning_interface == "anthropic_adaptive"`), always drop
+context_management (gateway emulation is a later phase), clamp max_tokens to the
+served model's ceiling, and fall back to the blunt drop when the served model is
+unknown.
+"""
+
+from __future__ import annotations
+
+from modelmeld.api.routes.messages import _native_body_for_upstream
+from modelmeld.api.schemas_anthropic import AnthropicMessagesRequest
+from modelmeld.scout.registry import ModelEntry
+
+
+def _body(max_tokens: int = 8000, **extra: object) -> AnthropicMessagesRequest:
+    return AnthropicMessagesRequest(
+        model="anthropic/modelmeld-auto",
+        max_tokens=max_tokens,
+        messages=[{"role": "user", "content": "hi"}],
+        **extra,
+    )
+
+
+def _entry(reasoning: str = "anthropic_adaptive", max_out: int | None = None) -> ModelEntry:
+    return ModelEntry(
+        model_id="served-model", provider="anthropic", context_window=200000,
+        cost_per_m_input=3.0, cost_per_m_output=15.0,
+        reasoning_interface=reasoning, max_output_tokens=max_out,
+    )
+
+
+def test_no_substitution_returns_body_unchanged() -> None:
+    b = _body(thinking={"type": "adaptive"})
+    # served_model None or equal to the requested model → passthrough verbatim.
+    assert _native_body_for_upstream(b, None) is b
+    assert _native_body_for_upstream(b, b.model) is b
+
+
+def test_reasoning_model_keeps_reasoning_drops_context() -> None:
+    b = _body(
+        thinking={"type": "adaptive"}, effort="high",
+        output_config={"effort": "high"}, context_management={"edits": []},
+    )
+    out = _native_body_for_upstream(b, "served-model", _entry("anthropic_adaptive"))
+    ex = out.model_extra or {}
+    assert "thinking" in ex and "effort" in ex and "output_config" in ex
+    assert "context_management" not in ex  # always dropped until gateway emulation
+    assert out.model == "served-model"
+
+
+def test_nonreasoning_model_drops_whole_cluster() -> None:
+    b = _body(thinking={"type": "adaptive"}, effort="high", context_management={"edits": []})
+    out = _native_body_for_upstream(b, "served-model", _entry("none"))
+    ex = out.model_extra or {}
+    assert not any(k in ex for k in ("thinking", "effort", "output_config", "context_management"))
+
+
+def test_unknown_entry_falls_back_to_blunt_drop() -> None:
+    b = _body(thinking={"type": "adaptive"}, effort="high", context_management={"edits": []})
+    out = _native_body_for_upstream(b, "served-model", served_entry=None)
+    ex = out.model_extra or {}
+    assert not any(k in ex for k in ("thinking", "effort", "context_management"))
+
+
+def test_max_tokens_clamped_to_served_cap() -> None:
+    b = _body(max_tokens=8000, thinking={"type": "adaptive"})
+    out = _native_body_for_upstream(b, "served-model", _entry("anthropic_adaptive", max_out=4000))
+    assert out.max_tokens == 4000
+
+
+def test_max_tokens_not_clamped_when_under_cap() -> None:
+    b = _body(max_tokens=8000)
+    out = _native_body_for_upstream(b, "served-model", _entry("anthropic_adaptive", max_out=64000))
+    assert out.max_tokens == 8000
+
+
+def test_original_body_is_not_mutated() -> None:
+    b = _body(thinking={"type": "adaptive"}, context_management={"x": 1})
+    _native_body_for_upstream(b, "served-model", _entry("none"))
+    ex = b.model_extra or {}
+    assert "thinking" in ex and "context_management" in ex  # original untouched


### PR DESCRIPTION
## Summary
  Replaces the blunt "drop thinking/effort/output_config/context_management on every
  model substitution" with capability-aware reconciliation. First slice of B-3
  (re-enabling the harness's reasoning/context controls instead of stripping them).

  ## What's in Phase 1
  - **Schema** (`ModelEntry`, both base + overlay load paths, all defaulted →
    backward-compatible): `reasoning_interface`, `max_output_tokens`, `supported_betas`.
  - **Reconciler** (`_native_body_for_upstream`, Anthropic-native streaming path):
    keep the reasoning cluster when `reasoning_interface == "anthropic_adaptive"`,
    else drop atomically; always drop `context_management` (gateway emulation is
    Phase 3); clamp `max_tokens` to the served model's cap; conservative blunt-drop
    fallback when the served model is unresolvable.
  - **Data**: Claude base entries populated. Opus 4.7 / Sonnet 4.6 → reasoning now
    survives a Claude→Claude substitution; Haiku 4.5 → `"none"` (effort 400s on it),
    no regression.

  ## Scope / deferred
  - **Phase 2** = reasoning translation on the OpenAI-compatible egress (OSS models).
  - **Phase 3** = gateway-side `context_management` emulation via the memory layer.
  - Haiku thinking-without-effort needs per-field granularity (later).

  ## Test plan
  +7 reconciler unit tests (keep/drop per capability, blunt fallback, clamp, original
  body untouched). Full suite **1166 passed**; ruff/pyright/boundary clean.