### PR TITLE
fix(routing): apply provider_model_id on capability egress, not the canonical id

### DIFF
--- a/src/modelmeld/api/routes/chat.py
+++ b/src/modelmeld/api/routes/chat.py
@@ -1059,13 +1059,18 @@ def _apply_model_override(
 ) -> ChatCompletionRequest:
     """For CAPABILITY routing: rewrite `request.model` to the scout's pick.
 
-    Other policies leave the request untouched.
+    The WIRE model is the chosen provider's own slug (`provider_model_id`, e.g.
+    "qwen/qwen3-coder") when the registry row carries one, falling back to the
+    canonical `model_id_override` otherwise. `model_id_override` itself stays
+    canonical for response attribution + registry lookups — only the egress
+    `request.model` is rewritten here. Other policies leave the request untouched.
     """
     if decision.model_id_override is None:
         return request
-    if decision.model_id_override == request.model:
+    wire_model = decision.provider_model_id or decision.model_id_override
+    if wire_model == request.model:
         return request
-    return request.model_copy(update={"model": decision.model_id_override})
+    return request.model_copy(update={"model": wire_model})
 
 
 def _canonical_model_id_for_header(

--- a/src/modelmeld/router/base.py
+++ b/src/modelmeld/router/base.py
@@ -57,7 +57,12 @@ class RoutingDecision:
     `scout_decision`       — what tier-Scout said (None when bypassed).
     `policy_applied`       — the policy that produced this decision.
     `rationale`            — human-readable trace for logs / debugging.
-    `model_id_override`    — for CAPABILITY routing: swap `request.model` with this.
+    `model_id_override`    — for CAPABILITY routing: the canonical model_id, used
+                             for response attribution + registry lookup.
+    `provider_model_id`    — for CAPABILITY routing: the provider's own slug to put
+                             on the egress wire (e.g. "qwen/qwen3-coder"). Distinct
+                             from `model_id_override`; empty/None → send the
+                             canonical id verbatim (back-compat for rows with none).
     `capability_decision`  — for CAPABILITY routing: full CapabilityDecision.
     """
 
@@ -67,6 +72,7 @@ class RoutingDecision:
     policy_applied: RoutingPolicy
     rationale: str
     model_id_override: str | None = None
+    provider_model_id: str | None = None
     capability_decision: object | None = None
     # ^ typed as object to avoid an import cycle between router/base + scout/capability.
 

--- a/src/modelmeld/router/capability.py
+++ b/src/modelmeld/router/capability.py
@@ -219,6 +219,7 @@ class CapabilityRouter(Router):
             return self._build_decision(
                 decision, adapter, fallback_id, provider, failover_from, skipped,
                 task_score=entry.task_scores.get(decision.task_category, 0.0),
+                provider_model_id=entry.provider_model_id,
             )
 
         raise RouterError(
@@ -236,11 +237,20 @@ class CapabilityRouter(Router):
         failover_from: str | None,
         skipped: list[str],
         task_score: float | None = None,
+        provider_model_id: str | None = None,
     ) -> RoutingDecision:
+        # The provider's wire slug for the model we actually picked: explicit on
+        # the fallback path (the fallback entry's), else the chosen decision's.
+        effective_pmid = (
+            provider_model_id if provider_model_id is not None
+            else cap_decision.provider_model_id
+        )
         if model_id != cap_decision.chosen_model_id:
             # We took a fallback — update the decision to reflect what we used.
             score = task_score if task_score is not None else cap_decision.task_score
-            cap_decision = cap_decision.with_model(model_id, provider, score)
+            cap_decision = cap_decision.with_model(
+                model_id, provider, score, provider_model_id=effective_pmid or "",
+            )
 
         suffix = f";skipped={','.join(skipped)}" if skipped else ""
         rationale = f"capability;{cap_decision.rationale}{suffix}"
@@ -255,6 +265,7 @@ class CapabilityRouter(Router):
             policy_applied=RoutingPolicy.CAPABILITY,
             rationale=rationale,
             model_id_override=model_id,
+            provider_model_id=effective_pmid or None,
             capability_decision=cap_decision,
         )
 

--- a/src/modelmeld/scout/capability.py
+++ b/src/modelmeld/scout/capability.py
@@ -169,8 +169,15 @@ class CapabilityDecision:
     category_decision: TaskCategoryDecision | None = None
     devtool_fingerprint: Fingerprint | None = None
     rationale: str = ""
+    # The provider's own model id (the slug the upstream expects on the wire),
+    # distinct from the canonical `chosen_model_id` used for attribution. Empty
+    # when the registry row has none (then the canonical id is sent verbatim).
+    provider_model_id: str = ""
 
-    def with_model(self, model_id: str, provider: str, task_score: float) -> CapabilityDecision:
+    def with_model(
+        self, model_id: str, provider: str, task_score: float,
+        provider_model_id: str = "",
+    ) -> CapabilityDecision:
         """Return a copy with a different chosen model (used during failover)."""
         return CapabilityDecision(
             chosen_model_id=model_id,
@@ -182,6 +189,7 @@ class CapabilityDecision:
             category_decision=self.category_decision,
             devtool_fingerprint=self.devtool_fingerprint,
             rationale=f"{self.rationale};failover={model_id}",
+            provider_model_id=provider_model_id,
         )
 
 
@@ -461,6 +469,7 @@ class CapabilityScout:
             category_decision=category_decision,
             devtool_fingerprint=fingerprint,
             rationale=rationale,
+            provider_model_id=chosen_entry.provider_model_id,
         )
 
     def _pinned_decision(
@@ -487,6 +496,7 @@ class CapabilityScout:
             category_decision=None,
             devtool_fingerprint=self.fingerprinter.identify(request),
             rationale=f"PIN: model={entry.model_id};scout_bypassed(MODELMELD_ALLOW_MODEL_PIN)",
+            provider_model_id=entry.provider_model_id,
         )
 
     def lookup_fallback(self, model_id: str) -> ModelEntry | None:

--- a/tests/test_router_capability.py
+++ b/tests/test_router_capability.py
@@ -61,12 +61,16 @@ def _req() -> ChatCompletionRequest:
     )
 
 
-def _entry(model_id: str, provider: str, cost_in: float, cost_out: float, coding: float) -> ModelEntry:
+def _entry(
+    model_id: str, provider: str, cost_in: float, cost_out: float, coding: float,
+    provider_model_id: str = "",
+) -> ModelEntry:
     return ModelEntry(
         model_id=model_id, provider=provider, context_window=100000,
         cost_per_m_input=cost_in, cost_per_m_output=cost_out,
         task_scores={"coding": coding},
         last_updated="2026-05-17", source="test",
+        provider_model_id=provider_model_id,
     )
 
 
@@ -105,6 +109,92 @@ async def test_anthropic_pick_maps_to_cloud_tier() -> None:
     )
     decision = await router.route(_req())
     assert decision.tier == Tier.CLOUD
+
+
+# ---------------------------------------------------------------------------
+# provider_model_id — the provider's own wire slug, distinct from the canonical
+# model_id used for attribution. Regression: the canonical id used to leak onto
+# the egress wire (the overlay's provider_model_id was never applied), so any
+# model whose provider slug differs from its canonical id 4xx'd at the upstream.
+# ---------------------------------------------------------------------------
+
+async def test_decision_carries_provider_model_id_for_wire() -> None:
+    registry = ModelRegistry([
+        _entry("qwen3-coder-480b", "openai", 0.5, 1.0, coding=0.85,
+               provider_model_id="qwen/qwen3-coder"),
+    ])
+    scout = CapabilityScout(registry=registry, quality_threshold=0.80)
+    router = CapabilityRouter(
+        scout=scout, adapters_by_provider={"openai": _FakeAdapter("openai")},
+    )
+    decision = await router.route(_req())
+    # Canonical id is preserved for attribution; the provider slug rides the wire.
+    assert decision.model_id_override == "qwen3-coder-480b"
+    assert decision.provider_model_id == "qwen/qwen3-coder"
+
+
+async def test_decision_provider_model_id_none_when_absent() -> None:
+    """No provider_model_id on the row → None, so egress sends the canonical id
+    verbatim (back-compat for providers that accept the bare name)."""
+    registry = ModelRegistry([_entry("gpt", "openai", 1.0, 3.0, coding=0.85)])
+    scout = CapabilityScout(registry=registry, quality_threshold=0.80)
+    router = CapabilityRouter(
+        scout=scout, adapters_by_provider={"openai": _FakeAdapter("openai")},
+    )
+    decision = await router.route(_req())
+    assert decision.model_id_override == "gpt"
+    assert decision.provider_model_id is None
+
+
+async def test_fallback_uses_fallback_entrys_provider_model_id() -> None:
+    """A fallback must carry the FALLBACK row's slug, not the primary's."""
+    registry = ModelRegistry([
+        _entry("qwen", "vllm", 0.5, 1.0, coding=0.85,
+               provider_model_id="vendor/qwen-primary"),         # primary
+        _entry("gpt-mini", "openai", 1.0, 3.0, coding=0.83,
+               provider_model_id="openai/gpt-mini-slug"),        # 1st fallback
+    ])
+    scout = CapabilityScout(registry=registry, quality_threshold=0.80)
+    router = CapabilityRouter(
+        scout=scout,
+        adapters_by_provider={
+            "vllm": _FakeAdapter("vllm", healthy=False),  # force fallback
+            "openai": _FakeAdapter("openai", healthy=True),
+        },
+    )
+    decision = await router.route(_req())
+    assert decision.model_id_override == "gpt-mini"
+    assert decision.provider_model_id == "openai/gpt-mini-slug"
+
+
+def test_apply_model_override_puts_provider_slug_on_wire() -> None:
+    from modelmeld.api.routes.chat import _apply_model_override
+    from modelmeld.router import RoutingDecision
+
+    adapter = _FakeAdapter("openai")
+    decision = RoutingDecision(
+        tier=Tier.CLOUD, adapter=adapter, scout_decision=None,
+        policy_applied=RoutingPolicy.CAPABILITY, rationale="t",
+        model_id_override="qwen3-coder-480b",
+        provider_model_id="qwen/qwen3-coder",
+    )
+    out = _apply_model_override(_req(), decision)
+    assert out.model == "qwen/qwen3-coder"  # wire = provider slug
+
+
+def test_apply_model_override_falls_back_to_canonical_without_slug() -> None:
+    from modelmeld.api.routes.chat import _apply_model_override
+    from modelmeld.router import RoutingDecision
+
+    adapter = _FakeAdapter("openai")
+    decision = RoutingDecision(
+        tier=Tier.CLOUD, adapter=adapter, scout_decision=None,
+        policy_applied=RoutingPolicy.CAPABILITY, rationale="t",
+        model_id_override="deepseek-v4-pro",
+        provider_model_id=None,
+    )
+    out = _apply_model_override(_req(), decision)
+    assert out.model == "deepseek-v4-pro"  # no slug → canonical verbatim
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

  Capability routing rewrote the egress `request.model` to the canonical `model_id` and never applied  the chosen registry row's `provider_model_id`. Any model whose provider slug differs from its
  canonical id (e.g. `qwen3-coder-480b` → `qwen/qwen3-coder`) was rejected upstream with a 4xx;
  routing only worked where the provider happened to accept the bare canonical name, so
  `provider_model_id` was effectively dead metadata at egress. This threads it through
  `CapabilityDecision` → `RoutingDecision` and prefers it when rewriting the wire model, while
  keeping `model_id_override` canonical so response attribution, the cache key, and the
  Anthropic-native body are unchanged. Rows without a `provider_model_id` fall back to the canonical
  id verbatim.

  ## Type of change

  - [x] Bug fix (non-breaking change that resolves an issue)

  ## Test plan

  `tests/test_router_capability.py` adds four cases: the decision carries the provider slug on the
  primary and fallback paths, returns `None` when the row has no slug, and `_apply_model_override`
  puts the provider slug on the wire while leaving the canonical id for attribution. Full suite: 1203  passed, 12 skipped. Manually verified end-to-end against a local gateway: a model whose provider
  slug differs from its canonical id now routes (previously a hard upstream 4xx); a model whose name
  matches is unchanged.

  ## Linked issues

  _none_

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [ ] Documentation updated if user-facing behavior changed (internal-only behavior; no user-facing  doc change)
  - [ ] `pre-commit run --all-files` passes (no pre-commit config in repo)
  - [x] `pytest` passes (full suite, not just the changed file)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md`