### PR TITLE
feat(scout): structural escalate-detector for -auto (flag-gated, default off)

### DIFF
--- a/src/modelmeld/scout/capability.py
+++ b/src/modelmeld/scout/capability.py
@@ -19,6 +19,10 @@ from dataclasses import dataclass, field
 
 from modelmeld.api.schemas import ChatCompletionRequest
 from modelmeld.scout.devtool import Fingerprint, Fingerprinter
+from modelmeld.scout.difficulty import (
+    DifficultyClassifier,
+    difficulty_routing_enabled,
+)
 from modelmeld.scout.policy import (
     ModelMeldPolicy,
     frontier_providers,
@@ -220,6 +224,9 @@ class CapabilityScout:
             raise ValueError(f"fallback_depth must be ≥0, got {fallback_depth}")
         self.registry = registry
         self.classifier = classifier or TaskCategoryClassifier()
+        # Structural escalate-detector for AUTO (used when
+        # MODELMELD_DIFFICULTY_ROUTING is on; else the marker path runs).
+        self.difficulty_classifier = DifficultyClassifier()
         self.quality_threshold = quality_threshold
         self.eligible_providers = eligible_providers
         self.fingerprinter = fingerprinter or Fingerprinter()
@@ -318,7 +325,18 @@ class CapabilityScout:
                 # Further restrict to providers the customer actually
                 # supplied BYOK keys for — otherwise scout might pick
                 # gpt-5-mini when the customer only has an Anthropic key.
-                escalate, marker_count = should_escalate_to_frontier(request)
+                # Escalation signal: the structural difficulty detector when
+                # MODELMELD_DIFFICULTY_ROUTING is on (the gap concentrates on
+                # structural shapes, not reasoning-keyword phrasing), else the
+                # legacy reasoning-marker count. `category` is already resolved
+                # above; the detector is category-gated on it.
+                if difficulty_routing_enabled():
+                    diff = self.difficulty_classifier.classify(request, category)
+                    escalate = diff.escalate
+                    esc_detail = diff.rationale
+                else:
+                    escalate, marker_count = should_escalate_to_frontier(request)
+                    esc_detail = f"markers={marker_count}"
                 if escalate:
                     fr = frontier_providers()
                     if available_frontier_providers is not None:
@@ -333,15 +351,15 @@ class CapabilityScout:
                         policy_rationale = (
                             f"policy=auto(escalation_requested;"
                             f"no_frontier_adapter;fallback=oss_reasoner;"
-                            f"markers={marker_count})"
+                            f"{esc_detail})"
                         )
                     else:
                         eligible = fr
                         policy_rationale = (
-                            f"policy=auto(escalated=frontier;markers={marker_count})"
+                            f"policy=auto(escalated=frontier;{esc_detail})"
                         )
                 else:
-                    policy_rationale = f"policy=auto(escalated=no;markers={marker_count})"
+                    policy_rationale = f"policy=auto(escalated=no;{esc_detail})"
             elif policy is ModelMeldPolicy.QUALITY:
                 # Frontier by default UNLESS the request is detected as
                 # autocomplete-shape (handled by the bias logic below).

--- a/src/modelmeld/scout/difficulty.py
+++ b/src/modelmeld/scout/difficulty.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""Structural escalate-detector — when does a prompt actually need frontier?
+
+Replaces `-auto`'s reasoning-marker counting (`policy.should_escalate_to_frontier`).
+Gap-by-prompt-type analysis found the open-vs-frontier quality gap is LUMPY, not
+graded: it concentrates on a few *structural* prompt shapes — multi-file /
+long-horizon, greenfield / compositional construction, novel-algorithm reasoning
+— and is ~absent on the broad middle and on self-contained algorithmic work
+(where strong open-weight models match frontier). Reasoning-keyword phrasing is a
+poor proxy for that, and extended reasoning can even hurt coding, so the marker
+list misfires on exactly the coding traffic `-auto` serves.
+
+Pure-heuristic, no ML dependency (matches `HeuristicScout` /
+`TaskCategoryClassifier`), so it is safe on the routing hot path. Category-gated
+and tuned for PRECISION: it defaults to ROUTE_OSS and escalates only on a strong
+structural combination, because a false escalate burns the predictable-cost
+ceiling while a false route is recoverable later via reactive (stall-based)
+escalation.
+
+Selected by the `MODELMELD_DIFFICULTY_ROUTING` env flag (default OFF this
+increment — the marker path stays the shipped default until the detector's
+precision is evaluated against labeled data and the default is flipped).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from modelmeld.api.schemas import ChatCompletionRequest
+from modelmeld.scout.policy import extract_user_text
+
+
+class DifficultyRoute(str, Enum):
+    """Where the structural signal points for this prompt."""
+
+    ROUTE_OSS = "route_oss"   # strong OSS matches frontier — stay OSS
+    ESCALATE = "escalate"     # frontier has a real edge (the structural shapes)
+    NEITHER = "neither"       # beyond-frontier tail; frontier also struggles.
+    # NEITHER is reserved for a later increment (it needs difficulty-depth
+    # signals not visible from the prompt surface). v1 emits ROUTE_OSS/ESCALATE
+    # only; `-auto` would escalate NEITHER anyway (don't silently degrade).
+
+
+# Only these task categories are eligible to escalate. The broad middle
+# (simple_qa / summarization / tool_use) stays OSS — strong open models match
+# frontier there, and escalating it is the main false-positive the marker list
+# produced.
+_ESCALATABLE_CATEGORIES: frozenset[str] = frozenset({"coding", "reasoning"})
+
+
+@dataclass(frozen=True)
+class DifficultyWeights:
+    """Tunable thresholds for the structural escalate-detector.
+
+    OSS default ships conservative (precision-biased) values. Override for
+    org-specific tuning; a later increment fits these against labeled data.
+    """
+
+    # >= this many DISTINCT referenced files (or an explicit "across files"
+    # phrase) => multi-file scope, the strongest escalate signal.
+    multi_file_threshold: int = 2
+    # >= this many interacting constraints (conjunctions + enumerated items)
+    # => compositional.
+    constraint_threshold: int = 3
+
+
+DEFAULT_DIFFICULTY_WEIGHTS = DifficultyWeights()
+
+
+# --- structural feature patterns (case-insensitive) ------------------------- #
+_FILE_PATH_RE = re.compile(
+    r"\b[\w./-]+\.(?:py|ts|tsx|js|jsx|go|rs|java|cpp|cc|c|h|hpp|rb|php|cs|swift"
+    r"|kt|scala|sh|sql|json|ya?ml|toml|md)\b",
+    re.IGNORECASE,
+)
+_ACROSS_FILES_RE = re.compile(
+    r"\b(?:across|spanning|multiple|several|each of the)\s+(?:\w+\s+){0,2}"
+    r"(?:files|modules|services|packages|components|subsystems)\b",
+    re.IGNORECASE,
+)
+_GREENFIELD_RE = re.compile(
+    r"\b(?:create|build|implement|develop|design|scaffold|set up|stand up|write)\b"
+    r".{0,40}?\b(?:new|from scratch|app|application|service|system|library|cli"
+    r"|api|pipeline|framework|prototype|mvp|module|component|feature|integration)\b",
+    re.IGNORECASE | re.DOTALL,
+)
+_MUST_DISCOVER_RE = re.compile(
+    r"\b(?:figure out|work out|determine|come up with|devise|design)\b"
+    r".{0,40}?\b(?:algorithm|approach|strategy|how to|the best way|optimal|solution)\b",
+    re.IGNORECASE | re.DOTALL,
+)
+# Interacting-constraint signals.
+_CONSTRAINT_RE = re.compile(
+    r"\b(?:and also|as well as|in addition|additionally|while also|must(?: also)?"
+    r"|should(?: also)?|ensure (?:that|it)|make sure|without breaking|but keep)\b",
+    re.IGNORECASE,
+)
+_ENUM_RE = re.compile(r"(?m)^\s*(?:[-*]|\d+[.)])\s+")  # bullet / numbered list items
+
+
+@dataclass(frozen=True)
+class DifficultyDecision:
+    """Output of `DifficultyClassifier.classify()`."""
+
+    route: DifficultyRoute
+    rationale: str                       # short trace for logs / telemetry
+    signals: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def escalate(self) -> bool:
+        """`-auto` escalates ESCALATE and the (reserved) NEITHER tail."""
+        return self.route in (DifficultyRoute.ESCALATE, DifficultyRoute.NEITHER)
+
+
+class DifficultyClassifier:
+    """Heuristic structural escalate-detector. See module docstring."""
+
+    name = "structural_difficulty"
+
+    def __init__(self, weights: DifficultyWeights | None = None) -> None:
+        self.weights = weights or DEFAULT_DIFFICULTY_WEIGHTS
+
+    def classify(
+        self, request: ChatCompletionRequest, category: str,
+    ) -> DifficultyDecision:
+        # Category gate first: the broad middle never escalates.
+        if category not in _ESCALATABLE_CATEGORIES:
+            return DifficultyDecision(
+                route=DifficultyRoute.ROUTE_OSS,
+                rationale=f"category={category}:not_escalatable",
+                signals={"category": category},
+            )
+
+        # User text only — system prompts carry harness boilerplate that would
+        # skew the signal (mirrors policy.extract_user_text's rationale).
+        text = extract_user_text(request)
+        w = self.weights
+
+        distinct_files = len({m.group(0).lower() for m in _FILE_PATH_RE.finditer(text)})
+        multi_file = (
+            distinct_files >= w.multi_file_threshold
+            or bool(_ACROSS_FILES_RE.search(text))
+        )
+        greenfield = bool(_GREENFIELD_RE.search(text))
+        constraint_count = len(_CONSTRAINT_RE.findall(text)) + len(_ENUM_RE.findall(text))
+        compositional = constraint_count >= w.constraint_threshold
+        must_discover = bool(_MUST_DISCOVER_RE.search(text))
+
+        signals: dict[str, Any] = {
+            "category": category,
+            "distinct_files": distinct_files,
+            "multi_file": multi_file,
+            "greenfield": greenfield,
+            "constraint_count": constraint_count,
+            "compositional": compositional,
+            "must_discover_algorithm": must_discover,
+        }
+
+        # HIGH PRECISION: escalate only on a strong combination, never a single
+        # weak hit. These are the shapes where frontier showed a real edge.
+        fired: list[str] = []
+        if multi_file:
+            fired.append(f"multi_file(files={distinct_files})")
+        if greenfield and compositional:
+            fired.append(f"greenfield+compositional(constraints={constraint_count})")
+        if must_discover:
+            fired.append("must_discover_algorithm")
+
+        if fired:
+            return DifficultyDecision(
+                route=DifficultyRoute.ESCALATE,
+                rationale="escalate:" + ",".join(fired),
+                signals=signals,
+            )
+        return DifficultyDecision(
+            route=DifficultyRoute.ROUTE_OSS,
+            rationale="route_oss:no_strong_structural_signal",
+            signals=signals,
+        )
+
+
+def difficulty_routing_enabled() -> bool:
+    """Whether `MODELMELD_DIFFICULTY_ROUTING` selects the structural detector
+    over the legacy reasoning-marker escalation for `-auto`. Default OFF."""
+    return os.environ.get("MODELMELD_DIFFICULTY_ROUTING", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+__all__ = [
+    "DEFAULT_DIFFICULTY_WEIGHTS",
+    "DifficultyClassifier",
+    "DifficultyDecision",
+    "DifficultyRoute",
+    "DifficultyWeights",
+    "difficulty_routing_enabled",
+]

--- a/tests/test_difficulty.py
+++ b/tests/test_difficulty.py
@@ -1,0 +1,102 @@
+"""Structural escalate-detector (scout/difficulty.py)."""
+
+from __future__ import annotations
+
+import pytest
+
+from modelmeld.api.schemas import ChatCompletionRequest
+from modelmeld.scout.difficulty import (
+    DifficultyClassifier,
+    DifficultyRoute,
+    difficulty_routing_enabled,
+)
+
+_clf = DifficultyClassifier()
+
+
+def _req(text: str) -> ChatCompletionRequest:
+    return ChatCompletionRequest(model="m", messages=[{"role": "user", "content": text}])
+
+
+def _route(text: str, category: str = "coding") -> DifficultyRoute:
+    return _clf.classify(_req(text), category).route
+
+
+# --- category gate: the broad middle never escalates ----------------------- #
+
+def test_non_escalatable_category_never_escalates() -> None:
+    # blatantly multi-file, but summarization is not an escalatable category
+    d = _clf.classify(_req("summarize the changes across a.py b.py c.py d.py"), "summarization")
+    assert d.route is DifficultyRoute.ROUTE_OSS
+    assert "not_escalatable" in d.rationale
+
+
+def test_simple_qa_routes_oss() -> None:
+    assert _route("what does this function return?", "simple_qa") is DifficultyRoute.ROUTE_OSS
+
+
+# --- file/module scope (strongest signal) ---------------------------------- #
+
+def test_multi_file_coding_escalates() -> None:
+    d = _clf.classify(
+        _req("Fix the auth bug across auth.py, routes.py and handlers.py"), "coding")
+    assert d.route is DifficultyRoute.ESCALATE
+    assert d.signals["distinct_files"] >= 2
+    assert "multi_file" in d.rationale
+
+
+def test_across_files_phrase_escalates() -> None:
+    assert _route("Refactor the error handling across multiple modules") is DifficultyRoute.ESCALATE
+
+
+def test_single_file_fix_routes_oss() -> None:
+    assert _route("Fix the off-by-one in parser.py") is DifficultyRoute.ROUTE_OSS
+
+
+# --- greenfield + compositional -------------------------------------------- #
+
+def test_greenfield_plus_compositional_escalates() -> None:
+    text = (
+        "Build a new rate-limiting service. It must support sliding windows, "
+        "and also per-tenant quotas, and ensure that it persists across restarts."
+    )
+    assert _route(text) is DifficultyRoute.ESCALATE
+
+
+def test_greenfield_alone_routes_oss() -> None:
+    # greenfield verb but no interacting constraints → not strong enough
+    assert _route("Build a small CLI that echoes its arguments") is DifficultyRoute.ROUTE_OSS
+
+
+# --- novel-algorithm vs specified ------------------------------------------ #
+
+def test_must_discover_algorithm_escalates() -> None:
+    assert _route(
+        "Figure out the best algorithm to deduplicate this stream in O(1) memory",
+    ) is DifficultyRoute.ESCALATE
+
+
+def test_specified_algorithm_single_file_routes_oss() -> None:
+    # self-contained, algorithm given (LiveCodeBench-shape) → strong OSS holds
+    assert _route("Implement binary search over the sorted list in search.py") is DifficultyRoute.ROUTE_OSS
+
+
+# --- escalate property + flag ---------------------------------------------- #
+
+def test_escalate_property() -> None:
+    assert _clf.classify(_req("fix the bug across a.py and b.py"), "coding").escalate is True
+    assert _clf.classify(_req("fix the typo in a.py"), "coding").escalate is False
+
+
+def test_flag_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MODELMELD_DIFFICULTY_ROUTING", raising=False)
+    assert difficulty_routing_enabled() is False
+
+
+@pytest.mark.parametrize(
+    ("val", "expected"),
+    [("1", True), ("true", True), ("on", True), ("YES", True), ("0", False), ("", False)],
+)
+def test_flag_reads_env(monkeypatch: pytest.MonkeyPatch, val: str, expected: bool) -> None:
+    monkeypatch.setenv("MODELMELD_DIFFICULTY_ROUTING", val)
+    assert difficulty_routing_enabled() is expected

--- a/tests/test_scout_capability.py
+++ b/tests/test_scout_capability.py
@@ -609,6 +609,38 @@ async def test_auto_alias_escalates_to_frontier_on_two_reasoning_markers() -> No
     assert "escalated=frontier" in decision.rationale
 
 
+async def test_auto_structural_flag_escalates_on_multifile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With MODELMELD_DIFFICULTY_ROUTING on, AUTO escalates on a multi-file
+    coding ask (structural signal) rather than reasoning markers."""
+    monkeypatch.setenv("MODELMELD_DIFFICULTY_ROUTING", "1")
+    scout = CapabilityScout(registry=_mixed_tier_registry())
+    decision = await scout.choose(_policy_req(
+        "anthropic/modelmeld-auto",
+        "Fix the token refresh bug across auth.py, session.py and middleware.py.",
+    ))
+    assert decision.chosen_provider == "anthropic"
+    assert "escalated=frontier" in decision.rationale
+    assert "multi_file" in decision.rationale
+
+
+async def test_auto_structural_flag_ignores_reasoning_markers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fix: with the structural detector on, a prompt that WOULD escalate
+    under the marker heuristic (2+ markers) does NOT escalate absent a
+    structural signal — markers no longer drive coding escalation."""
+    monkeypatch.setenv("MODELMELD_DIFFICULTY_ROUTING", "1")
+    scout = CapabilityScout(registry=_mixed_tier_registry())
+    decision = await scout.choose(_policy_req(
+        "anthropic/modelmeld-auto",
+        "Please think step by step and explain your reasoning carefully.",
+    ))
+    assert decision.chosen_provider != "anthropic"  # stayed OSS, not frontier
+    assert "escalated=no" in decision.rationale
+
+
 async def test_auto_alias_single_marker_does_not_escalate() -> None:
     """Single marker is not enough — must be 2+ distinct."""
     scout = CapabilityScout(registry=_mixed_tier_registry())


### PR DESCRIPTION
## Summary

  `-auto` currently escalates OSS->frontier by counting reasoning-marker phrases ("step by
  step", "explain your reasoning", ...) in the user text. That's a weak proxy for where
  frontier actually has an edge: the open-weight-vs-frontier quality gap concentrates on a
  few *structural* prompt shapes — multi-file / long-horizon work, greenfield +
  multi-constraint construction, and novel-algorithm reasoning — and is ~absent on the broad  middle and on self-contained algorithmic work where strong open models match frontier.
  Worse, extended reasoning can *degrade* coding output, so a reasoning-keyword trigger
  misfires on exactly the coding traffic `-auto` serves.

  This adds `scout/difficulty.py`: a pure-heuristic (no ML deps, hot-path-safe),
  **category-gated**, **precision-biased** escalate-detector. It defaults to staying OSS and  escalates only on a strong structural combination (multi-file scope, or
  greenfield+compositional, or must-discover-an-algorithm); the broad categories (simple_qa
  / summarization / tool_use) never escalate. It's wired into the `CapabilityScout` AUTO
  branch behind `MODELMELD_DIFFICULTY_ROUTING`:

  - **flag off (default):** existing reasoning-marker behavior, unchanged.
  - **flag on:** the structural detector replaces marker-counting for `-auto`.

  Default stays off until the detector's precision is evaluated against labeled data and the  default is flipped (deliberate gate — flipping a customer-facing escalation heuristic
  unvalidated would risk the predictable-cost-ceiling).

  ## Type of change

  - [x] New feature (non-breaking; gated, default off)
  - [ ] Bug fix
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Test-only change
  - [ ] Build / CI / tooling

  ## Test plan

  - New `tests/test_difficulty.py`: category gate, multi-file / across-files escalation,
  single-file fix routes OSS, greenfield+compositional escalates, greenfield-alone routes
  OSS, must-discover escalates, specified-algorithm-single-file routes OSS, the `escalate`
  property, and the env-flag parsing.
  - New `tests/test_scout_capability.py` cases: with the flag on, AUTO escalates on a
  multi-file coding ask, and a 2-marker prompt with no structural signal does NOT escalate
  (markers no longer drive coding escalation). Flag-off path covered by the existing marker
  tests (no regression).
  - Full suite: `pytest -q` -> 1245 passed, 12 skipped. `ruff check` + `pyright` clean.

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [ ] Documentation updated if user-facing behavior changed
  - [x] `pytest` passes (full suite)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md` first