### PR TITLE
test(router): gate the multi-provider wire-slug invariant

### DIFF
--- a/tests/test_router_capability.py
+++ b/tests/test_router_capability.py
@@ -198,6 +198,54 @@ def test_apply_model_override_falls_back_to_canonical_without_slug() -> None:
 
 
 # ---------------------------------------------------------------------------
+# MULTI-PROVIDER wire-slug invariant — the one the gates were BLIND to.
+# When a model_id is served by several providers, the egress wire must carry
+# the slug of the provider the SCOUT CHOSE (cheapest eligible), NOT whatever
+# registry.get(model_id) returns (the last-inserted/default row). Re-deriving
+# the slug inside the router via registry.get()/lookup_fallback() passes every
+# single-provider fixture above but sends the WRONG provider's slug here. The
+# decision must thread the *chosen entry's* slug through from the scout.
+# ---------------------------------------------------------------------------
+
+async def test_multi_provider_wire_slug_is_scout_chosen_providers_slug() -> None:
+    from modelmeld.api.routes.chat import _apply_model_override
+    from modelmeld.scout.multi_provider_registry import MultiProviderModelRegistry
+
+    # Same model_id, two providers, DISTINCT slugs. The PRICEY row is inserted
+    # last, so base get(model_id) (last-write-wins) returns it — while pick()
+    # (cheapest) returns the CHEAP row. That divergence is what makes the latent
+    # bug observable; a single-provider registry can never expose it.
+    registry = MultiProviderModelRegistry([
+        _entry("glm-5", "cheap-prov", 0.10, 0.20, coding=0.85,
+               provider_model_id="cheap-prov/glm-5"),
+        _entry("glm-5", "pricey-prov", 5.0, 9.0, coding=0.85,
+               provider_model_id="pricey-prov/glm-5"),
+    ])
+    # Precondition: the two accessors genuinely disagree (else the test is moot).
+    default = registry.get("glm-5")
+    assert default is not None and default.provider_model_id == "pricey-prov/glm-5"
+
+    scout = CapabilityScout(registry=registry, quality_threshold=0.80)
+    router = CapabilityRouter(
+        scout=scout,
+        adapters_by_provider={
+            "cheap-prov": _FakeAdapter("cheap-prov"),
+            "pricey-prov": _FakeAdapter("pricey-prov"),
+        },
+    )
+    decision = await router.route(_req())
+
+    # Scout picks the cheapest provider; the canonical id is preserved for
+    # attribution; the WIRE slug must be the chosen (cheap) provider's, never
+    # the get()-default (pricey) one.
+    assert decision.adapter.name == "cheap-prov"
+    assert decision.model_id_override == "glm-5"
+    assert decision.provider_model_id == "cheap-prov/glm-5"
+    out = _apply_model_override(_req(), decision)
+    assert out.model == "cheap-prov/glm-5"
+
+
+# ---------------------------------------------------------------------------
 # Adapter selection
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
 ## Summary

  Adds a `CapabilityRouter` regression test for a correctness invariant the existing suite
  could not express: when a `model_id` is served by **multiple providers** and the scout
  picks a provider whose `provider_model_id` differs from the one `registry.get(model_id)`
  returns (the last-inserted/default row), the egress wire must carry the **chosen**
  provider's slug. Every prior `provider_model_id` test used a single-provider
  `ModelRegistry` — whose `_by_id` map holds exactly one row per `model_id` — so this case
  was structurally unreachable. The gap matters because a router that re-derives the slug in  the router layer via `registry.get()`/`lookup_fallback()` (rather than threading the
  scout-chosen entry's slug through the decision) passes the entire suite while sending the
  wrong provider's slug on any multi-provider model. The new test uses
  `MultiProviderModelRegistry` with two rows for one `model_id`, asserts the two accessors
  disagree (precondition), and pins the wire to the cheapest-chosen provider's slug.

  ## Type of change

  - [ ] Bug fix (non-breaking change that resolves an issue)
  - [ ] New feature (non-breaking change that adds capability)
  - [ ] Breaking change (fix or feature that changes existing behavior in a way clients can
  observe)
  - [ ] Refactor (no behavior change, internals only)
  - [ ] Documentation
  - [x] Test-only change
  - [ ] Build / CI / tooling

  ## Test plan

  - New test `test_multi_provider_wire_slug_is_scout_chosen_providers_slug` passes against
  current `main` (the threading is already correct here): `pytest
  tests/test_router_capability.py` -> 17 passed.
  - Confirmed it is discriminating, not vacuous: it would fail any implementation that
  derives the wire slug from `registry.get(model_id)` (returns the pricey/last-inserted row)  instead of the scout-chosen entry.
  - Full suite: `pytest -q` -> 1223 passed, 12 skipped. `ruff check` + `pyright` on the file  clean.

  ## Linked issues

  (none)

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [ ] Documentation updated if user-facing behavior changed
  - [x] `pytest` passes (full suite, not just the changed file)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md` first

  ## Additional context

  Pure test addition — no source changes. Closes a blind spot where a gate-green patch could  still ship a wrong-provider-slug bug on multi-provider models.