### PR TITLE
feat(routing): env-gated model pin for end-to-end model benchmarking

### DIFF
--- a/src/modelmeld/api/routing_hints.py
+++ b/src/modelmeld/api/routing_hints.py
@@ -21,6 +21,7 @@ came from a framework declaration vs the heuristic classifier.
 
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 
@@ -31,6 +32,17 @@ HEADER_TASK_CATEGORY = "x-modelmeld-task-category"
 HEADER_AGENT_ROLE = "x-modelmeld-agent-role"
 HEADER_QUALITY_THRESHOLD = "x-modelmeld-quality-threshold"
 HEADER_EXCLUDE_PROVIDERS = "x-modelmeld-exclude-providers"
+# Eval/debug ONLY: force a specific served model, bypassing capability routing.
+# Honored solely when MODELMELD_ALLOW_MODEL_PIN is set on the gateway — so it is
+# inert (the header is ignored) on any default/production deployment and is NOT a
+# public API surface. Exists to benchmark a specific model end-to-end (e.g. the
+# agentic-efficiency eval) without skewing registry data.
+HEADER_PIN_MODEL = "x-modelmeld-pin-model"
+_MODEL_PIN_ENV = "MODELMELD_ALLOW_MODEL_PIN"
+
+
+def _model_pin_enabled() -> bool:
+    return os.environ.get(_MODEL_PIN_ENV, "").strip().lower() in ("1", "true", "yes", "on")
 
 # Liberal mapping — frameworks use varied vocabulary. Keys are normalized
 # (lowercased, hyphens → underscores). Add to this rather than reject when
@@ -86,6 +98,8 @@ class RoutingHints:
     agent_role: str | None = None             # normalized lowercase form
     quality_threshold: float | None = None
     excluded_providers: frozenset[str] | None = None
+    # Eval/debug pin (env-gated; None unless MODELMELD_ALLOW_MODEL_PIN is set).
+    pin_model: str | None = None
 
     @property
     def has_category_hint(self) -> bool:
@@ -117,12 +131,19 @@ def extract_hints_from_headers(headers: Mapping[str, str]) -> RoutingHints:
     agent_role = _parse_agent_role(h.get(HEADER_AGENT_ROLE))
     quality_threshold = _parse_quality_threshold(h.get(HEADER_QUALITY_THRESHOLD))
     excluded_providers = _parse_excluded_providers(h.get(HEADER_EXCLUDE_PROVIDERS))
+    # Env-gated: the pin header is only read when explicitly enabled, so the
+    # field stays None (header ignored) on every default/production gateway.
+    pin_model = None
+    if _model_pin_enabled():
+        raw_pin = h.get(HEADER_PIN_MODEL)
+        pin_model = raw_pin.strip() if raw_pin and raw_pin.strip() else None
 
     return RoutingHints(
         task_category=task_category,
         agent_role=agent_role,
         quality_threshold=quality_threshold,
         excluded_providers=excluded_providers,
+        pin_model=pin_model,
     )
 
 

--- a/src/modelmeld/scout/capability.py
+++ b/src/modelmeld/scout/capability.py
@@ -206,6 +206,16 @@ class CapabilityScout:
         the customer only supplied an Anthropic BYOK key would just
         cascade to a 503. None means "no BYOK restriction known."
         """
+        # Eval/debug model pin (env-gated upstream in routing_hints —
+        # `pin_model` is only ever populated when MODELMELD_ALLOW_MODEL_PIN is
+        # set, so this is inert on a default/production gateway). When present,
+        # bypass capability selection entirely and serve exactly that model, so
+        # a specific served model can be benchmarked end-to-end (agentic-
+        # efficiency eval) without skewing registry data or per-token routing.
+        pinned = hints.pin_model if hints is not None else None
+        if pinned:
+            return self._pinned_decision(request, pinned)
+
         # Hint-driven category overrides the classifier. Frameworks know what
         # their agents do; we trust the declaration when present.
         category_decision: TaskCategoryDecision | None = None
@@ -370,6 +380,32 @@ class CapabilityScout:
             category_decision=category_decision,
             devtool_fingerprint=fingerprint,
             rationale=rationale,
+        )
+
+    def _pinned_decision(
+        self, request: ChatCompletionRequest, model_id: str,
+    ) -> CapabilityDecision:
+        """Serve an explicitly pinned model, bypassing capability selection.
+        Eval/debug only (env-gated upstream). Raises NoEligibleModelError if the
+        pinned id isn't in the registry, so an operator typo fails loudly rather
+        than silently falling back to normal routing."""
+        entry = self.registry.get(model_id)
+        if entry is None:
+            raise NoEligibleModelError(
+                task_category="pinned",
+                quality_threshold=0.0,
+                eligible_providers=None,
+            )
+        return CapabilityDecision(
+            chosen_model_id=entry.model_id,
+            chosen_provider=entry.provider,
+            task_category="pinned",
+            task_score=0.0,
+            quality_threshold=0.0,
+            fallback_model_ids=[],
+            category_decision=None,
+            devtool_fingerprint=self.fingerprinter.identify(request),
+            rationale=f"PIN: model={entry.model_id};scout_bypassed(MODELMELD_ALLOW_MODEL_PIN)",
         )
 
     def lookup_fallback(self, model_id: str) -> ModelEntry | None:

--- a/tests/test_chat_capability_routing.py
+++ b/tests/test_chat_capability_routing.py
@@ -595,3 +595,62 @@ async def test_anthropic_stream_message_start_carries_canonical_routed_model() -
     assert msg_start is not None, f"no message_start event in stream: {raw[:300]!r}"
     assert msg_start["message"]["model"] == "qwen-cheap"
     assert cheap.received_models == ["qwen-cheap"]
+
+
+# ---------------------------------------------------------------------------
+# Eval/debug model pin (env-gated). When MODELMELD_ALLOW_MODEL_PIN is set, the
+# x-modelmeld-pin-model header forces a specific served model, bypassing the
+# scout. Inert (header ignored) when the env is unset — never a production
+# surface. Enables benchmarking a specific model end-to-end (agentic eval).
+# ---------------------------------------------------------------------------
+
+
+def _pin_app() -> tuple[_FakeAdapter, _FakeAdapter, object]:
+    # Scout would pick qwen-cheap (cheapest meeting threshold); the pin targets
+    # the pricier model so a successful pin is unambiguous.
+    cheap = _FakeAdapter("vllm")
+    pricier = _FakeAdapter("anthropic")
+    app = _build_app_with_capability_router(
+        registry_entries=[
+            _entry("qwen-cheap", "vllm", 0.5, 1.0, coding=0.85),
+            _entry("pricier-pin", "anthropic", 2.0, 4.0, coding=0.90),
+        ],
+        adapters={"vllm": cheap, "anthropic": pricier},
+    )
+    return cheap, pricier, app
+
+
+async def test_model_pin_overrides_scout_when_env_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("MODELMELD_ALLOW_MODEL_PIN", "1")
+    cheap, pricier, app = _pin_app()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            json=_payload("refactor this function"),
+            headers={"x-modelmeld-pin-model": "pricier-pin"},
+        )
+    assert resp.status_code == 200
+    # Pinned model served despite being pricier than the scout's normal pick.
+    assert pricier.received_models == ["pricier-pin"]
+    assert cheap.received_models == []
+    assert resp.headers["x-modelmeld-routed-model"] == "pricier-pin"
+
+
+async def test_model_pin_header_ignored_when_env_disabled(monkeypatch) -> None:
+    monkeypatch.delenv("MODELMELD_ALLOW_MODEL_PIN", raising=False)
+    cheap, pricier, app = _pin_app()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            json=_payload("refactor this function"),
+            headers={"x-modelmeld-pin-model": "pricier-pin"},
+        )
+    assert resp.status_code == 200
+    # Env off → header ignored → scout picks the cheapest as usual.
+    assert cheap.received_models == ["qwen-cheap"]
+    assert pricier.received_models == []
+    assert resp.headers["x-modelmeld-routed-model"] == "qwen-cheap"


### PR DESCRIPTION
## Summary

  Adds an `x-modelmeld-pin-model` header that forces a specific served model and
  bypasses capability selection — honored **only** when the gateway env
  `MODELMELD_ALLOW_MODEL_PIN` is set. On any default/production deployment the env
  is unset, so the header is ignored (the hint field stays `None`) and routing is
  unchanged. This is a testing/debug primitive — **not a public API surface** — that
  lets us benchmark a specific served model end-to-end (e.g. an agentic-efficiency
  eval) without skewing registry data or per-token routing.

  ## Type of change

  - [x] New feature (non-breaking change that adds capability)

  ## Test plan

  - `tests/test_chat_capability_routing.py`: `test_model_pin_overrides_scout_when_env_enabled`
    (with the env set, a pinned pricier model is served despite the scout's cheaper
    pick) and `test_model_pin_header_ignored_when_env_disabled` (env unset → header
    ignored → normal routing). Full suite: `pytest -q` → 1178 passed; `ruff`,
    `pyright src`, `scripts/verify_boundary.py` green.

  ## Linked issues

  N/A

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [ ] Documentation updated if user-facing behavior changed
  - [x] `pytest` passes (full suite, not just the changed file)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md` first

  ## Additional context

  Default-off by design: nothing changes for existing deployments. A pinned id not
  in the registry raises `NoEligibleModelError` (fails loudly on operator typo).