### PR TITLE
feat(cli): add `modelmeld setup --self-host` onboarding wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,26 +11,45 @@
 
 ## Quickstart
 
+Run the gateway yourself and route real OSS models in a couple of
+minutes. You bring a provider key (OpenRouter is the easiest — one key,
+many open-weight models, pay-as-you-go); ModelMeld picks the cheapest
+model that clears the quality bar per request.
+
 ```bash
-pip install modelmeld
-modelmeld setup --tool claude-code
+pip install 'modelmeld[anthropic,openai]'
+modelmeld setup --self-host
 ```
 
-The setup CLI prompts for your ModelMeld API key (and optionally an
-Anthropic key for BYOK frontier routing), writes a sourceable shell
-script, pre-configures Claude Code's `/model` picker with the three
-ModelMeld policies, and smoke-tests the routing pipeline before
-declaring success.
+The wizard prompts for whichever provider keys you have (OpenRouter /
+Fireworks / Together for cloud-OSS routing, an optional Anthropic /
+OpenAI key for frontier escalation, or a local vLLM endpoint), enables
+capability routing, pre-configures Claude Code's `/model` picker, and —
+before declaring success — boots the gateway and **proves a real OSS
+model served a request** (it fails loudly rather than leaving you on a
+silent no-op).
 
-Then in your shell:
+Then, in two shells:
 
 ```bash
+# shell 1 — run the gateway
+source ~/.modelmeld/modelmeld-gateway.env
+uvicorn modelmeld.api.server:app --host 0.0.0.0 --port 8080
+
+# shell 2 — point Claude Code at it
 source ~/.modelmeld/setup-claude-code.sh
 claude
 ```
 
 In the Claude Code TUI, type `/model` → pick `ModelMeld — Auto` (or
-`Saver` / `Quality`). That's it. Self-hosting? See [Self-host](#self-host) below.
+`Saver` / `Quality`). No provider key yet? `modelmeld setup --self-host
+--demo` points you at the cheapest one-key on-ramp. Diagnose anytime
+with `modelmeld doctor`.
+
+> **Hosted (managed) gateway** — point your tool at our URL and skip
+> running anything yourself. Currently **invite-only beta**:
+> [request access](https://modelmeld.ai). Once you have a key,
+> `modelmeld setup --tool claude-code` configures the hosted path.
 
 ## Anthropic prompt caching, end-to-end
 
@@ -142,21 +161,32 @@ Honest non-coverage list for the v1 OSS API surface:
   current `default_registry.json` snapshot ship as the defaults. All
   tunable via constructor args.
 
-## Self-host
+## Self-host (manual config)
 
-`modelmeld setup` configures your tool against the hosted gateway at
-`api.modelmeld.ai`. To run the gateway yourself instead:
+The [Quickstart](#quickstart) wizard is the recommended path — it writes
+the config below for you and verifies real routing. To wire it by hand:
+
+The gateway reads `MODELMELD_`-prefixed env vars. **Two settings are
+required for real routing** — without them the gateway falls back to a
+no-op stub adapter that returns canned replies to every request:
 
 ```bash
 pip install 'modelmeld[anthropic,openai]'
-export ANTHROPIC_API_KEY=sk-ant-…   # your real Anthropic key
-export OPENAI_API_KEY=sk-…           # your real OpenAI key (optional)
+
+# 1. Capability routing (the scout picks a model per request).
+export MODELMELD_ROUTING_POLICY=capability
+# 2. At least one provider key (note the MODELMELD_ prefix):
+export MODELMELD_OPENROUTER_API_KEY=sk-or-…   # cloud-OSS routing
+# Optional frontier escalation for -auto / -quality:
+export MODELMELD_ANTHROPIC_API_KEY=sk-ant-…
+export MODELMELD_OPENAI_API_KEY=sk-…
+
 uvicorn modelmeld.api.server:app --host 0.0.0.0 --port 8080
 ```
 
-Then point your tool at `http://localhost:8080`. Behavior is identical
-to the hosted endpoint; you supply upstream keys via env vars instead
-of BYOK headers.
+Then point your tool at `http://localhost:8080`. In self-host you supply
+upstream keys to the gateway via these env vars (not per-request BYOK
+headers — those are for the hosted multi-tenant path).
 
 For routing across local vLLM + cloud providers, see
 [`docs/backends.md`](docs/backends.md). For full self-host operational

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -11,6 +11,14 @@ end-to-end with cost parity vs going direct to Anthropic.
 
 ## One-command setup (recommended)
 
+> **Self-hosting?** If you're running the gateway yourself (the
+> public-today path — the hosted gateway is invite-only beta), use
+> `modelmeld setup --self-host` instead. It prompts for your provider
+> keys (OpenRouter / Fireworks / Together / vLLM), enables capability
+> routing, and verifies real OSS routing before finishing. No ModelMeld
+> API key required. See the [Quickstart](../../README.md#quickstart).
+> The hosted-gateway flow below needs a `gws_` key.
+
 ```bash
 pip install modelmeld
 modelmeld setup --tool claude-code

--- a/src/modelmeld/api/server.py
+++ b/src/modelmeld/api/server.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -30,9 +31,30 @@ from modelmeld.scout import ModelRegistry, Scout, build_scout
 from modelmeld.scout.multi_provider_registry import default_multi_provider_registry
 from modelmeld.tokens import TokenCounter, build_token_counter
 
+logger = logging.getLogger(__name__)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    # Loud-fail the #1 self-host footgun: the default config
+    # (routing_policy=single + upstream_provider=stub) serves a canned
+    # stub reply to EVERY request with no error. A tester who follows a
+    # bare `uvicorn modelmeld.api.server:app` lands here and never sees
+    # real routing. Warn at startup so the silent no-op is at least loud.
+    settings = getattr(app.state, "settings", None)
+    if (
+        settings is not None
+        and getattr(settings, "routing_policy", None) == "single"
+        and getattr(settings, "upstream_provider", None) == "stub"
+    ):
+        logger.warning(
+            "ModelMeld is running with routing_policy=single + "
+            "upstream_provider=stub: ALL requests return a canned stub "
+            "reply, not real model output. Run `modelmeld setup "
+            "--self-host` (or set MODELMELD_ROUTING_POLICY=capability + a "
+            "provider key such as MODELMELD_OPENROUTER_API_KEY) to enable "
+            "real routing. See the README Self-host section.",
+        )
     try:
         yield
     finally:

--- a/src/modelmeld/cli/__init__.py
+++ b/src/modelmeld/cli/__init__.py
@@ -66,9 +66,51 @@ def main(argv: list[str] | None = None) -> int:
         help="Your OpenAI API key for BYOK frontier routing. Optional.",
     )
     setup_p.add_argument(
+        "--self-host",
+        action="store_true",
+        help=(
+            "Configure a gateway you run yourself (localhost) instead of the "
+            "hosted endpoint. Prompts for cloud-OSS provider keys (OpenRouter "
+            "/ Fireworks / Together), optional frontier keys, and/or a local "
+            "vLLM endpoint; enables capability routing; and smoke-tests real "
+            "OSS routing before declaring success. No ModelMeld API key needed."
+        ),
+    )
+    setup_p.add_argument(
+        "--openrouter-key",
+        help="OpenRouter API key (self-host). Enables cloud-OSS routing.",
+    )
+    setup_p.add_argument(
+        "--fireworks-key",
+        help="Fireworks API key (self-host). Enables cloud-OSS routing.",
+    )
+    setup_p.add_argument(
+        "--together-key",
+        help="Together API key (self-host). Enables cloud-OSS routing.",
+    )
+    setup_p.add_argument(
+        "--vllm-endpoint",
+        help=(
+            "Local vLLM OpenAI-compatible endpoint URL (self-host), e.g. "
+            "http://localhost:8000/v1. Enables local OSS routing, no key."
+        ),
+    )
+    setup_p.add_argument(
+        "--demo",
+        action="store_true",
+        help=(
+            "Self-host with no keys: print the cheapest real on-ramp instead "
+            "of silently configuring a no-op stub gateway. Exits non-zero."
+        ),
+    )
+    setup_p.add_argument(
         "--base-url",
-        default="https://api.modelmeld.ai",
-        help="ModelMeld gateway URL (default: hosted endpoint)",
+        default=None,
+        help=(
+            "ModelMeld gateway URL. Defaults to the hosted endpoint "
+            "(https://api.modelmeld.ai), or http://localhost:8080 with "
+            "--self-host."
+        ),
     )
     setup_p.add_argument(
         "--allow-custom-host",

--- a/src/modelmeld/cli/setup.py
+++ b/src/modelmeld/cli/setup.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import socket
+import subprocess
 import sys
 import time
 import urllib.error
@@ -647,19 +649,517 @@ def _setup_codex(args: Any, base_url: str, interactive: bool) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Self-host specifics — gateway config, transient boot, real-routing smoke
+# ---------------------------------------------------------------------------
+#
+# Why this path exists: the public-today path is self-host, but the gateway
+# ships INERT. config.py defaults to routing_policy="single" +
+# upstream_provider="stub", so out of the box every request hits a no-op
+# stub adapter with no error. The documented `export ANTHROPIC_API_KEY=…;
+# uvicorn …` snippet sets neither the capability routing mode nor any
+# MODELMELD_*-prefixed provider key (config reads MODELMELD_ANTHROPIC_API_KEY,
+# not ANTHROPIC_API_KEY), so the tester silently gets stub-or-nothing and
+# never sees the OSS-routing value prop.
+#
+# The fix is config/UX, not capability — every adapter already ships and
+# `_infer_providers_from_credentials` wires keys → adapters once
+# routing_policy=capability. This wizard collects whichever provider keys
+# the tester has, writes routing_policy=capability + those keys, and — the
+# acceptance bar — boots a transient gateway and proves a real OSS provider
+# served a request (x-modelmeld-routed-to != "stub") before declaring
+# success.
+
+
+# The gateway has no auth in the OSS core (auth is the enterprise seam), but
+# Claude Code refuses to start without a non-empty ANTHROPIC_API_KEY. This
+# placeholder satisfies the client; the local gateway ignores it.
+_SELF_HOST_CLIENT_PLACEHOLDER_KEY = "sk-modelmeld-localhost-noauth"
+
+# Real OSS providers we can route to in self-host. If the smoke test's
+# x-modelmeld-routed-to is none of these (e.g. "stub"), real routing did
+# NOT happen and the gate fails.
+_OSS_PROVIDERS = ("openrouter", "fireworks", "together", "vllm", "tensorrt_llm")
+
+
+def _self_host_gateway_env_vars(
+    *,
+    openrouter_key: str | None,
+    fireworks_key: str | None,
+    together_key: str | None,
+    vllm_endpoint: str | None,
+    anthropic_key: str | None,
+    openai_key: str | None,
+) -> dict[str, str]:
+    """The MODELMELD_* env the self-host gateway needs for real routing.
+
+    Always sets capability routing — without it, the inferred provider keys
+    are ignored and the gateway stays on the single/stub default. One dict,
+    used for BOTH the persisted sourceable script AND the transient
+    smoke-test subprocess, so what we validate is exactly what we persist.
+    """
+    env: dict[str, str] = {"MODELMELD_ROUTING_POLICY": "capability"}
+    if openrouter_key:
+        env["MODELMELD_OPENROUTER_API_KEY"] = openrouter_key
+    if fireworks_key:
+        env["MODELMELD_FIREWORKS_API_KEY"] = fireworks_key
+    if together_key:
+        env["MODELMELD_TOGETHER_API_KEY"] = together_key
+    if vllm_endpoint:
+        env["MODELMELD_VLLM_ENDPOINT"] = vllm_endpoint
+    # Frontier keys live on the GATEWAY in self-host (the operator IS the
+    # user), not as per-request client BYOK headers. capability mode makes
+    # them eligible for -auto/-quality while -saver stays OSS-only.
+    if anthropic_key:
+        env["MODELMELD_ANTHROPIC_API_KEY"] = anthropic_key
+    if openai_key:
+        env["MODELMELD_OPENAI_API_KEY"] = openai_key
+    return env
+
+
+def _write_self_host_gateway_env(
+    target: Path, env_vars: dict[str, str], base_url: str,
+) -> None:
+    """Sourceable shell script of gateway env vars. Source BEFORE uvicorn."""
+    port = base_url.rsplit(":", 1)[-1] if base_url.count(":") >= 2 else "8080"
+    lines = [
+        "#!/bin/bash",
+        "# ModelMeld self-host GATEWAY config. Source this, then launch the",
+        "# gateway in the same shell:",
+        f"#   source {target}",
+        f"#   uvicorn modelmeld.api.server:app --host 0.0.0.0 --port {port}",
+        "",
+        "# Capability routing: the scout picks the cheapest model meeting the",
+        "# quality bar per request. WITHOUT this line the gateway falls back",
+        "# to a no-op stub and every request returns a canned reply.",
+    ]
+    # MODELMELD_ROUTING_POLICY first, then keys, for readability.
+    lines.append(f"export MODELMELD_ROUTING_POLICY={env_vars['MODELMELD_ROUTING_POLICY']}")
+    for key, value in env_vars.items():
+        if key == "MODELMELD_ROUTING_POLICY":
+            continue
+        lines.append(f"export {key}={value}")
+    content = "\n".join(lines) + "\n"
+    _atomic_write_text(target, content, mode=0o600)
+
+
+def _free_port() -> int:
+    """Grab a free localhost TCP port for the transient smoke-test gateway."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_healthz(base_url: str, timeout: float = 25.0) -> bool:
+    """Poll /healthz until the transient gateway is up or timeout elapses."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            status, _hdrs, _body = _http_get(
+                f"{base_url}/healthz", headers={}, timeout=2.0,
+            )
+            if status == 200:
+                return True
+        except (urllib.error.URLError, TimeoutError, OSError):
+            pass
+        time.sleep(0.4)
+    return False
+
+
+def _boot_transient_gateway(
+    env_vars: dict[str, str],
+) -> tuple[subprocess.Popen[bytes], str]:
+    """Spawn `python -m uvicorn modelmeld.api.server:app` on a free port with
+    the collected gateway env injected.
+
+    Spawning the LITERAL command the tester runs (rather than an in-process
+    ASGI client) is deliberate: the silent-stub dead-end is specifically
+    about `uvicorn …:app`, so the smoke test must prove that exact
+    invocation does real routing.
+    """
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    proc_env = {**os.environ, **env_vars}
+    proc = subprocess.Popen(
+        [
+            sys.executable, "-m", "uvicorn",
+            "modelmeld.api.server:app",
+            "--host", "127.0.0.1",
+            "--port", str(port),
+            "--log-level", "warning",
+        ],
+        env=proc_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    return proc, base_url
+
+
+def _smoke_test_self_host(
+    base_url: str, *, expect_oss: bool, expect_frontier: bool,
+) -> list[SmokeResult]:
+    """Self-host real-routing smoke. No api key / no BYOK header (OSS core is
+    unauthenticated; frontier is gateway-side).
+
+    Test A: GET /v1/models — gateway reachable.
+    Test B (the gate, when an OSS key was supplied): POST /v1/messages with
+      -saver. PASS iff 200 AND a real OSS provider served it
+      (x-modelmeld-routed-to in _OSS_PROVIDERS, NOT "stub") AND the body
+      isn't the stub sentinel. Green here = real OSS routing provably
+      happened.
+    Test C (when a frontier key was supplied): -quality should route to a
+      frontier model. This is the gate for a frontier-only self-host.
+    """
+    results: list[SmokeResult] = []
+
+    status, _hdrs, body = _http_get(f"{base_url}/v1/models", headers={})
+    if status == 200:
+        try:
+            n = len(json.loads(body).get("data", []))
+            results.append(SmokeResult("models discovery", True, f"{n} models advertised"))
+        except json.JSONDecodeError:
+            results.append(SmokeResult("models discovery", False, "200 but body not JSON"))
+    else:
+        results.append(SmokeResult(
+            "models discovery", False,
+            f"HTTP {status} — {body[:120].decode('utf-8', 'replace')}",
+        ))
+
+    # Verbose prompt + max_tokens>256 keeps the scout out of
+    # autocomplete-shape downgrade territory for both alias tests.
+    prompt = (
+        "I'm verifying my self-hosted ModelMeld routing setup. Please reply "
+        "with a short 2-3 sentence description of what type hints do in "
+        "Python and why they help with code quality."
+    )
+
+    # The OSS gate: a real OSS provider must serve a -saver request.
+    if expect_oss:
+        status, hdrs, body = _http_post_json(
+            f"{base_url}/v1/messages",
+            body={
+                "model": "anthropic/modelmeld-saver",
+                "max_tokens": 512,
+                "messages": [{"role": "user", "content": prompt}],
+            },
+            headers={"anthropic-version": "2023-06-01"},
+        )
+        if status == 200:
+            routed_to = (hdrs.get("x-modelmeld-routed-to") or "").lower()
+            routed_model = hdrs.get("x-modelmeld-routed-model")
+            looks_stub = routed_to == "stub" or b"stub adapter" in body.lower()
+            if routed_to in _OSS_PROVIDERS and not looks_stub:
+                results.append(SmokeResult(
+                    "real OSS routing (-saver)", True,
+                    f"served by {routed_to} → {routed_model or 'unknown model'}",
+                    routed_model=routed_model,
+                ))
+            elif looks_stub:
+                results.append(SmokeResult(
+                    "real OSS routing (-saver)", False,
+                    "served by the STUB adapter — no real model was called. "
+                    "MODELMELD_ROUTING_POLICY=capability + a provider key didn't "
+                    "take effect. Re-run `modelmeld setup --self-host`.",
+                ))
+            else:
+                results.append(SmokeResult(
+                    "real OSS routing (-saver)", False,
+                    f"routed to unexpected provider {routed_to!r} "
+                    f"(model {routed_model!r}) — expected one of {_OSS_PROVIDERS}",
+                ))
+        else:
+            try:
+                err_body: Any = json.loads(body)
+            except Exception:
+                err_body = body[:200].decode("utf-8", "replace")
+            results.append(SmokeResult(
+                "real OSS routing (-saver)", False,
+                f"HTTP {status}: {err_body} — check the provider key is valid "
+                "(a bad key surfaces as a 401/502 from the upstream provider).",
+            ))
+
+    if expect_frontier:
+        status, hdrs, body = _http_post_json(
+            f"{base_url}/v1/messages",
+            body={
+                "model": "anthropic/modelmeld-quality",
+                "max_tokens": 512,
+                "messages": [{"role": "user", "content": prompt}],
+            },
+            headers={"anthropic-version": "2023-06-01"},
+        )
+        if status == 200:
+            routed_to = (hdrs.get("x-modelmeld-routed-to") or "").lower()
+            routed_model = hdrs.get("x-modelmeld-routed-model") or ""
+            is_frontier = routed_to in ("anthropic", "openai") or (
+                routed_model.startswith("claude-") or routed_model.startswith("gpt-")
+            )
+            results.append(SmokeResult(
+                "frontier routing (-quality)", is_frontier,
+                f"served by {routed_to} → {routed_model or 'unknown model'}"
+                + ("" if is_frontier else " (expected a frontier model)"),
+                routed_model=routed_model or None,
+            ))
+        else:
+            results.append(SmokeResult(
+                "frontier routing (-quality)", False,
+                f"HTTP {status}: {body[:150].decode('utf-8', 'replace')}",
+            ))
+
+    return results
+
+
+def _arg_value(args: Any, name: str) -> str | None:
+    """Normalized non-empty CLI arg value, or None."""
+    raw = getattr(args, name, None)
+    return (_normalize(raw) or None) if raw else None
+
+
+def _prompt_self_host_keys(args: Any, interactive: bool) -> dict[str, str | None]:
+    """Collect provider keys from flags, then prompt for any the tester wants
+    to add interactively."""
+    keys: dict[str, str | None] = {
+        "openrouter": _arg_value(args, "openrouter_key"),
+        "fireworks": _arg_value(args, "fireworks_key"),
+        "together": _arg_value(args, "together_key"),
+        "vllm": _arg_value(args, "vllm_endpoint"),
+        "anthropic": _arg_value(args, "byok_anthropic"),
+        "openai": _arg_value(args, "byok_openai"),
+    }
+    if not interactive:
+        return keys
+
+    any_oss = any(keys[p] for p in ("openrouter", "fireworks", "together", "vllm"))
+    if not any_oss:
+        print(
+            "\n  Cloud-OSS routing (the value prop): paste a key for any ONE "
+            "provider and the gateway routes real OSS models per request. "
+            "OpenRouter is the easiest to start with — one key, many OSS "
+            "models, pay-as-you-go: https://openrouter.ai/keys",
+        )
+        if not keys["openrouter"]:
+            keys["openrouter"] = _prompt_secret(
+                "  OpenRouter API key (sk-or-…, blank to skip): ", required=False,
+            ) or None
+        if not any(keys[p] for p in ("openrouter", "fireworks", "together", "vllm")):
+            ans = input(
+                "  Add Fireworks / Together / a local vLLM endpoint instead? [y/N]: ",
+            ).strip().lower()
+            if ans == "y":
+                keys["fireworks"] = _prompt_secret(
+                    "  Fireworks API key (blank to skip): ", required=False,
+                ) or None
+                keys["together"] = _prompt_secret(
+                    "  Together API key (blank to skip): ", required=False,
+                ) or None
+                keys["vllm"] = _prompt_secret(
+                    "  vLLM endpoint URL e.g. http://localhost:8000/v1 "
+                    "(blank to skip): ", required=False,
+                ) or None
+
+    if not keys["anthropic"] and not keys["openai"]:
+        print(
+            "\n  Optional: a frontier key (Anthropic / OpenAI) lets the "
+            "-auto and -quality policies escalate to Sonnet/Opus/GPT. "
+            "-saver stays OSS-only regardless. In self-host the key lives on "
+            "your gateway and is never sent anywhere but the provider.",
+        )
+        ans = input("  Add an Anthropic frontier key now? [y/N]: ").strip().lower()
+        if ans == "y":
+            keys["anthropic"] = _prompt_secret(
+                "  Anthropic API key (sk-ant-…): ", required=False,
+            ) or None
+    return keys
+
+
+def _setup_self_host(args: Any, base_url: str, interactive: bool) -> int:
+    """Configure + validate a gateway the tester runs themselves."""
+    print(_bold("ModelMeld — self-host setup"))
+    print(f"  Gateway (you run this): {base_url}")
+
+    # --- Step 1: collect keys ---
+    _step("Step 1/5: Collect provider keys")
+    keys = _prompt_self_host_keys(args, interactive)
+    oss_keys = {p: keys[p] for p in ("openrouter", "fireworks", "together", "vllm")}
+    has_oss = any(oss_keys.values())
+    has_frontier = bool(keys["anthropic"] or keys["openai"])
+
+    if not has_oss and not has_frontier:
+        # Refuse to silently configure a no-op stub gateway.
+        if getattr(args, "demo", False) or not interactive:
+            _warn("No provider keys supplied — nothing to route to.")
+        print()
+        print(_bold("No keys, no routing — here's the cheapest on-ramp:"))
+        print()
+        print("  OpenRouter gives you one key for many OSS models, "
+              "pay-as-you-go, no minimum:")
+        print(f"     {_bold('https://openrouter.ai/keys')}")
+        print()
+        print("  Grab a key, then re-run:")
+        print(f"     {_bold('modelmeld setup --self-host --openrouter-key sk-or-…')}")
+        print()
+        print("  (A keyless gateway can only serve the no-op stub adapter, so "
+              "this wizard won't configure one — you'd see canned replies, not "
+              "real routing.)")
+        return 2
+
+    if has_oss:
+        for prov, val in oss_keys.items():
+            if val:
+                label = "endpoint" if prov == "vllm" else "key"
+                _ok(f"{prov} {label} set")
+    else:
+        _warn(
+            "No cloud-OSS / vLLM key — only frontier routing will work. "
+            "-saver (OSS-only) will have nothing to route to. Add an "
+            "OpenRouter key to unlock the savings path.",
+        )
+    if keys["anthropic"]:
+        _ok(f"Anthropic frontier key set ({len(keys['anthropic'])} chars)")
+    if keys["openai"]:
+        _ok(f"OpenAI frontier key set ({len(keys['openai'])} chars)")
+
+    gateway_env = _self_host_gateway_env_vars(
+        openrouter_key=keys["openrouter"],
+        fireworks_key=keys["fireworks"],
+        together_key=keys["together"],
+        vllm_endpoint=keys["vllm"],
+        anthropic_key=keys["anthropic"],
+        openai_key=keys["openai"],
+    )
+
+    # --- Step 2: write the gateway env script ---
+    _step("Step 2/5: Write gateway env script")
+    setup_dir = Path.home() / ".modelmeld"
+    gateway_script = setup_dir / "modelmeld-gateway.env"
+    try:
+        _write_self_host_gateway_env(gateway_script, gateway_env, base_url)
+        _ok(f"Wrote {gateway_script} (LF-only, mode 0600)")
+    except Exception as e:
+        _err(f"Failed to write gateway env script: {e}")
+        return 1
+
+    # --- Step 3: write the Claude Code client env script ---
+    _step("Step 3/5: Write Claude Code client env script")
+    client_script = setup_dir / "setup-claude-code.sh"
+    try:
+        # No BYOK header: self-host frontier is gateway-side, and the OSS
+        # core needs no api key. The placeholder satisfies Claude Code's
+        # non-empty-key requirement; the gateway ignores it.
+        _write_claude_code_env_script(
+            client_script, base_url, _SELF_HOST_CLIENT_PLACEHOLDER_KEY,
+            None, None,
+        )
+        _ok(f"Wrote {client_script} (LF-only, mode 0600)")
+    except Exception as e:
+        _err(f"Failed to write client env script: {e}")
+        return 1
+
+    # --- Step 4: boot a transient gateway, pre-write cache, smoke-test ---
+    _step("Step 4/5: Boot a gateway and verify real routing")
+    proc: subprocess.Popen[bytes] | None = None
+    smoke_ok = True
+    try:
+        proc, probe_url = _boot_transient_gateway(gateway_env)
+        if not _wait_for_healthz(probe_url):
+            out = b""
+            if proc.poll() is not None and proc.stdout is not None:
+                out = proc.stdout.read() or b""
+            _err(
+                "Gateway didn't come up. Is the `modelmeld` package importable "
+                "and uvicorn installed? "
+                + (f"Output:\n{out[:500].decode('utf-8', 'replace')}" if out else ""),
+            )
+            return 1
+        _ok("Gateway up")
+
+        # Pre-write the Claude Code discovery cache for the LOCAL gateway.
+        cache_path = Path.home() / ".claude" / "cache" / "gateway-models.json"
+        try:
+            status, _hdrs, mbody = _http_get(f"{probe_url}/v1/models", headers={})
+            if status == 200:
+                _write_claude_code_cache(cache_path, base_url, json.loads(mbody))
+                n_models = len(json.loads(mbody).get("data", []))
+                _ok(f"Pre-wrote {cache_path} ({n_models} models)")
+            else:
+                _warn(f"Couldn't fetch /v1/models (HTTP {status}); /model picker "
+                      "may be empty until you launch the gateway.")
+        except Exception as e:
+            _warn(f"Cache pre-write skipped: {e}")
+
+        if not args.skip_smoke_test:
+            results = _smoke_test_self_host(
+                probe_url, expect_oss=has_oss, expect_frontier=has_frontier,
+            )
+            for r in results:
+                if r.ok:
+                    _ok(f"{r.label}: {r.detail}")
+                else:
+                    _err(f"{r.label}: {r.detail}")
+            # The gate is the real-OSS-routing test specifically. A missing
+            # frontier key (no -quality test) or an empty OSS lineup is not a
+            # hard failure on its own, but a stub/HTTP failure on -saver is.
+            smoke_ok = all(r.ok for r in results)
+        else:
+            _warn("Smoke test skipped (--skip-smoke-test) — real routing NOT verified.")
+    finally:
+        if proc is not None and proc.poll() is None:
+            proc.terminate()
+            with contextlib.suppress(Exception):
+                proc.wait(timeout=5)
+            if proc.poll() is None:
+                proc.kill()
+
+    if not args.skip_smoke_test and not smoke_ok:
+        _err("Routing verification failed — see errors above. Config files were "
+             "written; fix the issue and re-run, or `modelmeld doctor`.")
+        return 1
+
+    # --- Step 5: final instructions ---
+    _step("Step 5/5: Done")
+    port = base_url.rsplit(":", 1)[-1] if base_url.count(":") >= 2 else "8080"
+    print()
+    print(_bold("Self-host setup complete. Real OSS routing verified." if not
+                args.skip_smoke_test else "Self-host setup complete."))
+    print()
+    print("  1. Start the gateway (in one shell):")
+    print(f"     {_bold(f'source {gateway_script}')}")
+    print(f"     {_bold(f'uvicorn modelmeld.api.server:app --host 0.0.0.0 --port {port}')}")
+    print("  2. Point Claude Code at it (in another shell):")
+    print(f"     {_bold(f'source {client_script}')}")
+    print(f"     {_bold('claude')}")
+    print("  3. Pick a routing tier in /model:")
+    print(f"     • {_bold('ModelMeld — Saver')}  (OSS-only, predictable cost ceiling)")
+    print(f"     • {_bold('ModelMeld — Auto')}   (escalates to frontier on reasoning markers)")
+    print(f"     • {_bold('ModelMeld — Quality')} (frontier-first"
+          + ("" if has_frontier else "; needs a frontier key — add one and re-run") + ")")
+    print()
+    print("  Diagnose anytime with `modelmeld doctor`.")
+    print()
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Main flow
 # ---------------------------------------------------------------------------
 
 
 def run_setup(args: Any) -> int:
     """Execute the `modelmeld setup` command. Returns process exit code."""
-    base_url = args.base_url.rstrip("/")
+    self_host = getattr(args, "self_host", False) or getattr(args, "demo", False)
+    # --base-url defaults to the hosted endpoint, or localhost for self-host.
+    raw_base_url = getattr(args, "base_url", None) or (
+        "http://localhost:8080" if self_host else "https://api.modelmeld.ai"
+    )
+    base_url = raw_base_url.rstrip("/")
     try:
         _validate_base_url(base_url, allow_custom_host=args.allow_custom_host)
     except ValueError as e:
         _err(str(e))
         return 2
     interactive = not args.yes
+
+    if self_host:
+        return _setup_self_host(args, base_url, interactive)
 
     if args.tool == "codex":
         return _setup_codex(args, base_url, interactive)

--- a/tests/test_cli_setup_self_host.py
+++ b/tests/test_cli_setup_self_host.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""Tests for `modelmeld setup --self-host`.
+
+The self-host wizard turns the README dead-end (the documented `export
+ANTHROPIC_API_KEY=…; uvicorn …` path silently lands on the no-op stub
+adapter) into a real on-ramp. These tests pin the contract:
+
+  - It writes routing_policy=capability + the supplied provider keys
+    (without capability mode the keys are ignored and the gateway stays
+    on stub — the exact bug this fixes).
+  - It refuses to configure a keyless (stub-only) gateway: no keys → a
+    non-zero exit with an on-ramp message, NOT a silent stub.
+  - The smoke gate passes ONLY when a real OSS provider served the
+    request (x-modelmeld-routed-to != "stub"); a stub response fails it.
+  - The client env script points at the local gateway with NO BYOK
+    header (self-host frontier is gateway-side).
+
+HTTP + the transient gateway subprocess are stubbed so the test is
+offline and non-destructive (Path.home redirected to tmp). The
+real-key live smoke remains a manual release step.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from modelmeld.cli import setup as setup_mod
+
+skip_on_windows_modes = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX mode bits not supported on Windows NTFS",
+)
+
+_MODELS_RESPONSE = {
+    "data": [
+        {"id": "anthropic/modelmeld-saver", "display_name": "ModelMeld — Saver"},
+        {"id": "anthropic/modelmeld-auto", "display_name": "ModelMeld — Auto"},
+        {"id": "anthropic/modelmeld-quality"},
+    ]
+}
+
+
+def _args(**overrides: Any) -> SimpleNamespace:
+    base = dict(
+        tool="claude-code",
+        self_host=True,
+        demo=False,
+        base_url=None,                 # resolves to http://localhost:8080
+        api_key=None,
+        byok_anthropic=None,
+        byok_openai=None,
+        openrouter_key=None,
+        fireworks_key=None,
+        together_key=None,
+        vllm_endpoint=None,
+        allow_custom_host=False,
+        skip_smoke_test=False,
+        yes=True,                      # non-interactive
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class _FakeProc:
+    """Stand-in for the uvicorn subprocess Popen handle."""
+
+    def __init__(self) -> None:
+        self._alive = True
+
+    def poll(self) -> int | None:
+        return None if self._alive else 0
+
+    def terminate(self) -> None:
+        self._alive = False
+
+    def wait(self, timeout: float | None = None) -> int:
+        self._alive = False
+        return 0
+
+    def kill(self) -> None:
+        self._alive = False
+
+
+def _install_fakes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    routed_to: str = "openrouter",
+    routed_model: str = "qwen/qwen3-coder",
+    messages_status: int = 200,
+) -> None:
+    """Redirect home + stub the gateway boot and HTTP so the wizard runs
+    fully offline. `routed_to` controls what the smoke test sees."""
+    monkeypatch.setattr(Path, "home", lambda *a, **k: tmp_path)
+    monkeypatch.setattr(
+        setup_mod, "_boot_transient_gateway",
+        lambda env: (_FakeProc(), "http://127.0.0.1:59999"),
+    )
+    monkeypatch.setattr(setup_mod, "_wait_for_healthz", lambda url, timeout=25.0: True)
+
+    def _fake_get(url: str, headers: dict[str, str], timeout: float = 15.0):
+        return 200, {}, json.dumps(_MODELS_RESPONSE).encode("utf-8")
+
+    def _fake_post(url: str, body: dict[str, Any], headers: dict[str, str], timeout: float = 30.0):
+        model = body.get("model", "")
+        # frontier alias → claim a frontier provider so the optional test passes
+        if model.endswith("-quality"):
+            return 200, {"x-modelmeld-routed-to": "anthropic",
+                         "x-modelmeld-routed-model": "claude-sonnet-4-6"}, b'{"content":[]}'
+        if messages_status != 200:
+            return messages_status, {}, b'{"detail":"boom"}'
+        reply = (b'{"content":[{"text":"stub adapter reply"}]}'
+                 if routed_to == "stub" else b'{"content":[{"text":"ok"}]}')
+        return 200, {"x-modelmeld-routed-to": routed_to,
+                     "x-modelmeld-routed-model": routed_model}, reply
+
+    monkeypatch.setattr(setup_mod, "_http_get", _fake_get)
+    monkeypatch.setattr(setup_mod, "_http_post_json", _fake_post)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_gateway_env_always_sets_capability() -> None:
+    """The whole point: keys are inert without capability mode."""
+    env = setup_mod._self_host_gateway_env_vars(
+        openrouter_key="sk-or-x", fireworks_key=None, together_key=None,
+        vllm_endpoint=None, anthropic_key=None, openai_key=None,
+    )
+    assert env["MODELMELD_ROUTING_POLICY"] == "capability"
+    assert env["MODELMELD_OPENROUTER_API_KEY"] == "sk-or-x"
+
+
+def test_gateway_env_wires_each_provider() -> None:
+    env = setup_mod._self_host_gateway_env_vars(
+        openrouter_key="o", fireworks_key="f", together_key="t",
+        vllm_endpoint="http://localhost:8000/v1", anthropic_key="sk-ant-a",
+        openai_key="sk-o",
+    )
+    assert env["MODELMELD_FIREWORKS_API_KEY"] == "f"
+    assert env["MODELMELD_TOGETHER_API_KEY"] == "t"
+    assert env["MODELMELD_VLLM_ENDPOINT"] == "http://localhost:8000/v1"
+    assert env["MODELMELD_ANTHROPIC_API_KEY"] == "sk-ant-a"
+    assert env["MODELMELD_OPENAI_API_KEY"] == "sk-o"
+
+
+def test_gateway_env_omits_unset_providers() -> None:
+    env = setup_mod._self_host_gateway_env_vars(
+        openrouter_key="o", fireworks_key=None, together_key=None,
+        vllm_endpoint=None, anthropic_key=None, openai_key=None,
+    )
+    assert "MODELMELD_FIREWORKS_API_KEY" not in env
+    assert "MODELMELD_ANTHROPIC_API_KEY" not in env
+
+
+def test_write_gateway_env_is_lf_only(tmp_path: Path) -> None:
+    target = tmp_path / "modelmeld-gateway.env"
+    env = setup_mod._self_host_gateway_env_vars(
+        openrouter_key="sk-or-x", fireworks_key=None, together_key=None,
+        vllm_endpoint=None, anthropic_key=None, openai_key=None,
+    )
+    setup_mod._write_self_host_gateway_env(target, env, "http://localhost:8080")
+    raw = target.read_bytes()
+    assert b"\r" not in raw
+    text = target.read_text()
+    assert "export MODELMELD_ROUTING_POLICY=capability" in text
+    assert "export MODELMELD_OPENROUTER_API_KEY=sk-or-x" in text
+    assert "port 8080" in text
+
+
+def test_arg_value_normalizes_and_blanks() -> None:
+    assert setup_mod._arg_value(SimpleNamespace(k="  v\r\n"), "k") == "v"
+    assert setup_mod._arg_value(SimpleNamespace(k=""), "k") is None
+    assert setup_mod._arg_value(SimpleNamespace(), "missing") is None
+
+
+def test_prompt_keys_noninteractive_uses_flags_only() -> None:
+    args = _args(openrouter_key="sk-or-x", byok_anthropic="sk-ant-a")
+    keys = setup_mod._prompt_self_host_keys(args, interactive=False)
+    assert keys["openrouter"] == "sk-or-x"
+    assert keys["anthropic"] == "sk-ant-a"
+    assert keys["fireworks"] is None
+
+
+# ---------------------------------------------------------------------------
+# Full flow
+# ---------------------------------------------------------------------------
+
+
+def test_no_keys_refuses_stub_and_exits_nonzero(monkeypatch, tmp_path) -> None:
+    """No keys must NOT silently configure a stub gateway."""
+    monkeypatch.setattr(Path, "home", lambda *a, **k: tmp_path)
+    rc = setup_mod.run_setup(_args())
+    assert rc == 2
+    # Nothing written — we refused rather than persist a no-op config.
+    assert not (tmp_path / ".modelmeld" / "modelmeld-gateway.env").exists()
+
+
+def test_happy_path_writes_capability_config(monkeypatch, tmp_path) -> None:
+    _install_fakes(monkeypatch, tmp_path, routed_to="openrouter")
+    rc = setup_mod.run_setup(_args(openrouter_key="sk-or-x"))
+    assert rc == 0
+
+    gw = tmp_path / ".modelmeld" / "modelmeld-gateway.env"
+    assert gw.exists()
+    gw_text = gw.read_text()
+    assert "MODELMELD_ROUTING_POLICY=capability" in gw_text
+    assert "MODELMELD_OPENROUTER_API_KEY=sk-or-x" in gw_text
+
+    client = tmp_path / ".modelmeld" / "setup-claude-code.sh"
+    assert client.exists()
+    client_text = client.read_text()
+    assert "ANTHROPIC_BASE_URL=http://localhost:8080" in client_text
+    # Self-host: NO per-request BYOK header in the client config.
+    assert "ANTHROPIC_CUSTOM_HEADERS" not in client_text
+
+    cache = tmp_path / ".claude" / "cache" / "gateway-models.json"
+    assert cache.exists()
+    assert cache.read_text().count("modelmeld-") >= 3
+
+
+def test_gate_fails_when_routed_to_stub(monkeypatch, tmp_path) -> None:
+    """If the served provider is the stub, the gate must fail (rc=1)."""
+    _install_fakes(monkeypatch, tmp_path, routed_to="stub")
+    rc = setup_mod.run_setup(_args(openrouter_key="sk-or-x"))
+    assert rc == 1
+
+
+def test_gate_fails_on_upstream_http_error(monkeypatch, tmp_path) -> None:
+    _install_fakes(monkeypatch, tmp_path, messages_status=502)
+    rc = setup_mod.run_setup(_args(openrouter_key="sk-or-x"))
+    assert rc == 1
+
+
+def test_skip_smoke_still_writes_config(monkeypatch, tmp_path) -> None:
+    _install_fakes(monkeypatch, tmp_path, routed_to="stub")  # would fail gate
+    rc = setup_mod.run_setup(_args(openrouter_key="sk-or-x", skip_smoke_test=True))
+    assert rc == 0  # skipping the smoke means the stub routing isn't checked
+    assert (tmp_path / ".modelmeld" / "modelmeld-gateway.env").exists()
+
+
+def test_frontier_key_enables_quality_smoke(monkeypatch, tmp_path) -> None:
+    _install_fakes(monkeypatch, tmp_path, routed_to="openrouter")
+    rc = setup_mod.run_setup(_args(openrouter_key="sk-or-x", byok_anthropic="sk-ant-a"))
+    assert rc == 0
+    gw_text = (tmp_path / ".modelmeld" / "modelmeld-gateway.env").read_text()
+    assert "MODELMELD_ANTHROPIC_API_KEY=sk-ant-a" in gw_text
+
+
+def test_frontier_only_self_host_passes_via_quality_gate(monkeypatch, tmp_path) -> None:
+    """A frontier-only self-host (no OSS key) must not be blocked by the
+    -saver gate — it has nothing OSS to route to. The -quality frontier
+    test is the gate instead."""
+    # routed_to=stub would fail an OSS gate, but with no OSS key the OSS
+    # test is skipped entirely; only -quality (→ anthropic) is checked.
+    _install_fakes(monkeypatch, tmp_path, routed_to="stub")
+    rc = setup_mod.run_setup(_args(byok_anthropic="sk-ant-a"))
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring
+# ---------------------------------------------------------------------------
+
+
+def test_argparse_self_host_defaults_base_url(monkeypatch, tmp_path) -> None:
+    """`setup --self-host` should parse and default base_url to localhost."""
+    from modelmeld.cli import main
+
+    captured: dict[str, Any] = {}
+
+    def _fake_run(args: Any) -> int:
+        captured["base_url"] = args.base_url
+        captured["self_host"] = args.self_host
+        return 0
+
+    monkeypatch.setattr("modelmeld.cli.run_setup", _fake_run)
+    rc = main(["setup", "--self-host", "--openrouter-key", "sk-or-x"])
+    assert rc == 0
+    assert captured["self_host"] is True
+    # base_url default is resolved inside run_setup, so it's None at parse time
+    assert captured["base_url"] is None


### PR DESCRIPTION
## Summary

  The public-today path is self-host, but the gateway shipped inert: it defaults to
  `routing_policy="single"` + `upstream_provider="stub"`, so out of the box every request hits a
  no-op stub adapter with no error. The documented self-host snippet (`export ANTHROPIC_API_KEY=…;
  uvicorn …`) didn't help — that var is invisible to the gateway (config reads `MODELMELD_`-prefixed
  vars), and even corrected it wouldn't matter in `single`/`stub` mode. A new self-hoster followed
  the README, got canned stub replies, and never saw real routing. The gap was config/UX, not
  capability — every adapter already ships, and once `routing_policy=capability` is set,
  `_infer_providers_from_credentials` wires the provider keys to adapters.

  This adds `modelmeld setup --self-host`: it collects whichever provider keys the user has, writes
  `routing_policy=capability` + those keys, pre-configures Claude Code against the local gateway, and  — the acceptance bar — boots the gateway and proves a real provider served a request before
  declaring success.

  ## Type of change

  - [x] Bug fix (non-breaking change that resolves an issue)
  - [x] New feature (non-breaking change that adds capability)
  - [x] Documentation

  ## Test plan

  - New `tests/test_cli_setup_self_host.py` (14 tests, offline + non-destructive — `Path.home`
  redirected to tmp, gateway boot + HTTP stubbed):
    - `_self_host_gateway_env_vars` always sets `capability` and wires each provider; omits unset
  ones.
    - Gateway env script is LF-only with the expected exports.
    - No-keys path exits non-zero and writes nothing (refuses a silent stub).
    - Happy path writes the capability gateway config + client script (no BYOK header) + discovery
  cache.
    - Smoke gate fails (rc=1) when the served provider is `stub` or on an upstream HTTP error.
    - Frontier-only self-host passes via the `-quality` gate (the `-saver` OSS gate is skipped when
  no OSS key is configured).
    - `--skip-smoke-test` still writes config; argparse wiring for `--self-host`.
  - Manually verified the gate end-to-end: booted a transient default (`single`/`stub`) gateway via
  the real subprocess path and confirmed the `-saver` smoke **correctly fails** with "served by the
  STUB adapter". `/v1/models` returns the registry-derived lineup.
  - Full suite: `1220 passed, 12 skipped`. `ruff check .` clean. `pyright src` clean. `python
  scripts/verify_boundary.py` clean.
  - Live real-key smoke (a real OSS provider serving `-saver`) is a manual step — run `modelmeld
  setup --self-host --openrouter-key <key>` to see a green gate.

  ## Linked issues

  <!-- add issue refs if any -->

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [x] Documentation updated if user-facing behavior changed
  - [ ] `pre-commit run --all-files` passes
  - [x] `pytest` passes (full suite, not just the changed file)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md` first

  ## Additional context

  Also adds a startup warning when the gateway boots in the accidental `single`/`stub` config, so
  even a bare `uvicorn modelmeld.api.server:app` isn't silently a no-op. The README Quickstart now
  leads with the self-host wizard (the path a public reader can complete today); the hosted gateway
  is marked invite-only beta.