### PR TITLE
feat(routing): latency-aware ranking for auto-policy agentic requests

### DIFF
--- a/src/modelmeld/scout/capability.py
+++ b/src/modelmeld/scout/capability.py
@@ -80,6 +80,28 @@ _AUTOCOMPLETE_MAX_INPUT_CHARS = 4000
 # "trivial-fast" tier's task scores.
 _AUTOCOMPLETE_QUALITY_THRESHOLD = 0.55
 
+# --- D1 latency term (routing-objective redesign) ---
+# Applied ONLY to `-auto` + tool-bearing (agentic) requests; `-saver` stays
+# pure cost (predictable cost ceiling is its wedge) and `-quality` is
+# frontier-first. The scout ranks eligible candidates by latency-adjusted
+# cost: blended_cost * (1 + _AUTO_LATENCY_WEIGHT * estimated_turn_latency_s).
+#
+# Weight calibration (deliberately modest — see the pressure-test in
+# docs/design-routing-objective.md): at ~0.02/s a 15 s/turn model carries a
+# ~+30% effective-cost penalty vs ~+14% for a 7 s/turn one. This BREAKS
+# NEAR-COST TIES toward the faster option (the per-(model x provider) case:
+# same model + same cost on two backends, faster backend wins) but by design
+# does NOT override a large genuine cost advantage. It is NOT meant to flip a
+# 2x-cheaper-but-slower model on its own — that model's real problem is
+# reliability + turns-to-converge (RO-3) and mid-flight escalation (RO-5),
+# not per-turn latency. Tuning this weight to force such a flip would be a
+# savings claim that doesn't survive pressure-testing.
+_AUTO_LATENCY_WEIGHT = 0.02
+# Agentic turns emit little output (D-1 telemetry: ~91 output tokens/turn vs
+# ~61k input). Input size is taken from the actual request; output uses this
+# small fixed reference.
+_AGENTIC_REF_OUTPUT_TOKENS = 128
+
 # Optional dependency: framework-supplied hints. Imported under
 # TYPE_CHECKING to avoid an import cycle (api.routing_hints imports task_category).
 from typing import TYPE_CHECKING
@@ -340,12 +362,29 @@ class CapabilityScout:
         require_tool_support = bool(request.tools)
         min_ctx_required = self._required_context_window(request)
 
+        # D1 latency term: only `-auto` + tool-bearing (agentic) requests rank
+        # on latency-adjusted cost. `-saver` and non-alias requests stay pure
+        # cost (latency_weight=0 → byte-identical to the old ranking);
+        # `-quality` is frontier-first and not latency-ranked in v1.
+        latency_weight = 0.0
+        latency_ref_input = 0
+        latency_rationale = ""
+        if policy is ModelMeldPolicy.AUTO and require_tool_support:
+            latency_weight = _AUTO_LATENCY_WEIGHT
+            latency_ref_input = self._estimated_input_tokens(request)
+            latency_rationale = (
+                f"d1=latency(w={_AUTO_LATENCY_WEIGHT};ref_in={latency_ref_input})"
+            )
+
         ranked = self.registry.rank(
             task_category=category,
             quality_threshold=threshold,
             eligible_providers=eligible,
             min_context_window=min_ctx_required,
             require_tool_support=require_tool_support,
+            latency_weight=latency_weight,
+            latency_ref_input_tokens=latency_ref_input,
+            latency_ref_output_tokens=_AGENTIC_REF_OUTPUT_TOKENS,
         )
         if not ranked:
             raise NoEligibleModelError(
@@ -369,6 +408,8 @@ class CapabilityScout:
             rationale = f"{rationale};{policy_rationale}"
         if bias_rationale:
             rationale = f"{rationale};{bias_rationale}"
+        if latency_rationale:
+            rationale = f"{rationale};{latency_rationale}"
 
         return CapabilityDecision(
             chosen_model_id=chosen_entry.model_id,
@@ -486,20 +527,11 @@ class CapabilityScout:
                 return False  # short-circuit on first overage
         return char_count <= _AUTOCOMPLETE_MAX_INPUT_CHARS
 
-    def _required_context_window(self, request: ChatCompletionRequest) -> int:
-        """Estimate the context window the request demands.
-
-        Counts input chars across all message contents, divides by
-        ~4 chars/token (the conservative-for-code estimate per the
-        litellm canonical pattern), adds `max_tokens` budget for the
-        response, then applies 1.2× headroom for prompt-engineering
-        overhead (system prompt template, message role tokens, etc.).
-
-        Returns 0 when the request is small enough that the filter is
-        a no-op. The filter only kicks in when input + response
-        plausibly exceeds smaller models' context windows
-        (~16K-32K range).
-        """
+    def _estimated_input_tokens(self, request: ChatCompletionRequest) -> int:
+        """Rough input-token estimate: message text + tool-def schemas, at
+        ~4 chars/token (conservative-for-code, per the litellm canonical
+        pattern). Used by both the context-window filter and the D1 latency
+        term (as the per-turn prefill size)."""
         char_count = 0
         for msg in request.messages:
             content = getattr(msg, "content", None)
@@ -523,6 +555,20 @@ class CapabilityScout:
                     char_count += 200  # rough estimate for unknown tool shape
                 if hasattr(tool, "function") and hasattr(tool.function, "description"):
                     char_count += len(tool.function.description or "")
-        input_tokens = char_count // _CHARS_PER_TOKEN_ESTIMATE
+        return char_count // _CHARS_PER_TOKEN_ESTIMATE
+
+    def _required_context_window(self, request: ChatCompletionRequest) -> int:
+        """Estimate the context window the request demands.
+
+        Input tokens (`_estimated_input_tokens`) + `max_tokens` response
+        budget, times 1.2× headroom for prompt-engineering overhead (system
+        prompt template, message role tokens, etc.).
+
+        Returns 0 when the request is small enough that the filter is
+        a no-op. The filter only kicks in when input + response
+        plausibly exceeds smaller models' context windows
+        (~16K-32K range).
+        """
+        input_tokens = self._estimated_input_tokens(request)
         response_budget = request.max_tokens or 1024
         return int((input_tokens + response_budget) * _CONTEXT_WINDOW_HEADROOM_MULT)

--- a/src/modelmeld/scout/multi_provider_registry.py
+++ b/src/modelmeld/scout/multi_provider_registry.py
@@ -33,7 +33,11 @@ import json
 import logging
 from importlib import resources
 
-from modelmeld.scout.registry import ModelEntry, ModelRegistry
+from modelmeld.scout.registry import (
+    ModelEntry,
+    ModelRegistry,
+    _effective_cost_key,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +114,9 @@ class MultiProviderModelRegistry(ModelRegistry):
         eligible_providers: frozenset[str] | None = None,
         min_context_window: int = 0,
         require_tool_support: bool = False,
+        latency_weight: float = 0.0,
+        latency_ref_input_tokens: int = 0,
+        latency_ref_output_tokens: int = 0,
     ) -> list[tuple[ModelEntry, float]]:
         """Multi-provider rank: iterates over every ``(model_id, provider)``
         row, not just the base's collapsed ``_by_id`` representatives.
@@ -117,9 +124,16 @@ class MultiProviderModelRegistry(ModelRegistry):
         Required for ``eligible_providers`` filtering to actually pick the
         right provider when a model has multiple rows. Without this
         override, the base class only sees one entry per model_id (the
-        last-inserted one) — so a customer who configured only Fireworks
-        would have qwen3-coder-30b's Fireworks row hidden if vLLM was
-        inserted last in the registry.
+        last-inserted one) — so a customer who configured only one upstream
+        would have a model's other-provider rows hidden if a different
+        provider was inserted last in the registry.
+
+        Latency (D1) ordering is identical to the base class — see
+        ``ModelRegistry.rank`` and ``_effective_cost_key``. Because each
+        ``(model_id, provider)`` row carries its own latency fields, the
+        latency term ranks *per provider* once per-provider latency data
+        lands; with model-level seed data the rows for one model share a
+        latency and the term reduces to model-level ordering.
         """
         result: list[tuple[ModelEntry, float]] = []
         for entry in self._by_key.values():
@@ -132,7 +146,12 @@ class MultiProviderModelRegistry(ModelRegistry):
             if not entry.meets_threshold(task_category, quality_threshold):
                 continue
             result.append((entry, entry.blended_cost_per_m()))
-        result.sort(key=lambda pair: pair[1])
+        result.sort(
+            key=lambda pair: _effective_cost_key(
+                pair[0], pair[1], latency_weight,
+                latency_ref_input_tokens, latency_ref_output_tokens,
+            )
+        )
         return result
 
     def pick(

--- a/src/modelmeld/scout/registry.py
+++ b/src/modelmeld/scout/registry.py
@@ -84,6 +84,29 @@ class ModelEntry:
     # e.g. context-management/compaction; decides which betas survive a
     # Claude->Claude substitution.
     supported_betas: tuple[str, ...] = ()
+    # --- Latency signal (D1 of the routing-objective redesign) ---
+    # Per-token price selects against the thing that governs the agentic-coding
+    # experience: time-to-complete. These two fields let the scout rank on
+    # latency-adjusted cost (see `estimated_turn_latency_s` + the scout's D1
+    # term). Both default None ("unknown") so a registry/seed without latency
+    # data behaves exactly as before — the scout's latency factor is a no-op
+    # for entries that lack it.
+    #
+    # `median_ttft_s` — median time-to-first-token in seconds. Prefill-dominated;
+    # the relevant axis for agentic turns (output is tiny, input is ~99%).
+    # `median_output_tps` — median output tokens/second (decode throughput).
+    # `latency_source` — provenance, e.g. "artificial_analysis@medium" (AA's
+    # ~1k-token reference input) or "measured" (first-party gateway telemetry).
+    #
+    # CAVEAT (load-bearing, see docs/design-routing-objective.md): public AA
+    # latency is measured at a small reference input (~1k tokens) on AA's
+    # reference provider — a COARSE proxy for our ~61k-token agentic prefill,
+    # and NOT per-serving-provider. v1 ships this model-level signal; the
+    # per-(model x provider) prefill latency that resolves provider-backend
+    # roulette comes from a later first-party-telemetry pass.
+    median_ttft_s: float | None = None
+    median_output_tps: float | None = None
+    latency_source: str = ""
 
     def blended_cost_per_m(
         self,
@@ -97,6 +120,60 @@ class ModelEntry:
 
     def meets_threshold(self, task: TaskCategory, threshold: float) -> bool:
         return self.task_scores.get(task, 0.0) >= threshold
+
+    def estimated_turn_latency_s(
+        self, input_tokens: int, output_tokens: int,
+    ) -> float | None:
+        """Estimate wall-clock seconds for one turn — the per-turn latency
+        signal the D1 term ranks on.
+
+        Returns None when this row carries no throughput data — callers treat
+        that as "no latency signal" (the scout's D1 factor falls back to
+        cost-only for such rows, so missing data never makes a model look
+        artificially fast).
+
+        v1 model (deliberately conservative):
+
+            median_ttft_s + output_tokens / median_output_tps
+
+        ``input_tokens`` is accepted but NOT used to extrapolate prefill time in
+        v1, on purpose. We only have public AA throughput: ``median_output_tps``
+        is *decode* speed, and prefill runs at a very different (much faster)
+        rate we cannot derive from it — dividing a ~61k-token agentic prefill by
+        decode tps over-estimates by 1-2 orders of magnitude and would let the
+        latency factor swamp cost. ``median_ttft_s`` (AA's ~1k-reference
+        time-to-first-token) is the prefill-onset proxy we *do* have; we use it
+        as the fixed base. Producing a real per-(model x provider) prefill
+        latency at agentic input sizes is the deferred first-party-telemetry
+        pass (see docs/design-routing-objective.md); ``input_tokens`` is kept in
+        the signature for that successor model.
+        """
+        if self.median_output_tps is None or self.median_output_tps <= 0:
+            return None
+        ttft = self.median_ttft_s or 0.0
+        return ttft + output_tokens / self.median_output_tps
+
+
+def _effective_cost_key(
+    entry: ModelEntry,
+    blended_cost: float,
+    latency_weight: float,
+    ref_input_tokens: int,
+    ref_output_tokens: int,
+) -> float:
+    """Latency-adjusted sort key (D1). Shared by base + multi-provider rank().
+
+    ``latency_weight <= 0`` returns the plain blended cost (cost-only ordering).
+    Otherwise penalize cost by estimated per-turn latency; rows with no latency
+    signal (``estimated_turn_latency_s`` is None) keep their plain cost so they
+    are neither rewarded nor punished for missing data.
+    """
+    if latency_weight <= 0:
+        return blended_cost
+    latency_s = entry.estimated_turn_latency_s(ref_input_tokens, ref_output_tokens)
+    if latency_s is None:
+        return blended_cost
+    return blended_cost * (1.0 + latency_weight * latency_s)
 
 
 class ModelRegistry:
@@ -145,6 +222,15 @@ class ModelRegistry:
                         if row.get("max_output_tokens") is not None else None
                     ),
                     supported_betas=tuple(row.get("supported_betas", ())),
+                    median_ttft_s=(
+                        float(row["median_ttft_s"])
+                        if row.get("median_ttft_s") is not None else None
+                    ),
+                    median_output_tps=(
+                        float(row["median_output_tps"])
+                        if row.get("median_output_tps") is not None else None
+                    ),
+                    latency_source=row.get("latency_source", ""),
                 )
             )
         return cls(entries)
@@ -229,6 +315,9 @@ class ModelRegistry:
         eligible_providers: frozenset[str] | None = None,
         min_context_window: int = 0,
         require_tool_support: bool = False,
+        latency_weight: float = 0.0,
+        latency_ref_input_tokens: int = 0,
+        latency_ref_output_tokens: int = 0,
     ) -> list[tuple[ModelEntry, float]]:
         """All eligible candidates sorted cheapest-first. Returns (entry, blended_cost) pairs.
 
@@ -237,6 +326,18 @@ class ModelRegistry:
           - provider in eligible_providers (if set)
           - context_window >= min_context_window
           - supports_tools == True (if require_tool_support)
+
+        Ordering (D1 latency term): when ``latency_weight > 0`` candidates are
+        sorted by a latency-adjusted *effective* cost
+        ``blended_cost * (1 + latency_weight * estimated_turn_latency_s)`` — a
+        cheaper-but-slower model loses to a slightly-pricier-but-faster one for
+        the agentic shape described by ``latency_ref_*_tokens``. Rows without
+        latency data fall back to plain cost (no reward/penalty), so a partial
+        registry never makes an unmeasured model look artificially fast. The
+        returned pair's second element is always the *real* blended cost (not
+        the effective key), so callers' cost reporting stays truthful.
+        ``latency_weight == 0`` (the default) is byte-identical to the old
+        cost-only ranking — this is what keeps ``-saver`` ranking unchanged.
         """
         result: list[tuple[ModelEntry, float]] = []
         for entry in self._by_id.values():
@@ -249,7 +350,12 @@ class ModelRegistry:
             if not entry.meets_threshold(task_category, quality_threshold):
                 continue
             result.append((entry, entry.blended_cost_per_m()))
-        result.sort(key=lambda pair: pair[1])
+        result.sort(
+            key=lambda pair: _effective_cost_key(
+                pair[0], pair[1], latency_weight,
+                latency_ref_input_tokens, latency_ref_output_tokens,
+            )
+        )
         return result
 
 

--- a/tests/test_scout_d1_latency.py
+++ b/tests/test_scout_d1_latency.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""D1 latency term — the routing-objective redesign's first dimension.
+
+Covers the `ModelEntry` latency fields + `estimated_turn_latency_s`, the
+latency-adjusted ranking in `ModelRegistry.rank` /
+`MultiProviderModelRegistry.rank`, and the scout wiring that applies the term
+ONLY to `-auto` + tool-bearing requests.
+
+The load-bearing claims (see docs/design-routing-objective.md):
+  * `-saver` / non-`-auto` ranking is byte-identical to the cost-only ordering
+    (latency_weight defaults to 0).
+  * the latency term BREAKS NEAR-COST TIES toward the faster option (the
+    per-(model x provider) case) but DOES NOT override a genuine cost gap.
+  * rows with no latency data are no-ops (never made to look fast).
+"""
+
+from __future__ import annotations
+
+from modelmeld.api.schemas import (
+    ChatCompletionRequest,
+    FunctionDef,
+    Tool,
+    UserMessage,
+)
+from modelmeld.scout.capability import CapabilityScout
+from modelmeld.scout.multi_provider_registry import MultiProviderModelRegistry
+from modelmeld.scout.registry import ModelEntry, ModelRegistry
+
+
+def _entry(
+    model_id: str,
+    provider: str,
+    cost_in: float,
+    cost_out: float,
+    *,
+    coding: float = 0.8,
+    ttft: float | None = None,
+    tps: float | None = None,
+) -> ModelEntry:
+    return ModelEntry(
+        model_id=model_id,
+        provider=provider,
+        context_window=200000,
+        cost_per_m_input=cost_in,
+        cost_per_m_output=cost_out,
+        # tool-bearing requests classify as `tool_use`; score both so the
+        # scout-level tests can pick under either classification.
+        task_scores={"coding": coding, "tool_use": coding},
+        median_ttft_s=ttft,
+        median_output_tps=tps,
+        latency_source="test" if tps is not None else "",
+    )
+
+
+# ---------------------------------------------------------------------------
+# ModelEntry latency fields + estimate
+# ---------------------------------------------------------------------------
+
+def test_latency_fields_default_none() -> None:
+    e = _entry("m", "vllm", 1.0, 1.0)
+    assert e.median_ttft_s is None
+    assert e.median_output_tps is None
+    assert e.latency_source == ""
+
+
+def test_estimated_turn_latency_none_without_throughput() -> None:
+    e = _entry("m", "vllm", 1.0, 1.0)  # no tps
+    assert e.estimated_turn_latency_s(61000, 128) is None
+
+
+def test_estimated_turn_latency_uses_ttft_plus_output_only() -> None:
+    # v1 intentionally does NOT extrapolate prefill from input_tokens.
+    e = _entry("m", "vllm", 1.0, 1.0, ttft=0.5, tps=100.0)
+    # 0.5 + 128/100 = 1.78; input size must not change it.
+    assert abs(e.estimated_turn_latency_s(1_000, 128) - 1.78) < 1e-9
+    assert e.estimated_turn_latency_s(1_000, 128) == e.estimated_turn_latency_s(
+        999_999, 128
+    )
+
+
+def test_from_json_round_trips_latency() -> None:
+    reg = ModelRegistry.from_json(
+        {
+            "version": 1,
+            "models": [
+                {
+                    "model_id": "x",
+                    "provider": "vllm",
+                    "context_window": 1000,
+                    "cost_per_m_input": 1.0,
+                    "cost_per_m_output": 1.0,
+                    "median_ttft_s": 0.5,
+                    "median_output_tps": 100.0,
+                    "latency_source": "artificial_analysis@medium",
+                },
+                {  # latency omitted -> None
+                    "model_id": "y",
+                    "provider": "vllm",
+                    "context_window": 1000,
+                    "cost_per_m_input": 1.0,
+                    "cost_per_m_output": 1.0,
+                },
+            ],
+        }
+    )
+    x = reg.get("x")
+    assert x is not None and x.median_ttft_s == 0.5 and x.median_output_tps == 100.0
+    assert x.latency_source == "artificial_analysis@medium"
+    y = reg.get("y")
+    assert y is not None and y.median_ttft_s is None and y.median_output_tps is None
+
+
+# ---------------------------------------------------------------------------
+# rank() — latency_weight=0 is the unchanged cost-only ordering
+# ---------------------------------------------------------------------------
+
+def test_rank_default_is_cost_only_and_stable() -> None:
+    reg = ModelRegistry(
+        [
+            _entry("a", "openai", 10.0, 30.0),
+            _entry("b", "openai", 1.0, 3.0),
+            _entry("c", "openai", 5.0, 15.0),
+        ]
+    )
+    default_order = [e.model_id for e, _ in reg.rank("coding")]
+    explicit_zero = [
+        e.model_id for e, _ in reg.rank("coding", latency_weight=0.0)
+    ]
+    assert default_order == explicit_zero == ["b", "c", "a"]
+
+
+def test_latency_weight_zero_ignores_latency_data() -> None:
+    # Latency data present but weight 0 -> ordering unaffected.
+    reg = ModelRegistry(
+        [
+            _entry("cheap-slow", "vllm", 1.0, 1.0, ttft=2.0, tps=30.0),
+            _entry("pricey-fast", "vllm", 2.0, 2.0, ttft=0.2, tps=200.0),
+        ]
+    )
+    order = [e.model_id for e, _ in reg.rank("coding", latency_weight=0.0)]
+    assert order == ["cheap-slow", "pricey-fast"]  # pure cost
+
+
+# ---------------------------------------------------------------------------
+# rank() — latency breaks near-cost ties (the per-provider case)
+# ---------------------------------------------------------------------------
+
+def test_latency_breaks_equal_cost_tie_toward_fast_provider() -> None:
+    # Same model, same cost, two providers, different speed.
+    fast = _entry("m", "prov-fast", 0.11, 0.80, ttft=0.4, tps=150.0)
+    slow = _entry("m", "prov-slow", 0.11, 0.80, ttft=1.2, tps=60.0)
+    reg = MultiProviderModelRegistry([slow, fast])  # insert slow first
+
+    cost_only = [e.provider for e, _ in reg.rank("coding", latency_weight=0.0)]
+    assert cost_only == ["prov-slow", "prov-fast"]  # tie -> insertion order
+
+    ranked = reg.rank(
+        "coding",
+        latency_weight=0.02,
+        latency_ref_input_tokens=61000,
+        latency_ref_output_tokens=128,
+    )
+    assert next(e.provider for e, _ in ranked) == "prov-fast"
+    # Returned cost must remain the REAL blended cost, not the effective key.
+    assert abs(ranked[0][1] - fast.blended_cost_per_m()) < 1e-9
+
+
+def test_latency_does_not_override_genuine_cost_gap() -> None:
+    # cheap+slow vs ~2x-pricier+fast: cost wins, by design.
+    cheap_slow = _entry("qwenish", "p1", 0.11, 0.80, ttft=1.2, tps=60.0)
+    pricey_fast = _entry("minimaxish", "p2", 0.255, 1.00, ttft=0.4, tps=150.0)
+    reg = MultiProviderModelRegistry([cheap_slow, pricey_fast])
+    ranked = reg.rank(
+        "coding",
+        latency_weight=0.02,
+        latency_ref_input_tokens=61000,
+        latency_ref_output_tokens=128,
+    )
+    assert ranked[0][0].model_id == "qwenish"
+
+
+def test_unmeasured_row_is_noop_under_latency() -> None:
+    # A row with no latency keeps plain cost; it is not treated as instant.
+    measured_fast = _entry("a", "p1", 1.0, 1.0, ttft=0.2, tps=200.0)
+    unmeasured_cheaper = _entry("b", "p2", 0.9, 0.9)  # cheaper, no latency
+    reg = MultiProviderModelRegistry([measured_fast, unmeasured_cheaper])
+    ranked = reg.rank(
+        "coding",
+        latency_weight=0.02,
+        latency_ref_input_tokens=61000,
+        latency_ref_output_tokens=128,
+    )
+    # unmeasured stays at its plain (cheaper) cost -> still first; latency
+    # never fabricates a speed advantage for the measured row.
+    assert ranked[0][0].model_id == "b"
+
+
+# ---------------------------------------------------------------------------
+# Scout wiring — D1 applies ONLY to -auto + tool-bearing
+# ---------------------------------------------------------------------------
+
+def _tool() -> Tool:
+    return Tool(
+        type="function",
+        function=FunctionDef(name="read_file", parameters={"type": "object"}),
+    )
+
+
+def _req(model: str, *, with_tools: bool) -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model=model,
+        messages=[UserMessage(role="user", content="refactor this module")],
+        tools=[_tool()] if with_tools else [],
+    )
+
+
+def _oss_scout() -> CapabilityScout:
+    reg = MultiProviderModelRegistry(
+        [
+            _entry("coderA", "vllm", 0.5, 1.5, ttft=0.5, tps=120.0),
+            _entry("coderB", "vllm", 0.6, 1.6, ttft=0.3, tps=180.0),
+        ]
+    )
+    return CapabilityScout(
+        registry=reg,
+        quality_threshold=0.70,
+        eligible_providers=frozenset({"vllm"}),
+    )
+
+
+async def test_auto_with_tools_applies_latency_term() -> None:
+    scout = _oss_scout()
+    decision = await scout.choose(_req("anthropic/modelmeld-auto", with_tools=True))
+    assert "d1=latency" in decision.rationale
+
+
+async def test_saver_with_tools_does_not_apply_latency() -> None:
+    scout = _oss_scout()
+    decision = await scout.choose(_req("anthropic/modelmeld-saver", with_tools=True))
+    assert "d1=latency" not in decision.rationale
+
+
+async def test_auto_without_tools_does_not_apply_latency() -> None:
+    scout = _oss_scout()
+    decision = await scout.choose(_req("anthropic/modelmeld-auto", with_tools=False))
+    assert "d1=latency" not in decision.rationale
+
+
+async def test_non_alias_with_tools_does_not_apply_latency() -> None:
+    scout = _oss_scout()
+    decision = await scout.choose(_req("qwen3-coder-next", with_tools=True))
+    assert "d1=latency" not in decision.rationale


### PR DESCRIPTION
## Summary

  Agentic coding is selected against by per-token-price routing: the cheapest-per-token model is often  the slowest and least reliable, so `-auto` ships a poor experience (long-running, wandering agentic
  loops) even though it's "cheap." This adds a measured latency signal (time-to-first-token + output  throughput) to the registry and ranks `-auto` + tool-bearing requests on latency-adjusted cost
  instead of price alone. The weight is calibrated to break near-cost ties toward the faster option; it  deliberately does NOT override a genuine cost advantage (a much-cheaper-but-slower model still wins,
  because its real cost is reliability and turns-to-converge, which are addressed separately).
  `-saver` and non-auto requests are unchanged: the latency weight defaults to 0, which is
  byte-identical to the prior cost-only ordering. Latency data is populated by the private registry
  feed; the public snapshot ships none, so the term is an inert no-op until real data lands.

  ## Type of change

  - [ ] Bug fix (non-breaking change that resolves an issue)
  - [x] New feature (non-breaking change that adds capability)
  - [ ] Breaking change (fix or feature that changes existing behavior in a way clients can observe)
  - [ ] Refactor (no behavior change, internals only)
  - [ ] Documentation
  - [ ] Test-only change
  - [ ] Build / CI / tooling

  ## Test plan

  New suite `tests/test_scout_d1_latency.py` (13 tests):
  - `ModelEntry` latency fields default to None; `estimated_turn_latency_s` returns None without
  throughput data and computes `ttft + output/output_tps` with it; `from_json` round-trips the fields.
  - `latency_weight=0` (the default) produces the exact prior cost-only ordering — regression guard
  that `-saver` and non-auto ranking are unchanged.
  - Equal-cost two-provider rows: the latency term ranks the faster provider first, while the returned
  cost stays the real blended cost.
  - A genuine ~2x cost gap is NOT overridden by latency (the cheaper-but-slower model still wins).
  - Rows with no latency data are no-ops (never made to look artificially fast).
  - Scout applies the term only for policy=auto + tool-bearing; `-saver`, non-alias, and
  auto-without-tools requests do not get it.

  Full suite: `pytest` → 1191 passed, 12 skipped. `ruff check` clean on changed files.

  ## Linked issues

  <!-- none -->

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [ ] Documentation updated if user-facing behavior changed
  - [x] `pre-commit run --all-files` passes
  - [x] `pytest` passes (full suite, not just the changed file)
  - [x] All commits have DCO signoff (`git commit -s`) — see `CONTRIBUTING.md`
  - [x] If this touches the open-core boundary or registry data, I've read `docs/open-core-boundary.md`  first

  ## Additional context

  The latency model is deliberately conservative for v1: it uses TTFT plus output-token time and does
  not extrapolate prefill latency from input size, because the only public throughput signal is
  decode-rate, which is the wrong rate for prefill and would over-estimate by 1-2 orders of magnitude.
  A per-(model, provider) prefill-latency signal measured at real agentic input sizes is a planned
  follow-up.