### PR TITLE
fix(translation): forward cache_control on Anthropic->OpenAI so providers can cache

### DIFF
--- a/src/modelmeld/api/schemas.py
+++ b/src/modelmeld/api/schemas.py
@@ -48,6 +48,12 @@ def _now_iso() -> str:
 class TextPart(BaseModel):
     type: Literal["text"]
     text: str
+    # Prompt-cache breakpoint (`{"type": "ephemeral"}`). Carried through from
+    # Anthropic content-block `cache_control` so OpenAI-compatible providers
+    # that support ephemeral prompt caching receive the marker and cache the
+    # prefix. `exclude_none` drops it on parts that don't carry one, so
+    # non-cache parts stay byte-clean on the wire.
+    cache_control: dict[str, Any] | None = None
 
 
 class ImageUrl(BaseModel):

--- a/src/modelmeld/translation/openai_anthropic.py
+++ b/src/modelmeld/translation/openai_anthropic.py
@@ -542,11 +542,11 @@ def from_anthropic_request(req: AnthropicMessagesRequest) -> ChatCompletionReque
     #    one leading SystemMessage; the non-system body keeps its original
     #    order. One Anthropic message may still yield multiple OpenAI messages
     #    (mixed tool_result + text in a single user turn).
-    system_parts: list[str] = []
+    system_parts: list[TextPart] = []
     if req.system is not None:
-        top_system = _anthropic_system_to_text(req.system)
-        if top_system:
-            system_parts.append(top_system)
+        for part in _anthropic_system_to_parts(req.system):
+            if part.text or part.cache_control:
+                system_parts.append(part)
 
     body_messages: list[Message] = []
     for msg in req.messages:
@@ -554,15 +554,22 @@ def from_anthropic_request(req: AnthropicMessagesRequest) -> ChatCompletionReque
             if isinstance(converted, SystemMessage):
                 system_text = _extract_text(converted.content)
                 if system_text:
-                    system_parts.append(system_text)
+                    system_parts.append(TextPart(type="text", text=system_text))
             else:
                 body_messages.append(converted)
 
     messages: list[Message] = []
     if system_parts:
-        messages.append(
-            SystemMessage(role="system", content="\n\n".join(system_parts))
-        )
+        # Emit the LIST form (preserving cache_control breakpoints) when any
+        # fragment carries one; else collapse to a single joined string — the
+        # D-2 strict-backend-safe back-compat shape unchanged for cache-less
+        # requests.
+        sys_content: str | list[TextPart]
+        if any(p.cache_control for p in system_parts):
+            sys_content = system_parts
+        else:
+            sys_content = "\n\n".join(p.text for p in system_parts)
+        messages.append(SystemMessage(role="system", content=sys_content))
     messages.extend(body_messages)
 
     # 3. Tools
@@ -603,11 +610,24 @@ def from_anthropic_request(req: AnthropicMessagesRequest) -> ChatCompletionReque
     )
 
 
-def _anthropic_system_to_text(system: str | list[AnthropicTextBlock]) -> str:
-    """D-2: list-form joins text blocks with '\\n\\n'. cache_control ignored."""
+def _anthropic_system_to_parts(system: str | list[AnthropicTextBlock]) -> list[TextPart]:
+    """System fragments as TextParts, PRESERVING each block's cache_control.
+
+    The big stable system prefix is a client's primary cache breakpoint, so
+    dropping cache_control here previously denied OpenAI-compatible backends
+    their prompt caching.
+    Callers collapse to a single joined string when NO fragment carries
+    cache_control (D-2, strict-OpenAI-backend-safe), else emit the list form
+    so the breakpoint survives to the provider."""
     if isinstance(system, str):
-        return system
-    return "\n\n".join(block.text for block in system)
+        return [TextPart(type="text", text=system)]
+    return [
+        TextPart(
+            type="text", text=block.text,
+            cache_control=block.cache_control.model_dump() if block.cache_control else None,
+        )
+        for block in system
+    ]
 
 
 def _anthropic_message_to_openai(msg: AnthropicMessage) -> list[Message]:
@@ -655,7 +675,10 @@ def _anthropic_user_to_openai(msg: AnthropicMessage) -> list[Message]:
 
     for block in msg.content:
         if isinstance(block, AnthropicTextBlock):
-            user_parts.append(TextPart(type="text", text=block.text))
+            user_parts.append(TextPart(
+                type="text", text=block.text,
+                cache_control=block.cache_control.model_dump() if block.cache_control else None,
+            ))
         elif isinstance(block, AnthropicImageBlock):
             raise TranslationError(
                 "Anthropic image content blocks are not supported in v1 "
@@ -684,7 +707,11 @@ def _anthropic_user_to_openai(msg: AnthropicMessage) -> list[Message]:
     # accumulated user text/image content as one trailing UserMessage.
     out: list[Message] = list(tool_messages)
     if user_parts:
-        if len(user_parts) == 1 and isinstance(user_parts[0], TextPart):
+        # Collapse a lone text part to a bare string ONLY when it carries no
+        # cache_control — otherwise keep the list form so the breakpoint
+        # survives to the provider.
+        if (len(user_parts) == 1 and isinstance(user_parts[0], TextPart)
+                and not user_parts[0].cache_control):
             out.append(UserMessage(role="user", content=user_parts[0].text))
         else:
             out.append(UserMessage(role="user", content=list(user_parts)))

--- a/tests/test_translation_anthropic_to_openai.py
+++ b/tests/test_translation_anthropic_to_openai.py
@@ -187,7 +187,11 @@ def test_no_system_field_does_not_inject() -> None:
     assert isinstance(out.messages[0], UserMessage)
 
 
-def test_system_cache_control_is_ignored_but_accepted() -> None:
+def test_system_cache_control_is_preserved() -> None:
+    """cache_control on a system block now SURVIVES translation (previously
+    dropped), so OpenAI-compatible providers that honor ephemeral breakpoints
+    can cache the prefix. The presence of a breakpoint switches the system
+    content to the list form instead of the collapsed string."""
     req = AnthropicMessagesRequest(
         model="m", max_tokens=10,
         system=[
@@ -199,7 +203,9 @@ def test_system_cache_control_is_ignored_but_accepted() -> None:
     out = from_anthropic_request(req)
     sys_msg = out.messages[0]
     assert isinstance(sys_msg, SystemMessage)
-    assert sys_msg.content == "Be terse."
+    assert isinstance(sys_msg.content, list)
+    assert sys_msg.content[0].text == "Be terse."
+    assert sys_msg.content[0].cache_control == {"type": "ephemeral"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_translation_openai_anthropic.py
+++ b/tests/test_translation_openai_anthropic.py
@@ -7,9 +7,11 @@ import json
 import pytest
 
 from modelmeld.api.schemas import ChatCompletionRequest
+from modelmeld.api.schemas_anthropic import AnthropicMessagesRequest
 from modelmeld.translation.openai_anthropic import (
     AnthropicStreamTranslator,
     TranslationError,
+    from_anthropic_request,
     from_anthropic_response,
     to_anthropic_params,
 )
@@ -56,6 +58,64 @@ def test_multiple_system_messages_concatenated() -> None:
     )
     params = to_anthropic_params(req)
     assert params["system"] == "Rule 1.\n\nRule 2."
+
+
+# ---------------------------------------------------------------------------
+# Request translation: Anthropic → OpenAI — cache_control forwarding.
+# Anthropic content-block cache_control breakpoints must survive translation
+# onto the OpenAI content parts so providers that support ephemeral prompt
+# caching receive them (they were previously dropped). Cache-less requests keep
+# the prior collapsed-string shape (strict-backend back-compat).
+# ---------------------------------------------------------------------------
+
+def test_system_cache_control_preserved_as_list() -> None:
+    req = AnthropicMessagesRequest.model_validate({
+        "model": "m", "max_tokens": 16,
+        "system": [
+            {"type": "text", "text": "BIG STABLE PREFIX",
+             "cache_control": {"type": "ephemeral"}},
+        ],
+        "messages": [{"role": "user", "content": "hi"}],
+    })
+    out = from_anthropic_request(req)
+    sysmsg = next(m for m in out.messages if m.role == "system")
+    assert isinstance(sysmsg.content, list)  # list form, NOT collapsed to string
+    assert sysmsg.content[0].text == "BIG STABLE PREFIX"
+    assert sysmsg.content[0].cache_control == {"type": "ephemeral"}
+    # And it must survive serialization to the wire (the egress path).
+    dumped = out.model_dump(exclude_none=True)
+    sys_dumped = next(m for m in dumped["messages"] if m["role"] == "system")
+    assert sys_dumped["content"][0]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_user_cache_control_preserved() -> None:
+    req = AnthropicMessagesRequest.model_validate({
+        "model": "m", "max_tokens": 16,
+        "messages": [{"role": "user", "content": [
+            {"type": "text", "text": "cached doc",
+             "cache_control": {"type": "ephemeral"}},
+        ]}],
+    })
+    out = from_anthropic_request(req)
+    usermsg = next(m for m in out.messages if m.role == "user")
+    assert isinstance(usermsg.content, list)  # not collapsed to a bare string
+    assert usermsg.content[0].cache_control == {"type": "ephemeral"}
+
+
+def test_system_without_cache_control_collapses_to_string() -> None:
+    """Back-compat: with no cache_control anywhere, the system stays a single
+    joined string (D-2 strict-backend shape, unchanged)."""
+    req = AnthropicMessagesRequest.model_validate({
+        "model": "m", "max_tokens": 16,
+        "system": [
+            {"type": "text", "text": "A"},
+            {"type": "text", "text": "B"},
+        ],
+        "messages": [{"role": "user", "content": "hi"}],
+    })
+    out = from_anthropic_request(req)
+    sysmsg = next(m for m in out.messages if m.role == "system")
+    assert sysmsg.content == "A\n\nB"
 
 
 def test_max_completion_tokens_takes_precedence_over_max_tokens() -> None:


### PR DESCRIPTION
## Summary

  The Anthropic->OpenAI translation dropped `cache_control` breakpoints on system and user
  content, so OpenAI-compatible providers that support ephemeral prompt caching never
  received the markers and couldn't cache the stable prefix across a multi-turn session.
  This adds a `cache_control` field to `TextPart` and preserves it from Anthropic content
  blocks through translation:

  - **System:** emitted as the content-part **list** form when any fragment carries a
  breakpoint; otherwise collapsed to a single joined string (the prior strict-backend-safe
  shape, unchanged for cache-less requests).
  - **User:** `cache_control` preserved on the text part, and a lone cached text part is no
  longer collapsed to a bare string (which would have dropped the marker).
  - `exclude_none` keeps non-cache parts byte-clean on the wire.

  ## Type of change

  - [x] Bug fix (non-breaking change that resolves an issue)
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Test-only change
  - [ ] Build / CI / tooling

  ## Test plan

  - New tests: `cache_control` preserved on system (list form) and user content, survives
  `model_dump(exclude_none=True)` to the wire, and the cache-less request still collapses
  system to the joined string (back-compat).
  - Updated the prior test that asserted `cache_control` was *ignored* to assert it's now
  preserved.
  - Full suite: `pytest -q` -> 1226 passed, 12 skipped. `ruff check` + `pyright` clean.
  - Verified out-of-band that the `openai`-SDK egress path forwards content-part
  `cache_control` to the provider unchanged.

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [ ] Documentation updated if user-facing behavior changed
  - [x] `pytest` passes (full suite)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md` first