### PR TITLE
fix(translation): forward Codex reasoning.effort on the Responses surface

### DIFF
--- a/src/modelmeld/translation/openai_responses.py
+++ b/src/modelmeld/translation/openai_responses.py
@@ -18,7 +18,7 @@ Phase 1 is non-streaming. The Responses SSE event stream is a separate follow-up
 from __future__ import annotations
 
 import time
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 from modelmeld.api.schemas import (
@@ -142,6 +142,35 @@ def _to_chat_tools(tools: list[dict[str, Any]] | None) -> list[Tool] | None:
     return out or None
 
 
+# Responses `reasoning.effort` accepts "minimal" in addition to low/medium/high;
+# the internal reasoning_effort tops out at low/medium/high, so "minimal" maps to
+# "low" (the closest reasoning level).
+_RESPONSES_EFFORT_TO_REASONING: dict[str, Literal["low", "medium", "high"]] = {
+    "minimal": "low",
+    "low": "low",
+    "medium": "medium",
+    "high": "high",
+}
+
+
+def _reasoning_effort_from_responses(
+    req: ResponsesRequest,
+) -> Literal["low", "medium", "high"] | None:
+    """Codex signals thinking via the Responses `reasoning.effort` field. Forward
+    it as the internal `reasoning_effort` so OpenAI-compatible OSS backends reason
+    instead of having it dropped — mirrors `from_anthropic_request`'s B-3 Phase 2
+    forwarding for the Messages surface (without this, the effort was silently lost
+    on the Responses path). `reasoning` is an extra field (not declared on the
+    schema), so it lives in model_extra. None when no reasoning was signalled."""
+    extra = req.model_extra or {}
+    reasoning = extra.get("reasoning")
+    if isinstance(reasoning, dict):
+        effort = reasoning.get("effort")
+        if isinstance(effort, str):
+            return _RESPONSES_EFFORT_TO_REASONING.get(effort)
+    return None
+
+
 def from_responses_request(req: ResponsesRequest) -> ChatCompletionRequest:
     messages: list[Message] = []
     if req.instructions:
@@ -162,6 +191,9 @@ def from_responses_request(req: ResponsesRequest) -> ChatCompletionRequest:
         tools=_to_chat_tools(req.tools),
         tool_choice=req.tool_choice,
         stream=req.stream,
+        # Forward Codex's reasoning intent so OSS backends reason (B-3 parity with
+        # the Messages surface); None when the client signalled no reasoning.
+        reasoning_effort=_reasoning_effort_from_responses(req),
     )
 
 

--- a/tests/test_translation_openai_responses.py
+++ b/tests/test_translation_openai_responses.py
@@ -248,3 +248,34 @@ def test_empty_completion_emits_one_empty_message_item() -> None:
     assert len(resp.output) == 1
     assert resp.output[0].type == "message"
     assert resp.output[0].content[0].text == ""
+
+
+# ---------------------------------------------------------------------------
+# Reasoning-effort forwarding (B-3 parity with the Messages surface). Codex
+# signals thinking via `reasoning.effort`; without forwarding it was silently
+# dropped on the Responses path, so OSS backends under-reasoned.
+# ---------------------------------------------------------------------------
+
+def test_reasoning_effort_is_forwarded() -> None:
+    req = ResponsesRequest(
+        model="m", input="fix the bug", reasoning={"effort": "high"},
+    )
+    out = from_responses_request(req)
+    assert out.reasoning_effort == "high"
+
+
+def test_reasoning_effort_minimal_maps_to_low() -> None:
+    req = ResponsesRequest(
+        model="m", input="x", reasoning={"effort": "minimal"},
+    )
+    assert from_responses_request(req).reasoning_effort == "low"
+
+
+def test_reasoning_effort_none_when_absent_or_unknown() -> None:
+    assert from_responses_request(
+        ResponsesRequest(model="m", input="x")
+    ).reasoning_effort is None
+    # An unrecognized effort value is dropped rather than passed through.
+    assert from_responses_request(
+        ResponsesRequest(model="m", input="x", reasoning={"effort": "turbo"})
+    ).reasoning_effort is None


### PR DESCRIPTION
## Summary

  `from_responses_request` never set `reasoning_effort`, so a Codex client's `reasoning: {effort:
  ...}` was silently dropped and OpenAI-compatible OSS backends under-reasoned on the Responses path
  — while the Messages surface already forwards effort. Effort delivered is a large lever on agentic
  turn count, so this quietly degraded Codex sessions routed to OSS. This reads `reasoning.effort`
  from the request and maps it to the internal `reasoning_effort` (`minimal` → `low`;
  `low`/`medium`/`high` pass through; unknown → `None`), mirroring `from_anthropic_request`. The
  translation is additive and safe: OpenAI-compatible OSS backends honor `reasoning_effort` on
  reasoning-capable models and ignore it otherwise.

  ## Type of change

  - [x] Bug fix (non-breaking change that resolves an issue)

  ## Test plan

  `tests/test_translation_openai_responses.py` adds three cases: effort is forwarded (`high` →
  `high`), `minimal` maps to `low`, and absent/unknown values yield `None`. Full suite: 1206 passed,
  12 skipped. Manually verified end-to-end against a local gateway with a Codex-shaped multi-turn
  request: the egress wire now carries `reasoning_effort` (previously absent).

  ## Linked issues

  _none_

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [ ] Documentation updated if user-facing behavior changed (internal egress behavior; no
  user-facing doc change)
  - [ ] `pre-commit run --all-files` passes (no pre-commit config in repo)
  - [x] `pytest` passes (full suite, not just the changed file)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md`