### PR TITLE
feat(registry): add current leader coders to the multi-provider overlay

### DIFF
--- a/src/modelmeld/scout/data/default_overlay.json
+++ b/src/modelmeld/scout/data/default_overlay.json
@@ -181,6 +181,66 @@
       "cost_per_m_output": 2.0,
       "task_scores": {"tool_use": 0.85},
       "source": "modelmeld_tool_eval_v1_2026_06_10"
+    },
+    {
+      "model_id": "deepseek-v4-flash",
+      "provider": "openrouter",
+      "provider_model_id": "deepseek/deepseek-v4-flash",
+      "context_window": 1048576,
+      "cost_per_m_input": 0.1,
+      "cost_per_m_output": 0.2,
+      "task_scores": {"tool_use": 0.85},
+      "source": "modelmeld_tool_eval_v1_2026_06_13"
+    },
+    {
+      "model_id": "minimax-m3",
+      "provider": "openrouter",
+      "provider_model_id": "minimax/minimax-m3",
+      "context_window": 1048576,
+      "cost_per_m_input": 0.3,
+      "cost_per_m_output": 1.2,
+      "task_scores": {"tool_use": 0.85},
+      "source": "modelmeld_tool_eval_v1_2026_06_13"
+    },
+    {
+      "model_id": "minimax-m3",
+      "provider": "together",
+      "provider_model_id": "MiniMaxAI/MiniMax-M3",
+      "context_window": 524288,
+      "cost_per_m_input": 0.3,
+      "cost_per_m_output": 1.2,
+      "task_scores": {"tool_use": 0.85},
+      "source": "modelmeld_tool_eval_v1_2026_06_13"
+    },
+    {
+      "model_id": "glm-5",
+      "provider": "openrouter",
+      "provider_model_id": "z-ai/glm-5",
+      "context_window": 202752,
+      "cost_per_m_input": 0.6,
+      "cost_per_m_output": 1.92,
+      "task_scores": {"tool_use": 0.85},
+      "source": "modelmeld_tool_eval_v1_2026_06_13"
+    },
+    {
+      "model_id": "glm-5",
+      "provider": "together",
+      "provider_model_id": "zai-org/GLM-5",
+      "context_window": 202752,
+      "cost_per_m_input": 1.0,
+      "cost_per_m_output": 3.2,
+      "task_scores": {"tool_use": 0.85},
+      "source": "modelmeld_tool_eval_v1_2026_06_13"
+    },
+    {
+      "model_id": "kimi-k2.6",
+      "provider": "openrouter",
+      "provider_model_id": "moonshotai/kimi-k2.6",
+      "context_window": 262144,
+      "cost_per_m_input": 0.68,
+      "cost_per_m_output": 3.41,
+      "task_scores": {"tool_use": 0.85},
+      "source": "modelmeld_tool_eval_v1_2026_06_13"
     }
   ]
 }

--- a/tests/test_sprint0_multi_provider_routing.py
+++ b/tests/test_sprint0_multi_provider_routing.py
@@ -142,6 +142,8 @@ async def test_together_only_setup_routes_tool_request_to_together(
         "gpt-oss-120b",
         "kimi-k2.6",
         "llama-3.3-70b-instruct",
+        "minimax-m3",
+        "glm-5",
     }
 
 


### PR DESCRIPTION
## Summary

  Adds four current strong OSS coders that were absent from the served lineup — `deepseek-v4-flash`,
  `minimax-m3`, `glm-5`, and a `kimi-k2.6` OpenRouter row — to `default_overlay.json`. Each `(model,
  provider)` row carries a `tool_use` score **measured** on the Tier-2 agentic bug-fix eval (all
  solved 20/20 → calibrated to the sonnet anchor at 0.85, the same method as the existing rows), with  context window and per-provider cost validated against the live provider catalogs
  (`scripts/validate_overlay.py`: 23 OK / 0 MISS) and the correct provider-specific slugs.
  `deepseek-v4-flash` and `minimax-m3` are overlay-only (like `minimax-m2`/`devstral`); `glm-5` and
  `kimi-k2.6` already have base entries, so this adds their provider availability.

  ## Type of change

  - [x] New feature (non-breaking change that adds capability)