### PR TITLE
feat(routing): -quality ranks on the agentic_coding prior when available

### DIFF
--- a/src/modelmeld/scout/capability.py
+++ b/src/modelmeld/scout/capability.py
@@ -102,6 +102,12 @@ _AUTO_LATENCY_WEIGHT = 0.02
 # small fixed reference.
 _AGENTIC_REF_OUTPUT_TOKENS = 128
 
+# Capability category `-quality` ranks agentic (tool-bearing) requests by.
+# Sourced from AA's Coding Index via the live registry feed (a sustained-
+# agentic-coding success-rate prior); absent in the OSS snapshot, where the
+# scout falls back per-model to the request's category score.
+_AGENTIC_CAPABILITY_CATEGORY = "agentic_coding"
+
 # Optional dependency: framework-supplied hints. Imported under
 # TYPE_CHECKING to avoid an import cycle (api.routing_hints imports task_category).
 from typing import TYPE_CHECKING
@@ -399,19 +405,31 @@ class CapabilityScout:
         # cheapest frontier model above threshold — a small/fast frontier model
         # that no-ops on sustained agentic loops (the confirmed `-quality`
         # agentic bug: 24/30 turns to a Haiku-tier model, zero edits). Re-rank
-        # by capability (the request's category score) descending, with cost as
-        # the tie-break so equally-capable models still prefer the cheaper one.
-        # Scoped to QUALITY + tools: simple QUALITY requests keep cost-first
-        # (cheapest frontier clearing the bar is correct there). Interim signal
-        # is the category task_score; switches to the AA `agentic_coding` prior
-        # once the live feed carries it.
+        # by capability descending, with cost as the tie-break so equally-capable
+        # models still prefer the cheaper one. Scoped to QUALITY + tools: simple
+        # QUALITY requests keep cost-first (cheapest frontier clearing the bar is
+        # correct there).
+        #
+        # Capability signal: prefer the `agentic_coding` prior (AA Coding Index
+        # — a sustained-agentic-coding SUCCESS-rate signal, the right axis for
+        # "won't no-op"), falling back per-model to the request's category score
+        # when a model lacks it (e.g. the OSS snapshot ships no agentic_coding;
+        # only the live feed carries it). Both are 0..1 capability scores; the
+        # mix is monotonic and degrades gracefully to the prior behavior when
+        # the prior is absent.
         quality_rationale = ""
         if policy is ModelMeldPolicy.QUALITY and require_tool_support:
-            ranked = sorted(
-                ranked,
-                key=lambda pair: (-pair[0].task_scores.get(category, 0.0), pair[1]),
+            def _capability(entry: ModelEntry) -> float:
+                ts = entry.task_scores
+                return ts.get(_AGENTIC_CAPABILITY_CATEGORY, ts.get(category, 0.0))
+
+            ranked = sorted(ranked, key=lambda pair: (-_capability(pair[0]), pair[1]))
+            signal = (
+                _AGENTIC_CAPABILITY_CATEGORY
+                if any(_AGENTIC_CAPABILITY_CATEGORY in e.task_scores for e, _ in ranked)
+                else category
             )
-            quality_rationale = "quality_agentic=capability_first"
+            quality_rationale = f"quality_agentic=capability_first(by={signal})"
 
         chosen_entry, chosen_cost = ranked[0]
         fallbacks: list[str] = [

--- a/tests/test_scout_quality_agentic.py
+++ b/tests/test_scout_quality_agentic.py
@@ -27,14 +27,20 @@ QUALITY = "anthropic/modelmeld-quality"
 AUTO = "anthropic/modelmeld-auto"
 
 
-def _frontier(model_id: str, provider: str, cost_in: float, cost_out: float, score: float) -> ModelEntry:
+def _frontier(
+    model_id: str, provider: str, cost_in: float, cost_out: float, score: float,
+    *, tool_use: float | None = None, agentic: float | None = None,
+) -> ModelEntry:
+    ts = {"coding": score, "tool_use": tool_use if tool_use is not None else score}
+    if agentic is not None:
+        ts["agentic_coding"] = agentic
     return ModelEntry(
         model_id=model_id,
         provider=provider,                       # anthropic/openai = frontier tier
         context_window=200000,
         cost_per_m_input=cost_in,
         cost_per_m_output=cost_out,
-        task_scores={"coding": score, "tool_use": score},
+        task_scores=ts,
     )
 
 
@@ -98,3 +104,23 @@ async def test_auto_with_tools_does_not_get_quality_rerank() -> None:
     scout = _scout(_weak_cheap(), _strong_pricey())
     decision = await scout.choose(_req(AUTO, with_tools=True))
     assert "quality_agentic=capability_first" not in decision.rationale
+
+
+async def test_quality_ranks_by_agentic_coding_when_present() -> None:
+    # agentic_coding DISAGREES with tool_use: by tool_use A wins, by the
+    # agentic prior B wins. -quality must prefer the agentic prior.
+    a = _frontier("high-tooluse", "openai", 1.0, 3.0, 0.8, tool_use=0.90, agentic=0.50)
+    b = _frontier("high-agentic", "anthropic", 3.0, 15.0, 0.8, tool_use=0.70, agentic=0.85)
+    scout = _scout(a, b)
+    decision = await scout.choose(_req(QUALITY, with_tools=True))
+    assert decision.chosen_model_id == "high-agentic"
+    assert "by=agentic_coding" in decision.rationale
+
+
+async def test_quality_falls_back_to_category_without_agentic_prior() -> None:
+    # No model carries agentic_coding (OSS snapshot) -> fall back to the
+    # category score; behavior + rationale reflect the fallback signal.
+    scout = _scout(_weak_cheap(), _strong_pricey())
+    decision = await scout.choose(_req(QUALITY, with_tools=True))
+    assert decision.chosen_model_id == "big-frontier"   # strongest by tool_use
+    assert "by=tool_use" in decision.rationale


### PR DESCRIPTION
## Summary

  The `-quality` agentic fix re-ranks tool-bearing requests by capability; it used
  the request's category score (`tool_use`) as the only signal. Now that the registry  feed carries `agentic_coding` (AA's Coding Index — a sustained-agentic-coding
  success-rate prior, the right axis for "won't no-op"), `-quality` prefers it
  per-model, falling back to the category score when a model lacks it (the OSS
  snapshot ships no `agentic_coding`; only the live feed carries it). Both are 0–1
  capability scores, so the mix is monotonic and degrades to the prior behavior when
  the prior is absent. The decision rationale records which signal drove the rank
  (`by=agentic_coding` or `by=<category>`).

  ## Type of change

  - [ ] Bug fix
  - [x] New feature (non-breaking; refines existing `-quality` ranking)
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Test-only change
  - [ ] Build / CI / tooling

  ## Test plan

  `tests/test_scout_quality_agentic.py`: `agentic_coding` preferred over a
  disagreeing `tool_use` ranking; graceful fallback to the category when no eligible
  model carries the prior; existing `-quality` scoping tests (strongest-not-cheapest,  tie-break by cost, simple requests stay cost-first, no leak to `-auto`) unchanged.
  Full suite: 1197 passed, 12 skipped. `ruff` clean.

  ## Linked issues

  <!-- none -->

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [ ] Documentation updated if user-facing behavior changed
  - [ ] `pre-commit run --all-files` passes
  - [x] `pytest` passes (full suite)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md` first

  ## Additional context

  Completes the interim `-quality` fix (which shipped ranking on the `tool_use` proxy  because `agentic_coding` wasn't yet in the registry). No behavior change until the
  feed carrying `agentic_coding` is deployed; until then the per-model fallback
  preserves current behavior. Ships in 0.17.0.