### PR TITLE
ci: bump GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out PR
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0  # full history needed to enumerate PR commits

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run release-please
-        uses: googleapis/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01  # v4.1.3
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7  # v5.0.0
         with:
           # Use a PAT (or GitHub App token) instead of the default
           # GITHUB_TOKEN. Tag pushes made by GITHUB_TOKEN do NOT fire

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Check out tag
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           # Use the dispatched tag if workflow_dispatch, else the
           # pushed tag (github.ref_name). `inputs.tag` is null on
@@ -50,7 +50,7 @@ jobs:
           ref: ${{ inputs.tag || github.ref_name }}
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
 
@@ -73,7 +73,7 @@ jobs:
         run: python -m build --wheel --sdist
 
       - name: Upload build artifacts for later jobs
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: modelmeld-dist
           path: dist/
@@ -85,10 +85,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out tag
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
 
@@ -111,7 +111,7 @@ jobs:
             --outfile modelmeld-${{ needs.build.outputs.version }}-sbom.json
 
       - name: Upload SBOM
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: sbom
           path: modelmeld-${{ needs.build.outputs.version }}-sbom.json
@@ -126,13 +126,13 @@ jobs:
       url: https://pypi.org/p/modelmeld
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: modelmeld-dist
           path: dist/
 
       - name: Download SBOM
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: sbom
           # Download SBOM to a separate dir, NOT dist/. The PyPI publish

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,9 +24,9 @@ jobs:
   pip-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install pip-audit
@@ -46,7 +46,7 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Fetch full history so secret scanning checks every commit,
           # not just the merge commit. Without this, a secret added then


### PR DESCRIPTION
## Summary

  GitHub forces the Node 24 runtime on runners from 2026-06-16 and removes Node 20 entirely on  2026-09-16; actions still declaring `using: node20` will stop running. The 0.16.0 release run
  surfaced the deprecation warning for checkout / setup-python / upload-artifact. This bumps every
  action that ran on Node 20 to its Node-24 release, preserving each file's existing pin style (commit
  SHA + version comment in `release.yml`/`dco.yml`, floating major tag in `ci.yml`/`security.yml`).

  - `actions/checkout` v4.2.2 -> v6.0.3
  - `actions/setup-python` v5.6.0 -> v6.2.0
  - `actions/upload-artifact` v4.4.3 -> v7.0.1
  - `actions/download-artifact` v4.1.8 -> v7.0.0
  - `googleapis/release-please-action` v4.1.3 -> v5.0.0

  `download-artifact` is held at v7 (not the latest v8) deliberately: v8 adds unrelated breaking
  surface (ESM migration, Content-Type-based decompress changes, enforced checks), while v7 already
  defaults to Node 24 and the named-artifact-across-jobs flow this repo uses is unchanged. The artifact  actions' v3->v4 immutability change is already absorbed (we were on v4). `release-please-action`
  v5's only breaking change is the Node 24 upgrade itself.

  ## Type of change

  - [ ] Bug fix (non-breaking change that resolves an issue)
  - [ ] New feature (non-breaking change that adds capability)
  - [ ] Breaking change (fix or feature that changes existing behavior in a way clients can observe)
  - [ ] Refactor (no behavior change, internals only)
  - [ ] Documentation
  - [ ] Test-only change
  - [x] Build / CI / tooling

  ## Test plan

  This PR's own checks exercise the bumped `checkout` / `setup-python`:
  - CI matrix (Python 3.10 / 3.11 / 3.12), security (pip-audit + gitleaks), and DCO must stay green.

  The `release.yml` artifact actions (`upload-artifact` / `download-artifact`) and
  `release-please-action` only run at release time, so the **next version tag is their real test**:
  - watch the next release's publish chain (PyPI -> Sigstore -> SBOM), as done for 0.16.0.
  - recovery if the artifact handoff regresses is already wired: `skip-existing: true` on the PyPI step  + `workflow_dispatch` re-run for an existing tag.

  No code or registry changes; package contents are untouched.

  ## Linked issues

  <!-- none -->

  ## Checklist

  - [ ] Tests added or updated and they actually exercise the change
  - [ ] Documentation updated if user-facing behavior changed
  - [ ] `pre-commit run --all-files` passes
  - [x] `pytest` passes (full suite, not just the changed file)
  - [x] All commits have DCO signoff (`git commit -s`) — see `CONTRIBUTING.md`
  - [ ] If this touches the open-core boundary or registry data, I've read `docs/open-core-boundary.md`  first

  ## Additional context

  Surfaced by the 0.16.0 release run's deprecation annotation. The Node-20 actions keep working until
  the September cutoff (and auto-run on Node 24 from June 16), so this is preventive, not urgent. SHA
  pins were resolved from each action's published Node-24 release tag.