### PR TITLE
fix(routing): -quality picks strongest model on agentic work, not cheapest frontier

### DIFF
--- a/src/modelmeld/scout/capability.py
+++ b/src/modelmeld/scout/capability.py
@@ -393,6 +393,26 @@ class CapabilityScout:
                 eligible_providers=eligible,
             )
 
+        # `-quality` on agentic (tool-bearing) work: pick the STRONGEST eligible
+        # model, not the cheapest one clearing the bar. The default ranking is
+        # cost-ascending, so frontier-restricted QUALITY otherwise selects the
+        # cheapest frontier model above threshold — a small/fast frontier model
+        # that no-ops on sustained agentic loops (the confirmed `-quality`
+        # agentic bug: 24/30 turns to a Haiku-tier model, zero edits). Re-rank
+        # by capability (the request's category score) descending, with cost as
+        # the tie-break so equally-capable models still prefer the cheaper one.
+        # Scoped to QUALITY + tools: simple QUALITY requests keep cost-first
+        # (cheapest frontier clearing the bar is correct there). Interim signal
+        # is the category task_score; switches to the AA `agentic_coding` prior
+        # once the live feed carries it.
+        quality_rationale = ""
+        if policy is ModelMeldPolicy.QUALITY and require_tool_support:
+            ranked = sorted(
+                ranked,
+                key=lambda pair: (-pair[0].task_scores.get(category, 0.0), pair[1]),
+            )
+            quality_rationale = "quality_agentic=capability_first"
+
         chosen_entry, chosen_cost = ranked[0]
         fallbacks: list[str] = [
             entry.model_id for entry, _ in ranked[1 : 1 + self.fallback_depth]
@@ -410,6 +430,8 @@ class CapabilityScout:
             rationale = f"{rationale};{bias_rationale}"
         if latency_rationale:
             rationale = f"{rationale};{latency_rationale}"
+        if quality_rationale:
+            rationale = f"{rationale};{quality_rationale}"
 
         return CapabilityDecision(
             chosen_model_id=chosen_entry.model_id,

--- a/tests/test_scout_quality_agentic.py
+++ b/tests/test_scout_quality_agentic.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""`-quality` on agentic (tool-bearing) work — capability-first ranking.
+
+Confirmed bug: QUALITY restricts to frontier then ranks cost-ascending, so it
+picks the *cheapest* frontier model clearing the threshold — a small/fast
+frontier model that no-ops on sustained agentic loops. Fix: for QUALITY +
+tool-bearing requests, rank by capability (the request's category score)
+descending, cost as the tie-break. Scoped to QUALITY + tools — simple QUALITY
+requests keep cost-first, and other policies are unaffected.
+"""
+
+from __future__ import annotations
+
+from modelmeld.api.schemas import (
+    ChatCompletionRequest,
+    FunctionDef,
+    Tool,
+    UserMessage,
+)
+from modelmeld.scout.capability import CapabilityScout
+from modelmeld.scout.multi_provider_registry import MultiProviderModelRegistry
+from modelmeld.scout.registry import ModelEntry
+
+QUALITY = "anthropic/modelmeld-quality"
+AUTO = "anthropic/modelmeld-auto"
+
+
+def _frontier(model_id: str, provider: str, cost_in: float, cost_out: float, score: float) -> ModelEntry:
+    return ModelEntry(
+        model_id=model_id,
+        provider=provider,                       # anthropic/openai = frontier tier
+        context_window=200000,
+        cost_per_m_input=cost_in,
+        cost_per_m_output=cost_out,
+        task_scores={"coding": score, "tool_use": score},
+    )
+
+
+def _scout(*entries: ModelEntry) -> CapabilityScout:
+    # eligible_providers left None so QUALITY's frontier filter drives selection.
+    return CapabilityScout(
+        registry=MultiProviderModelRegistry(list(entries)),
+        quality_threshold=0.70,
+    )
+
+
+def _req(model: str, *, with_tools: bool, text: str = "refactor the auth module across these files") -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model=model,
+        messages=[UserMessage(role="user", content=text)],
+        tools=(
+            [Tool(type="function", function=FunctionDef(name="edit_file", parameters={"type": "object"}))]
+            if with_tools else []
+        ),
+    )
+
+
+# Cheapest frontier model clears the bar but is the weakest; a pricier one is stronger.
+def _weak_cheap() -> ModelEntry:
+    return _frontier("mini-frontier", "openai", 0.25, 2.0, score=0.75)
+
+
+def _strong_pricey() -> ModelEntry:
+    return _frontier("big-frontier", "anthropic", 3.0, 15.0, score=0.90)
+
+
+# ---------------------------------------------------------------------------
+
+async def test_quality_agentic_picks_strongest_not_cheapest() -> None:
+    scout = _scout(_weak_cheap(), _strong_pricey())
+    decision = await scout.choose(_req(QUALITY, with_tools=True))
+    # The bug would pick mini-frontier ($0.95 blended) over big-frontier ($7.80).
+    assert decision.chosen_model_id == "big-frontier"
+    assert "quality_agentic=capability_first" in decision.rationale
+
+
+async def test_quality_agentic_breaks_capability_ties_by_cost() -> None:
+    # Two equally-capable frontier models -> prefer the cheaper.
+    cheap = _frontier("cheap-strong", "openai", 1.0, 3.0, score=0.90)
+    pricey = _frontier("pricey-strong", "anthropic", 3.0, 15.0, score=0.90)
+    scout = _scout(pricey, cheap)
+    decision = await scout.choose(_req(QUALITY, with_tools=True))
+    assert decision.chosen_model_id == "cheap-strong"
+
+
+async def test_quality_simple_request_stays_cost_first() -> None:
+    # No tools + max_tokens None => not autocomplete-shape => QUALITY still goes
+    # frontier, but the capability-first re-rank must NOT apply. Cheapest wins.
+    scout = _scout(_weak_cheap(), _strong_pricey())
+    decision = await scout.choose(_req(QUALITY, with_tools=False))
+    assert decision.chosen_model_id == "mini-frontier"
+    assert "quality_agentic=capability_first" not in decision.rationale
+
+
+async def test_auto_with_tools_does_not_get_quality_rerank() -> None:
+    scout = _scout(_weak_cheap(), _strong_pricey())
+    decision = await scout.choose(_req(AUTO, with_tools=True))
+    assert "quality_agentic=capability_first" not in decision.rationale


### PR DESCRIPTION
## Summary

  `-quality` restricts the candidate pool to the frontier tier, then the scout ranks
  cost-ascending and takes the cheapest model clearing the quality threshold. For
  tool-bearing (agentic) requests that selects the cheapest frontier model above a
  low bar — a small/fast frontier model that no-ops on sustained read/edit/verify
  loops (the confirmed bug: an agentic anchor ran ~24/30 turns on a Haiku-tier model
  with zero edits). This re-ranks QUALITY + tool-bearing requests by capability (the
  request's category score) descending, cost as the tie-break. Scoped to QUALITY +
  tools: simple QUALITY requests keep cost-first, and `-auto`/`-saver` are
  unaffected. Interim capability signal is the category task_score; it switches to
  the AA agentic-coding prior once the registry feed carries it.

  ## Type of change

  - [x] Bug fix (non-breaking change that resolves an issue)
  - [ ] New feature (non-breaking change that adds capability)
  - [ ] Breaking change (fix or feature that changes existing behavior in a way
  clients can observe)
  - [ ] Refactor (no behavior change, internals only)
  - [ ] Documentation
  - [ ] Test-only change
  - [ ] Build / CI / tooling

  ## Test plan

  `tests/test_scout_quality_agentic.py`: strongest-not-cheapest on quality+tools;
  capability ties broken by cost; simple quality requests stay cost-first (no
  re-rank); the re-rank does not leak to `-auto`. Full suite: 1195 passed, 12
  skipped. `ruff check` clean.

  ## Linked issues

  <!-- none -->

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [ ] Documentation updated if user-facing behavior changed
  - [ ] `pre-commit run --all-files` passes
  - [x] `pytest` passes (full suite, not just the changed file)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [ ] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md` first

  ## Additional context

  Same class of objective flaw as the `-auto` latency work (cost-min within tier
  under a one-shot threshold). The proper fix routes on the AA agentic-coding
  capability prior, which lands with the private registry feed; this is the
  OSS-snapshot interim using the category task_score.