### PR TITLE
fix(adapters): Together health check must tolerate its bare-list /models

### DIFF
--- a/src/modelmeld/adapters/together_adapter.py
+++ b/src/modelmeld/adapters/together_adapter.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import os
 
+import httpx
+
 from modelmeld.adapters.base import AdapterError
 from modelmeld.adapters.openai_adapter import OpenAIAdapter
 
@@ -38,8 +40,32 @@ class TogetherAdapter(OpenAIAdapter):
                 "TogetherAdapter requires an API key "
                 "(pass api_key= or set TOGETHER_API_KEY)."
             )
+        self._health_base = (base_url or _TOGETHER_BASE_URL).rstrip("/")
+        self._health_key = resolved_key
         super().__init__(
             api_key=resolved_key,
             base_url=base_url or _TOGETHER_BASE_URL,
             served_model=None,
         )
+
+    async def health(self) -> bool:
+        """Liveness probe for Together.
+
+        Together's `/models` returns a BARE JSON list, not the OpenAI
+        `{object:"list", data:[...]}` shape, so the SDK's `models.list()` (which
+        the inherited `OpenAIAdapter.health()` calls) raises
+        `'list' object has no attribute '_set_private_attributes'` and reports
+        the adapter permanently unhealthy. That silently broke ALL Together
+        routing — every model whose route resolves to Together 503'd, with no
+        failover on the pinned path. A raw GET that treats any 2xx as healthy is
+        the correct liveness signal here (chat itself is OpenAI-compatible and
+        unaffected)."""
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(
+                    f"{self._health_base}/models",
+                    headers={"Authorization": f"Bearer {self._health_key}"},
+                )
+            return resp.status_code < 400
+        except Exception:
+            return False

--- a/tests/test_adapters_together_openrouter.py
+++ b/tests/test_adapters_together_openrouter.py
@@ -10,8 +10,10 @@ exported from the adapters package.
 
 from __future__ import annotations
 
+import httpx
 import pytest
 
+import modelmeld.adapters.together_adapter as together_mod
 from modelmeld.adapters import (
     FireworksAdapter,
     OpenRouterAdapter,
@@ -53,6 +55,41 @@ def test_together_missing_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_together_no_served_model_pin() -> None:
     adapter = TogetherAdapter(api_key="t_test")
     assert adapter.served_model is None
+
+
+def _mock_async_client(handler):
+    """Factory replacing together_adapter.httpx.AsyncClient with a mock-transport
+    client so health()'s raw GET can be intercepted. Captures the real
+    AsyncClient before the monkeypatch so the factory doesn't recurse into the
+    patched name."""
+    real = httpx.AsyncClient
+    def _factory(*_args, **_kwargs):
+        return real(transport=httpx.MockTransport(handler))
+    return _factory
+
+
+async def test_together_health_true_on_bare_list_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: Together's /models returns a BARE list, not {data:[...]}.
+    The inherited SDK models.list() raises on that shape, so health() must use a
+    raw GET and treat any 2xx as healthy — otherwise ALL Together routing 503s."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/models")
+        return httpx.Response(200, json=[{"id": "a"}, {"id": "b"}])  # bare list
+    monkeypatch.setattr(together_mod.httpx, "AsyncClient", _mock_async_client(handler))
+    adapter = TogetherAdapter(api_key="t_test")
+    assert await adapter.health() is True
+
+
+async def test_together_health_false_on_error_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="unavailable")
+    monkeypatch.setattr(together_mod.httpx, "AsyncClient", _mock_async_client(handler))
+    adapter = TogetherAdapter(api_key="t_test")
+    assert await adapter.health() is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

  Together's `GET /v1/models` returns a bare JSON array, not the OpenAI `{object:"list", data:[...]}`  shape. `TogetherAdapter` inherited `OpenAIAdapter.health()`, which calls the SDK's `models.list()`
  — that raises on the bare-list shape (`'list' object has no attribute '_set_private_attributes'`),
  so `health()` returned `False` permanently. The `CapabilityRouter` therefore marked Together
  unhealthy and skipped it, silently returning 503 for **every** request that routed to Together.
  (Chat itself is fine — only the health probe was broken.) This overrides `health()` with a raw `GET  /models` that treats any 2xx as healthy.

  ## Type of change

  - [x] Bug fix (non-breaking change that resolves an issue)

  ## Test plan

  Added regression tests: a bare-list 2xx `/models` response → `health()` True (the case the SDK
  choked on), and an error status → False. Verified live against the real Together API that
  `health()` now returns True. Full suite: 1222 passed, 12 skipped.

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [ ] Documentation updated if user-facing behavior changed (internal adapter behavior)
  - [ ] `pre-commit run --all-files` passes (no pre-commit config in repo)
  - [x] `pytest` passes (full suite)
  - [x] All commits have DCO signoff
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md`