### PR TITLE
ci: pin release-please-action back to v4.1.3 (v5 dropped signoff)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run release-please
-        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7  # v5.0.0
+        # Pinned to v4.1.3, NOT v5: v5 dropped support for the `signoff:` input
+        # below (it silently ignores it), which left the release PR commit
+        # without a DCO Signed-off-by trailer and failed the DCO check on the
+        # 0.16.1 PR. v4 still honors signoff. Migrating to v5 requires moving
+        # the signoff option into a release-please manifest config file
+        # (release-please-config.json) — tracked separately. v4 runs on Node 20
+        # (deprecated by GitHub 2026-09-16); revisit before then.
+        uses: googleapis/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01  # v4.1.3
         with:
           # Use a PAT (or GitHub App token) instead of the default
           # GITHUB_TOKEN. Tag pushes made by GITHUB_TOKEN do NOT fire


### PR DESCRIPTION
## Summary

  `release-please-action` v5.0.0 — bumped in the Node-20 action sweep (#91) —
  silently ignores the `signoff:` input the workflow relies on, so the generated
  release PR commit lost its DCO `Signed-off-by` trailer and the 0.16.1 release PR
  (#93) failed the DCO check. (0.16.0/#87 was generated by v4 and passed; #93 by v5
  did not.) v4.1.3 still honors `signoff`. This pins `release-please-action` back to
  v4.1.3. It was an optional add-on to the Node-20 sweep, not one of the flagged
  actions, so reverting just it leaves checkout / setup-python / upload-artifact /
  download-artifact on their Node-24 versions. Migrating to v5 requires moving
  signoff into a release-please manifest config file — tracked separately.

  ## Type of change

  - [x] Bug fix (non-breaking change that resolves an issue)
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Test-only change
  - [x] Build / CI / tooling

  ## Test plan

  After merge to `main`, the Release PR workflow re-runs under v4.1.3 and regenerates  PR #93's commit with the `Signed-off-by` trailer; the DCO check on #93 should then
  pass. Verify #93's head commit shows `Signed-off-by: kevinsmith51 ...` and DCO is
  green before merging it.

  ## Linked issues

  <!-- none -->

  ## Checklist

  - [x] All commits have DCO signoff (`git commit -s`)
  - [ ] `pre-commit run --all-files` passes  <!-- repo has no pre-commit config; CI
  is the gate -->
  - [x] `pytest` passes  <!-- workflow-only change; full suite unaffected -->

  ## Additional context

  v4.1.3 runs on Node 20, which GitHub removes 2026-09-16 — revisit (migrate signoff
  to manifest config, then re-bump to v5) before then.