### PR TITLE
fix(routing): D1 imputes median latency for unmeasured models, not zero

### DIFF
--- a/src/modelmeld/scout/multi_provider_registry.py
+++ b/src/modelmeld/scout/multi_provider_registry.py
@@ -36,7 +36,7 @@ from importlib import resources
 from modelmeld.scout.registry import (
     ModelEntry,
     ModelRegistry,
-    _effective_cost_key,
+    _sort_latency_adjusted,
 )
 
 logger = logging.getLogger(__name__)
@@ -146,13 +146,10 @@ class MultiProviderModelRegistry(ModelRegistry):
             if not entry.meets_threshold(task_category, quality_threshold):
                 continue
             result.append((entry, entry.blended_cost_per_m()))
-        result.sort(
-            key=lambda pair: _effective_cost_key(
-                pair[0], pair[1], latency_weight,
-                latency_ref_input_tokens, latency_ref_output_tokens,
-            )
+        return _sort_latency_adjusted(
+            result, latency_weight,
+            latency_ref_input_tokens, latency_ref_output_tokens,
         )
-        return result
 
     def pick(
         self,

--- a/src/modelmeld/scout/registry.py
+++ b/src/modelmeld/scout/registry.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import statistics
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from importlib import resources
@@ -154,26 +155,51 @@ class ModelEntry:
         return ttft + output_tokens / self.median_output_tps
 
 
-def _effective_cost_key(
-    entry: ModelEntry,
-    blended_cost: float,
+def _sort_latency_adjusted(
+    result: list[tuple[ModelEntry, float]],
     latency_weight: float,
     ref_input_tokens: int,
     ref_output_tokens: int,
-) -> float:
-    """Latency-adjusted sort key (D1). Shared by base + multi-provider rank().
+) -> list[tuple[ModelEntry, float]]:
+    """Sort ``(entry, blended_cost)`` pairs by latency-adjusted cost (D1).
+    Shared by base + multi-provider ``rank()``.
 
-    ``latency_weight <= 0`` returns the plain blended cost (cost-only ordering).
-    Otherwise penalize cost by estimated per-turn latency; rows with no latency
-    signal (``estimated_turn_latency_s`` is None) keep their plain cost so they
-    are neither rewarded nor punished for missing data.
+    ``latency_weight <= 0`` → plain cost order (byte-identical to the old
+    cost-only ranking; this is what keeps ``-saver`` unchanged). Otherwise the
+    key is ``blended_cost * (1 + latency_weight * latency_s)``.
+
+    **Missing-data handling (the load-bearing bit):** a candidate with no
+    latency signal is imputed the **median latency of the measured candidates**
+    — NOT treated as instant. Earlier this gave unmeasured rows a free pass
+    (factor 1.0), which under partial coverage perversely rewarded exactly the
+    models we hadn't measured (e.g. the cheapest default pick) and penalized the
+    ones we had. Median imputation makes missing data *neutral*: an unmeasured
+    model ranks as an average-latency one, never an advantaged one. If NO
+    candidate has latency data, falls back to plain cost. The returned pair
+    keeps the real blended cost (not the effective key), so cost reporting stays
+    truthful; the sort is stable.
     """
-    if latency_weight <= 0:
-        return blended_cost
-    latency_s = entry.estimated_turn_latency_s(ref_input_tokens, ref_output_tokens)
-    if latency_s is None:
-        return blended_cost
-    return blended_cost * (1.0 + latency_weight * latency_s)
+    if latency_weight <= 0 or not result:
+        return sorted(result, key=lambda pair: pair[1])
+    latencies = [
+        e.estimated_turn_latency_s(ref_input_tokens, ref_output_tokens)
+        for e, _ in result
+    ]
+    measured = [lat for lat in latencies if lat is not None]
+    if not measured:
+        return sorted(result, key=lambda pair: pair[1])
+    median_lat = statistics.median(measured)
+
+    def _effective(indexed: tuple[int, tuple[ModelEntry, float]]) -> float:
+        i, (_, cost) = indexed
+        # Bind to a local so the None-narrowing sticks (pyright doesn't retain
+        # narrowing across a re-evaluated subscript).
+        measured_lat = latencies[i]
+        lat = measured_lat if measured_lat is not None else median_lat
+        return cost * (1.0 + latency_weight * lat)
+
+    ordered = sorted(enumerate(result), key=_effective)
+    return [pair for _, pair in ordered]
 
 
 class ModelRegistry:
@@ -350,13 +376,10 @@ class ModelRegistry:
             if not entry.meets_threshold(task_category, quality_threshold):
                 continue
             result.append((entry, entry.blended_cost_per_m()))
-        result.sort(
-            key=lambda pair: _effective_cost_key(
-                pair[0], pair[1], latency_weight,
-                latency_ref_input_tokens, latency_ref_output_tokens,
-            )
+        return _sort_latency_adjusted(
+            result, latency_weight,
+            latency_ref_input_tokens, latency_ref_output_tokens,
         )
-        return result
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_scout_d1_latency.py
+++ b/tests/test_scout_d1_latency.py
@@ -181,20 +181,35 @@ def test_latency_does_not_override_genuine_cost_gap() -> None:
     assert ranked[0][0].model_id == "qwenish"
 
 
-def test_unmeasured_row_is_noop_under_latency() -> None:
-    # A row with no latency keeps plain cost; it is not treated as instant.
-    measured_fast = _entry("a", "p1", 1.0, 1.0, ttft=0.2, tps=200.0)
-    unmeasured_cheaper = _entry("b", "p2", 0.9, 0.9)  # cheaper, no latency
-    reg = MultiProviderModelRegistry([measured_fast, unmeasured_cheaper])
+def test_unmeasured_row_imputed_median_not_instant() -> None:
+    # Three equal-cost models: fast (low latency), slow (high latency), and an
+    # unmeasured one. The unmeasured row is imputed the MEDIAN latency of the
+    # measured rows, so it sorts BETWEEN fast and slow. Under the old "no
+    # latency -> no penalty" behavior it would have been treated as instant and
+    # ranked FIRST (a free pass), which is the perverse outcome this fixes.
+    fast = _entry("fast", "p1", 1.0, 1.0, ttft=0.1, tps=500.0)   # ~0.36s
+    slow = _entry("slow", "p2", 1.0, 1.0, ttft=3.0, tps=20.0)    # ~9.4s
+    unmeasured = _entry("unmeasured", "p3", 1.0, 1.0)            # no latency
+    reg = MultiProviderModelRegistry([fast, slow, unmeasured])
     ranked = reg.rank(
         "coding",
         latency_weight=0.02,
         latency_ref_input_tokens=61000,
         latency_ref_output_tokens=128,
     )
-    # unmeasured stays at its plain (cheaper) cost -> still first; latency
-    # never fabricates a speed advantage for the measured row.
-    assert ranked[0][0].model_id == "b"
+    assert [e.model_id for e, _ in ranked] == ["fast", "unmeasured", "slow"]
+
+
+def test_no_candidate_has_latency_falls_back_to_cost() -> None:
+    # If NOTHING is measured, ranking is plain cost (no imputation possible).
+    a = _entry("a", "p1", 2.0, 2.0)
+    b = _entry("b", "p2", 1.0, 1.0)
+    reg = MultiProviderModelRegistry([a, b])
+    ranked = reg.rank(
+        "coding", latency_weight=0.02,
+        latency_ref_input_tokens=61000, latency_ref_output_tokens=128,
+    )
+    assert [e.model_id for e, _ in ranked] == ["b", "a"]  # pure cost
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

  The D1 latency term treated a candidate with no latency data as instant (factor 1.0, no penalty).  Under partial coverage that perversely rewarded exactly the unmeasured models — including the
  cheapest default pick — and penalized the ones we had measured. This imputes the **median latency
  of the measured candidates** for any unmeasured row, so missing data is neutral: an unmeasured
  model ranks as average-latency, never advantaged. If no candidate has latency data at all, it falls  back to plain cost. A shared `_sort_latency_adjusted()` replaces the per-entry sort key in both
  the base and multi-provider `rank()` paths.

  ## Type of change

  - [x] Bug fix (non-breaking change that resolves an issue)
  - [ ] New feature (non-breaking change that adds capability)
  - [ ] Breaking change (fix or feature that changes existing behavior in a way clients can observe)
  - [ ] Refactor (no behavior change, internals only)
  - [ ] Documentation
  - [ ] Test-only change
  - [ ] Build / CI / tooling

  ## Test plan

  `tests/test_scout_d1_latency.py`:
  - unmeasured row is imputed the median of measured candidates (sorts BETWEEN fast and slow, not
  first — the old "treated as instant" free pass is gone)
  - no candidate has latency → falls back to pure cost order
  - existing D1 tests unchanged: `latency_weight=0` is byte-identical to cost-only ordering;
  equal-cost tie breaks toward the faster provider; a genuine cost gap is not overridden.

  Full suite: 1198 passed, 12 skipped. `ruff check` clean on the changed files.

  ## Linked issues

  <!-- none -->

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [ ] Documentation updated if user-facing behavior changed
  - [ ] `pre-commit run --all-files` passes
  - [x] `pytest` passes (full suite, not just the changed file)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md` first

  ## Additional context

  Surfaced by validating D1 against the real hosted model pool: with the old zero-penalty fallback,
  unmeasured-and-cheapest models dodged the latency term entirely while measured models absorbed it —  the opposite of the intent. Median imputation makes D1 robust to the partial latency coverage that
  will always exist (new models, rolling aliases, unreconciled ids). Ships in 0.17.0.