### PR TITLE
feat(translation): B-3 Phase 2 — forward reasoning intent to OSS backends

### DIFF
--- a/src/modelmeld/translation/openai_anthropic.py
+++ b/src/modelmeld/translation/openai_anthropic.py
@@ -478,6 +478,42 @@ class AnthropicStreamTranslator:
 # Request: Anthropic → OpenAI  (feeds the /v1/messages route)
 # ---------------------------------------------------------------------------
 
+# Claude Code's reasoning intent (output_config.effort / thinking) is otherwise
+# dropped by the field-by-field mapping below. B-3 Phase 2 re-surfaces it as the
+# OpenAI-compatible `reasoning_effort`, which OpenAI-compat OSS backends honor on
+# reasoning-capable models and silently IGNORE on the rest (verified: no 4xx) —
+# so this is a safe additive translation, not gated on the served model. Anthropic
+# effort above "high" (xhigh/max) clamps to "high" (reasoning_effort tops out there).
+_ANTHROPIC_EFFORT_TO_REASONING: dict[str, str] = {
+    "low": "low",
+    "medium": "medium",
+    "high": "high",
+    "xhigh": "high",
+    "max": "high",
+}
+
+
+def _reasoning_effort_from_anthropic(
+    req: AnthropicMessagesRequest,
+) -> str | None:
+    """Map the client's reasoning intent to the internal `reasoning_effort`.
+
+    `output_config.effort` wins when present; otherwise adaptive thinking
+    (`thinking.type` not disabled/absent) maps to a moderate default. None when
+    the client signalled no reasoning.
+    """
+    extra = req.model_extra or {}
+    output_config = extra.get("output_config")
+    if isinstance(output_config, dict):
+        mapped = _ANTHROPIC_EFFORT_TO_REASONING.get(output_config.get("effort"))
+        if mapped is not None:
+            return mapped
+    thinking = extra.get("thinking")
+    if isinstance(thinking, dict) and thinking.get("type") not in (None, "disabled"):
+        return "medium"
+    return None
+
+
 def from_anthropic_request(req: AnthropicMessagesRequest) -> ChatCompletionRequest:
     """Translate an Anthropic Messages request into the internal OpenAI shape.
 
@@ -554,6 +590,11 @@ def from_anthropic_request(req: AnthropicMessagesRequest) -> ChatCompletionReque
         stream=req.stream or False,
         tools=tools,
         tool_choice=tool_choice,
+        # B-3 Phase 2: carry the client's reasoning intent (output_config.effort
+        # / adaptive thinking) as reasoning_effort so OpenAI-compatible OSS
+        # backends reason instead of having it dropped. None when no reasoning
+        # was signalled.
+        reasoning_effort=_reasoning_effort_from_anthropic(req),
         # metadata.user_id maps onto the OpenAI `user` field (similar purpose:
         # abuse/safety tracking by end-user identity).
         user=(req.metadata.user_id if req.metadata else None),

--- a/src/modelmeld/translation/openai_anthropic.py
+++ b/src/modelmeld/translation/openai_anthropic.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import json
 import re
 import time
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 from modelmeld.api.schemas import (
@@ -484,7 +484,7 @@ class AnthropicStreamTranslator:
 # reasoning-capable models and silently IGNORE on the rest (verified: no 4xx) —
 # so this is a safe additive translation, not gated on the served model. Anthropic
 # effort above "high" (xhigh/max) clamps to "high" (reasoning_effort tops out there).
-_ANTHROPIC_EFFORT_TO_REASONING: dict[str, str] = {
+_ANTHROPIC_EFFORT_TO_REASONING: dict[str, Literal["low", "medium", "high"]] = {
     "low": "low",
     "medium": "medium",
     "high": "high",
@@ -495,7 +495,7 @@ _ANTHROPIC_EFFORT_TO_REASONING: dict[str, str] = {
 
 def _reasoning_effort_from_anthropic(
     req: AnthropicMessagesRequest,
-) -> str | None:
+) -> Literal["low", "medium", "high"] | None:
     """Map the client's reasoning intent to the internal `reasoning_effort`.
 
     `output_config.effort` wins when present; otherwise adaptive thinking
@@ -505,9 +505,11 @@ def _reasoning_effort_from_anthropic(
     extra = req.model_extra or {}
     output_config = extra.get("output_config")
     if isinstance(output_config, dict):
-        mapped = _ANTHROPIC_EFFORT_TO_REASONING.get(output_config.get("effort"))
-        if mapped is not None:
-            return mapped
+        effort = output_config.get("effort")
+        if isinstance(effort, str):
+            mapped = _ANTHROPIC_EFFORT_TO_REASONING.get(effort)
+            if mapped is not None:
+                return mapped
     thinking = extra.get("thinking")
     if isinstance(thinking, dict) and thinking.get("type") not in (None, "disabled"):
         return "medium"

--- a/tests/test_anthropic_reasoning_effort.py
+++ b/tests/test_anthropic_reasoning_effort.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""B-3 Phase 2: the client's reasoning intent (output_config.effort / adaptive
+thinking) is re-surfaced as `reasoning_effort` on the internal request, so
+OpenAI-compatible OSS backends reason instead of having it dropped at
+translation. `output_config.effort` wins; adaptive thinking without an explicit
+effort maps to a moderate default; no signal → None.
+"""
+
+from __future__ import annotations
+
+from modelmeld.api.schemas_anthropic import AnthropicMessage, AnthropicMessagesRequest
+from modelmeld.translation import from_anthropic_request
+
+
+def _req(**extra: object) -> AnthropicMessagesRequest:
+    return AnthropicMessagesRequest(
+        model="anthropic/modelmeld-auto",
+        max_tokens=1024,
+        messages=[AnthropicMessage(role="user", content="hi")],
+        **extra,
+    )
+
+
+def test_output_config_effort_maps_directly() -> None:
+    for level in ("low", "medium", "high"):
+        out = from_anthropic_request(_req(output_config={"effort": level}))
+        assert out.reasoning_effort == level
+
+
+def test_effort_above_high_clamps_to_high() -> None:
+    for level in ("xhigh", "max"):
+        out = from_anthropic_request(_req(output_config={"effort": level}))
+        assert out.reasoning_effort == "high"
+
+
+def test_adaptive_thinking_without_effort_maps_to_medium() -> None:
+    out = from_anthropic_request(_req(thinking={"type": "adaptive"}))
+    assert out.reasoning_effort == "medium"
+
+
+def test_explicit_effort_wins_over_thinking() -> None:
+    out = from_anthropic_request(
+        _req(thinking={"type": "adaptive"}, output_config={"effort": "low"}),
+    )
+    assert out.reasoning_effort == "low"
+
+
+def test_no_reasoning_signal_is_none() -> None:
+    assert from_anthropic_request(_req()).reasoning_effort is None
+    assert from_anthropic_request(_req(thinking={"type": "disabled"})).reasoning_effort is None
+    # output_config present but no effort (e.g. only a format) → no reasoning.
+    assert from_anthropic_request(_req(output_config={"format": {"type": "json"}})).reasoning_effort is None
+
+
+def test_unknown_effort_value_is_ignored() -> None:
+    # A future/unrecognized effort string falls through to None rather than
+    # forwarding a value reasoning_effort can't represent.
+    assert from_anthropic_request(_req(output_config={"effort": "ludicrous"})).reasoning_effort is None
+
+
+def test_reasoning_effort_reaches_openai_egress_params() -> None:
+    """End-to-end: Anthropic effort → reasoning_effort → OpenAI egress dict
+    (which OpenAI-compatible reasoning-capable backends honor)."""
+    from modelmeld.adapters.openai_adapter import OpenAIAdapter
+
+    ad = OpenAIAdapter.__new__(OpenAIAdapter)
+    ad.served_model = None
+
+    internal = from_anthropic_request(_req(output_config={"effort": "high"}))
+    params = OpenAIAdapter._to_params(ad, internal, stream=False)
+    assert params.get("reasoning_effort") == "high"
+
+    # Omitted entirely when no reasoning was signalled (exclude_none).
+    plain = from_anthropic_request(_req())
+    assert "reasoning_effort" not in OpenAIAdapter._to_params(ad, plain, stream=False)


### PR DESCRIPTION
## Summary
  `from_anthropic_request` dropped the client's reasoning controls
  (`output_config.effort` / adaptive thinking), so OSS models never reasoned even
  when capable. Now it maps that intent to the internal `reasoning_effort`:
  effort wins (xhigh/max → high); adaptive thinking w/o explicit effort → "medium";
  no signal → None. `OpenAIAdapter` already serializes the field, so it reaches the
  OpenAI-compatible egress.

  ## Why it's safe (probe-confirmed)
  Reasoning-capable OSS backends honor flat `reasoning_effort` (glm-4.6, minimax-m2
  produce reasoning tokens); the rest (qwen3-coder-480b, devstral) return 200 and
  silently ignore it — no 4xx. So no capability gate is needed for correctness, and
  this doesn't touch the substitution reconcile seam (lower risk than first scoped).

  ## Type of change
  - [x] New feature

  ## Test plan
  +7 tests (effort mapping, xhigh/max clamp, adaptive default, effort-wins precedence,
  none-cases, end-to-end through the egress params). Full suite 1172 passed;
  ruff/pyright/boundary clean.

  ## Caveat / deferred
  "Ignored, no error" is provider-specific; a capability gate becomes load-bearing
  only if OSS later routes direct-to-provider. The stronger nested reasoning-object
  form is a later refinement. Phase 3 (gateway `context_management` emulation) remains.