### PR TITLE
feat(metrics): expose uptime_seconds on GET /metrics

### DIFF
--- a/src/modelmeld/api/routes/metrics.py
+++ b/src/modelmeld/api/routes/metrics.py
@@ -27,6 +27,7 @@ def _serialize(snap: MetricsSnapshot) -> dict:
         "total_output_tokens": snap.total_output_tokens,
         "total_tokens": snap.total_tokens,
         "total_cost_usd": snap.total_cost_usd,
+        "uptime_seconds": snap.uptime_seconds,
         "per_model": {
             model_id: {
                 "request_count": m.request_count,

--- a/src/modelmeld/metrics.py
+++ b/src/modelmeld/metrics.py
@@ -17,6 +17,7 @@ module imports nothing from the API or enterprise packages.
 from __future__ import annotations
 
 import threading
+import time
 from dataclasses import dataclass
 
 # Inbound wire formats we break request counts down by.
@@ -48,6 +49,7 @@ class MetricsSnapshot:
     total_tokens: int
 
     total_cost_usd: float
+    uptime_seconds: float
 
     per_model: dict[str, ModelMetrics]
 
@@ -62,6 +64,7 @@ class MetricsCollector:
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
+        self._created_at = time.monotonic()
         self._wire_counts: dict[str, int] = {fmt: 0 for fmt in WIRE_FORMATS}
         self._input_tokens = 0
         self._output_tokens = 0
@@ -109,6 +112,7 @@ class MetricsCollector:
                 )
                 for model_id, s in self._model_stats.items()
             }
+            uptime = time.monotonic() - self._created_at
             return MetricsSnapshot(
                 chat_completions_count=self._wire_counts.get("chat_completions", 0),
                 messages_count=self._wire_counts.get("messages", 0),
@@ -120,5 +124,6 @@ class MetricsCollector:
                 total_output_tokens=self._output_tokens,
                 total_tokens=self._input_tokens + self._output_tokens,
                 total_cost_usd=self._cost_usd,
+                uptime_seconds=uptime,
                 per_model=per_model,
             )

--- a/tests/test_route_metrics.py
+++ b/tests/test_route_metrics.py
@@ -74,6 +74,9 @@ async def test_fresh_app_has_zeroed_metrics() -> None:
     assert body["total_output_tokens"] == 0
     assert body["total_tokens"] == 0
     assert body["total_cost_usd"] == 0.0
+    assert "uptime_seconds" in body
+    assert isinstance(body["uptime_seconds"], (int, float))
+    assert body["uptime_seconds"] >= 0.0
     assert body["per_model"] == {}
 
 
@@ -127,10 +130,34 @@ async def test_metrics_json_shape() -> None:
     for key in (
         "chat_completions_count", "messages_count", "responses_count",
         "total_request_count", "total_input_tokens", "total_output_tokens",
-        "total_tokens", "total_cost_usd", "per_model",
+        "total_tokens", "total_cost_usd", "uptime_seconds", "per_model",
     ):
         assert key in body, f"missing key: {key}"
     assert isinstance(body["per_model"], dict)
+    assert isinstance(body["uptime_seconds"], (int, float))
+
+
+async def test_uptime_seconds_tracks_elapsed_time() -> None:
+    """uptime_seconds must reflect real elapsed time, not a constant. Read twice
+    across a sleep and require a STRICT increase — a hardcoded/zeroed value (the
+    obvious regression) would pass a `>=` check but fails this."""
+    import asyncio
+
+    app = build_app(adapter=_EchoAdapter())
+    async with _client(app) as client:
+        r1 = await client.get("/metrics")
+        uptime1 = r1.json()["uptime_seconds"]
+
+        await asyncio.sleep(0.05)
+
+        r2 = await client.get("/metrics")
+        uptime2 = r2.json()["uptime_seconds"]
+
+    assert isinstance(uptime1, (int, float))
+    assert isinstance(uptime2, (int, float))
+    assert uptime1 >= 0.0
+    # Strictly greater after a real delay: proves it is wired to a live clock.
+    assert uptime2 > uptime1
 
 
 def test_collector_accounting_and_cost() -> None:


### PR DESCRIPTION
 ## Summary

  `GET /metrics` reported cumulative counters since process start but carried no
  measure of the time window they cover, so a consumer couldn't compute any rate
  (requests/min, tokens/min, $/hour) — the core value of an observability surface.
  This adds `uptime_seconds` (monotonic seconds since the collector was created) to
  the snapshot and the JSON output.

  ## Type of change

  - [x] New feature (non-breaking change that adds capability)

  ## Test plan

  - `tests/test_route_metrics.py`: new `test_uptime_seconds_tracks_elapsed_time`
    reads `/metrics` twice across a delay and asserts a **strict** increase, so a
    hardcoded/zeroed value fails (a `>=` check would not catch that). Shape +
    zeroed-app tests updated to include the additive field.
  - Full suite: `pytest -q` → 1176 passed, 12 skipped. `ruff`, `pyright src`,
    `scripts/verify_boundary.py` green.

  ## Linked issues

  N/A

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [ ] Documentation updated if user-facing behavior changed
  - [x] `pytest` passes (full suite, not just the changed file)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read `docs/open-core-boundary.md` first

  ## Additional context

  Monotonic clock (`time.monotonic`), so the value is immune to wall-clock
  adjustments. Purely additive — existing `/metrics` consumers are unaffected.