### PR TITLE
fix(api): return canonical routed model in /v1/messages response body

### DIFF
--- a/src/modelmeld/api/routes/messages.py
+++ b/src/modelmeld/api/routes/messages.py
@@ -488,6 +488,10 @@ async def anthropic_messages(
     internal_request = inject_into_request(internal_request, mem_context)
     outgoing, redactions = _maybe_scrub(internal_request, decision, scrubber)
 
+    # Compute the canonical routed model (B-2: used in response body, not request echo).
+    # This is the model the scout decided to serve, not what the client asked for.
+    served_model = decision.model_id_override or outgoing.model
+
     # Streaming path (chunk 6). Pre-count input_tokens so the synthesized
     # `message_start` event carries an accurate count (Anthropic wire format
     # puts input_tokens upfront in message_start; output_tokens streams in
@@ -499,7 +503,7 @@ async def anthropic_messages(
         return await _stream_messages_with_failover(
             rt, decision, outgoing, redactions, hooks, request_id, started,
             identity, provider, mem_identity, token_counter,
-            request_model=body.model,
+            request_model=served_model,
             input_tokens=input_tokens,
             cache_status=cache_status,
             native_request=body,
@@ -511,7 +515,6 @@ async def anthropic_messages(
     # shape, so /v1/messages and /v1/chat/completions can share entries when
     # the prompt content is identical — cache hit just gets translated to
     # Anthropic shape on the way out.
-    served_model = decision.model_id_override or outgoing.model
     semantic_cacheable = is_request_semantically_cacheable(outgoing)
     cache_key = (
         cache_key_for_request(
@@ -535,7 +538,7 @@ async def anthropic_messages(
                 lookup.value, identity, cache_status="hit",
             )
             return _anthropic_json_response(
-                to_anthropic_response(lookup.value, request_model=body.model),
+                to_anthropic_response(lookup.value, request_model=served_model),
                 base_response=response,
             )
 
@@ -566,7 +569,7 @@ async def anthropic_messages(
                 sem_lookup.value, identity, cache_status="hit-semantic",
             )
             return _anthropic_json_response(
-                to_anthropic_response(sem_lookup.value, request_model=body.model),
+                to_anthropic_response(sem_lookup.value, request_model=served_model),
                 base_response=response,
             )
 
@@ -660,10 +663,12 @@ async def anthropic_messages(
     )
 
     # Translate internal ChatCompletion → Anthropic response shape.
-    # Pass body.model (the original) so capability-routing model overrides
-    # don't leak the internal target id to the client.
+    # Pass served_model (the canonical routed model) to match the behavior
+    # of /v1/chat/completions, which returns the routed model in the response
+    # body (B-2). This is the model that the scout decided to serve, matching
+    # x-modelmeld-routed-model in the response headers.
     return _anthropic_json_response(
-        to_anthropic_response(completion, request_model=body.model),
+        to_anthropic_response(completion, request_model=served_model),
         base_response=response,
     )
 

--- a/tests/test_chat_capability_routing.py
+++ b/tests/test_chat_capability_routing.py
@@ -10,6 +10,7 @@ Verifies that:
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 
 import httpx
@@ -20,6 +21,8 @@ from modelmeld.api.schemas import (
     ChatCompletionChunk,
     ChatCompletionRequest,
     Choice,
+    ChoiceDelta,
+    ChunkChoice,
     ResponseMessage,
     Usage,
 )
@@ -484,3 +487,111 @@ async def test_no_bias_header_when_no_bias_applied() -> None:
     assert "x-modelmeld-bias" not in resp.headers
 
 
+
+
+# ---------------------------------------------------------------------------
+# B-2: the Anthropic /v1/messages surface mirrors the OpenAI surface — the
+# response BODY reports the canonical routed model on a substitution, not the
+# requested model. These tests fail if request_model=served_model is reverted.
+# ---------------------------------------------------------------------------
+
+
+class _StreamFakeAdapter(ProviderAdapter):
+    """Streaming counterpart to _FakeAdapter: records the model it was asked to
+    serve and streams a short text response carrying that model id."""
+
+    is_egress = False
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.received_models: list[str] = []
+
+    async def chat(self, request: ChatCompletionRequest) -> ChatCompletion:
+        raise NotImplementedError("streaming-only adapter")
+
+    async def stream_chat(
+        self, request: ChatCompletionRequest,
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        self.received_models.append(request.model)
+        yield ChatCompletionChunk(
+            id="c1", object="chat.completion.chunk", created=1, model=request.model,
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(role="assistant", content="ok"))],
+        )
+        yield ChatCompletionChunk(
+            id="c1", object="chat.completion.chunk", created=1, model=request.model,
+            choices=[ChunkChoice(index=0, delta=ChoiceDelta(), finish_reason="stop")],
+            usage=Usage(prompt_tokens=5, completion_tokens=1, total_tokens=6),
+        )
+
+    async def health(self) -> bool:
+        return True
+
+
+async def test_anthropic_messages_response_model_is_canonical_routed_model() -> None:
+    """Requesting claude-opus-4-7 but routing to qwen-cheap must surface
+    qwen-cheap (the served model) in the /v1/messages response body — mirroring
+    test_capability_routing_overrides_request_model for /v1/chat/completions."""
+    cheap = _FakeAdapter("vllm")
+    expensive = _FakeAdapter("anthropic")
+    app = _build_app_with_capability_router(
+        registry_entries=[
+            _entry("qwen-cheap", "vllm", 0.5, 1.0, coding=0.85),
+            _entry("opus", "anthropic", 5.0, 25.0, coding=0.95),
+        ],
+        adapters={"vllm": cheap, "anthropic": expensive},
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/v1/messages", json={
+            "model": "claude-opus-4-7",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "refactor this function"}],
+        })
+    assert resp.status_code == 200
+    # The adapter saw the OVERRIDDEN model id, not the user's claude-opus-4-7.
+    assert cheap.received_models == ["qwen-cheap"]
+    assert expensive.received_models == []
+    # Response body model == served model, matching x-modelmeld-routed-model.
+    assert resp.json()["model"] == "qwen-cheap"
+    assert resp.headers["x-modelmeld-routed-model"] == "qwen-cheap"
+
+
+async def test_anthropic_stream_message_start_carries_canonical_routed_model() -> None:
+    """Streaming counterpart: the message_start event carries the canonical
+    routed model on a substitution, not the requested model."""
+    cheap = _StreamFakeAdapter("vllm")
+    expensive = _FakeAdapter("anthropic")
+    app = _build_app_with_capability_router(
+        registry_entries=[
+            _entry("qwen-cheap", "vllm", 0.5, 1.0, coding=0.85),
+            _entry("opus", "anthropic", 5.0, 25.0, coding=0.95),
+        ],
+        adapters={"vllm": cheap, "anthropic": expensive},
+    )
+    raw = ""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        async with client.stream("POST", "/v1/messages", json={
+            "model": "claude-opus-4-7",
+            "max_tokens": 64,
+            "stream": True,
+            "messages": [{"role": "user", "content": "refactor this function"}],
+        }) as resp:
+            assert resp.status_code == 200
+            async for piece in resp.aiter_text():
+                raw += piece
+    msg_start = None
+    for block in raw.split("\n\n"):
+        if "message_start" not in block:
+            continue
+        for line in block.splitlines():
+            if line.startswith("data:"):
+                msg_start = json.loads(line[len("data:"):].strip())
+                break
+        if msg_start:
+            break
+    assert msg_start is not None, f"no message_start event in stream: {raw[:300]!r}"
+    assert msg_start["message"]["model"] == "qwen-cheap"
+    assert cheap.received_models == ["qwen-cheap"]

--- a/tests/test_route_messages.py
+++ b/tests/test_route_messages.py
@@ -163,9 +163,17 @@ async def test_plain_request_returns_anthropic_shape() -> None:
     assert body["usage"] == {"input_tokens": 12, "output_tokens": 8}
 
 
-async def test_model_field_echoes_request_not_internal_completion_model() -> None:
-    """Capability routing may rewrite the internal model; the client must
-    see the model they asked for."""
+async def test_model_field_returns_canonical_routed_model() -> None:
+    """B-2: Response model field returns the canonical routed model (the model
+    the scout decided to serve), not the alias the client requested. This
+    matches the behavior of /v1/chat/completions and x-modelmeld-routed-model
+    in the response headers.
+
+    The _EchoAdapter is a single-adapter setup (no actual capability routing).
+    The model string it receives is the internal form (from the internal
+    ChatCompletionRequest), which mirrors what the client requested in this
+    case (no override). The response model field should match it.
+    """
     app = build_app(adapter=_EchoAdapter())
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app), base_url="http://test",
@@ -176,6 +184,8 @@ async def test_model_field_echoes_request_not_internal_completion_model() -> Non
             "messages": [{"role": "user", "content": "x"}],
         })
     assert resp.status_code == 200
+    # Response model field returns what the scout/router decided to serve.
+    # In single-adapter setup with no override, that's the request model itself.
     assert resp.json()["model"] == "claude-sonnet-4-6"
 
 

--- a/tests/test_route_messages_streaming.py
+++ b/tests/test_route_messages_streaming.py
@@ -237,6 +237,10 @@ async def test_text_stream_reassembles_to_full_response() -> None:
 
 
 async def test_message_start_carries_model_and_input_tokens() -> None:
+    """B-2: message_start event carries the canonical routed model (what the
+    scout decided to serve), matching x-modelmeld-routed-model in headers.
+    In this single-adapter setup with no override, the routed model is the
+    request model itself."""
     app = build_app(adapter=_TextStreamAdapter(text="ok"))
     status, _, raw = await _stream_post(app, {
         "model": "claude-haiku-4-5-20251001",
@@ -248,6 +252,7 @@ async def test_message_start_carries_model_and_input_tokens() -> None:
     msg_start = events[0]
     assert msg_start["type"] == "message_start"
     assert msg_start["_event_name"] == "message_start"
+    # The model field in message_start carries the canonical routed model
     assert msg_start["message"]["model"] == "claude-haiku-4-5-20251001"
     # input_tokens is the pre-counted estimate; must be >0 since the
     # user message wasn't empty


### PR DESCRIPTION
## Summary

  The Anthropic `/v1/messages` surface echoed the client's *requested* model in the
  response body, while `/v1/chat/completions` already returns the canonical *routed*
  model. On a capability-routing substitution the two surfaces disagreed, and the
  Anthropic body didn't match its own `x-modelmeld-routed-model` header. This aligns
  them: both surfaces report the served model on the non-streaming, streaming, and
  cache-hit paths.

  ## Type of change

  - [x] Bug fix (non-breaking change that resolves an issue)

  ## Test plan

  - `tests/test_chat_capability_routing.py`: two new override tests
    (`test_anthropic_messages_response_model_is_canonical_routed_model`,
    `test_anthropic_stream_message_start_carries_canonical_routed_model`) — request
    `claude-opus-4-7`, route to `qwen-cheap`, assert the response body /
    `message_start` reports `qwen-cheap`. Mutation-checked: reverting the fix makes
    both fail, so they actually exercise the change (the prior single-adapter tests
    passed either way).
  - `tests/test_route_messages.py` / `_streaming.py`: existing single-adapter
    model-field assertions updated to the canonical-routed-model expectation.
  - Full suite: `pytest -q` → 1175 passed, 12 skipped. `ruff`, `pyright src`,
    `scripts/verify_boundary.py` all green.

  ## Linked issues

  N/A

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [ ] Documentation updated if user-facing behavior changed
  - [x] `pre-commit run --all-files` passes
  - [x] `pytest` passes (full suite, not just the changed file)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read `docs/open-core-boundary.md` first

  ## Additional context

  Observable change: for aliased/substituted requests, the `/v1/messages` response
  `model` field now returns the served model instead of the requested alias —
  matching the OpenAI surface and the `x-modelmeld-routed-model` header. Neither
  value exposes a backend-provider slug.