### PR TITLE
feat(adapters): deterministic upstream backend for prompt-cache stickiness

### DIFF
--- a/src/modelmeld/adapters/openai_adapter.py
+++ b/src/modelmeld/adapters/openai_adapter.py
@@ -39,6 +39,7 @@ class OpenAIAdapter(ProviderAdapter):
         http_client: httpx.AsyncClient | None = None,
         retry_config: RetryConfig | None = None,
         served_model: str | None = None,
+        extra_body: dict[str, Any] | None = None,
     ) -> None:
         try:
             from openai import AsyncOpenAI
@@ -64,6 +65,17 @@ class OpenAIAdapter(ProviderAdapter):
         self._retry_config = retry_config or RetryConfig()
         # F-8: operator-pinned upstream model (overrides request.model).
         self.served_model = served_model
+        # Provider-specific body extras merged into every call (e.g. OpenRouter's
+        # `provider` routing preference). None → nothing added to the wire.
+        self._extra_body = extra_body
+
+    def _create_kwargs(
+        self, request: ChatCompletionRequest, *, stream: bool
+    ) -> dict[str, Any]:
+        kwargs = self._to_params(request, stream=stream)
+        if self._extra_body:
+            kwargs["extra_body"] = self._extra_body
+        return kwargs
 
     def _to_params(
         self, request: ChatCompletionRequest, *, stream: bool
@@ -82,7 +94,7 @@ class OpenAIAdapter(ProviderAdapter):
 
         async def _call():
             return await self._client.chat.completions.create(
-                **self._to_params(request, stream=False)
+                **self._create_kwargs(request, stream=False)
             )
 
         try:
@@ -100,7 +112,7 @@ class OpenAIAdapter(ProviderAdapter):
 
         async def _open_stream():
             return await self._client.chat.completions.create(
-                **self._to_params(request, stream=True)
+                **self._create_kwargs(request, stream=True)
             )
 
         try:

--- a/src/modelmeld/adapters/openrouter_adapter.py
+++ b/src/modelmeld/adapters/openrouter_adapter.py
@@ -23,6 +23,26 @@ from modelmeld.adapters.openai_adapter import OpenAIAdapter
 _OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 
+def _provider_routing() -> dict | None:
+    """OpenRouter `provider` routing preference, sent on every request.
+
+    OpenRouter load-balances each request across the underlying backends that
+    serve a model. Because prompt caching is per-backend, default load-balancing
+    scatters a multi-turn session across backends, so the cache never accumulates
+    across turns. A deterministic `sort` pins a session's turns to one backend so
+    the cache builds; `price` also makes that backend the cheapest (cost-optimal),
+    and `allow_fallbacks` preserves availability if it's down.
+
+    Override the sort or disable via `MODELMELD_OPENROUTER_PROVIDER_SORT`
+    (e.g. `throughput`, or empty string to disable and restore default
+    load-balancing).
+    """
+    sort = os.environ.get("MODELMELD_OPENROUTER_PROVIDER_SORT", "price").strip()
+    if not sort:
+        return None
+    return {"sort": sort, "allow_fallbacks": True}
+
+
 class OpenRouterAdapter(OpenAIAdapter):
     name = "openrouter"
     is_egress = True
@@ -42,8 +62,10 @@ class OpenRouterAdapter(OpenAIAdapter):
                 "OpenRouterAdapter requires an API key "
                 "(pass api_key= or set OPENROUTER_API_KEY)."
             )
+        routing = _provider_routing()
         super().__init__(
             api_key=resolved_key,
             base_url=base_url or _OPENROUTER_BASE_URL,
             served_model=None,
+            extra_body={"provider": routing} if routing else None,
         )

--- a/tests/test_adapters_together_openrouter.py
+++ b/tests/test_adapters_together_openrouter.py
@@ -10,6 +10,8 @@ exported from the adapters package.
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock
+
 import httpx
 import pytest
 
@@ -20,6 +22,7 @@ from modelmeld.adapters import (
     TogetherAdapter,
 )
 from modelmeld.adapters.base import AdapterError
+from modelmeld.api.schemas import ChatCompletionRequest
 
 # ---------------------------------------------------------------------------
 # TogetherAdapter
@@ -139,3 +142,58 @@ def test_three_upstream_providers_have_distinct_names() -> None:
     or_ = OpenRouterAdapter(api_key="or")
     assert {fw.name, tg.name, or_.name} == {"fireworks", "together", "openrouter"}
     assert fw.is_egress and tg.is_egress and or_.is_egress
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter provider-routing (cache-stickiness): a deterministic `provider`
+# preference pins a session to one backend so the per-backend prompt cache
+# accumulates across turns (default load-balancing scatters it across backends).
+# ---------------------------------------------------------------------------
+
+def test_openrouter_default_provider_routing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MODELMELD_OPENROUTER_PROVIDER_SORT", raising=False)
+    adapter = OpenRouterAdapter(api_key="or_test")
+    assert adapter._extra_body == {"provider": {"sort": "price", "allow_fallbacks": True}}
+
+
+def test_openrouter_provider_sort_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODELMELD_OPENROUTER_PROVIDER_SORT", "throughput")
+    adapter = OpenRouterAdapter(api_key="or_test")
+    assert adapter._extra_body == {"provider": {"sort": "throughput", "allow_fallbacks": True}}
+
+
+def test_openrouter_provider_routing_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODELMELD_OPENROUTER_PROVIDER_SORT", "")
+    adapter = OpenRouterAdapter(api_key="or_test")
+    assert adapter._extra_body is None
+
+
+def test_together_has_no_provider_routing() -> None:
+    # Provider routing is OpenRouter-specific; sibling OpenAI-compat adapters unset.
+    assert TogetherAdapter(api_key="tg")._extra_body is None
+
+
+async def test_openrouter_sends_provider_extra_body_on_chat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The provider preference must actually reach the wire (extra_body on the
+    create call), not just sit on the adapter."""
+    monkeypatch.delenv("MODELMELD_OPENROUTER_PROVIDER_SORT", raising=False)
+    adapter = OpenRouterAdapter(api_key="or_test")
+    fake = MagicMock()
+    fake.model_dump.return_value = {
+        "id": "x", "object": "chat.completion", "created": 0, "model": "m",
+        "choices": [{"index": 0,
+                     "message": {"role": "assistant", "content": "ok"},
+                     "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+    mock_create = AsyncMock(return_value=fake)
+    adapter._client.chat.completions.create = mock_create  # type: ignore[method-assign]
+    await adapter.chat(ChatCompletionRequest(
+        model="deepseek-v4-flash",
+        messages=[{"role": "user", "content": "hi"}],
+    ))
+    assert mock_create.call_args.kwargs.get("extra_body") == {
+        "provider": {"sort": "price", "allow_fallbacks": True},
+    }


### PR DESCRIPTION
## Summary
  
  Multi-turn sessions routed through OpenRouter were not benefiting from provider-side
  prompt caching. OpenRouter load-balances each request across the underlying backends that
  serve a model, and prompt caching is per-backend — so consecutive turns of one session
  land on different backends and the cache never accumulates. The result is full-context  reprocessing every turn on long sessions (cost + latency), even when `cache_control` is
  being forwarded correctly.
  This adds a generic `extra_body` mechanism to the base OpenAI-compatible adapter
  (`OpenAIAdapter`) and has `OpenRouterAdapter` send a deterministic `provider` routing
  preference on every request:

  {"provider": {"sort": "price", "allow_fallbacks": true}}

  A deterministic sort pins a session's turns to a single backend so the per-backend cache
  builds across turns. `price` makes that backend the cheapest available (cost-optimal,
  aligned with the gateway's cost-minimization), and `allow_fallbacks: true` preserves
  availability if the preferred backend is down. The preference is
  operator-tunable/disable-able via `MODELMELD_OPENROUTER_PROVIDER_SORT` (e.g. `throughput`,  or empty string to restore default load-balancing).

  The mechanism is generic and provider-scoped: only `OpenRouterAdapter` sets it (the
  `provider` field is OpenRouter-specific); sibling adapters (Together, Fireworks, vLLM,
  OpenAI) are unaffected and send no `extra_body`.

  ## Type of change

  - [x] New feature (non-breaking change that adds capability)
  - [ ] Bug fix (non-breaking change that resolves an issue)
  - [ ] Breaking change
  - [ ] Refactor (no behavior change, internals only)
  - [ ] Documentation
  - [ ] Test-only change
  - [ ] Build / CI / tooling

  ## Test plan

  - New tests in `tests/test_adapters_together_openrouter.py`:
    - default → `OpenRouterAdapter` carries `{"provider": {"sort": "price",
  "allow_fallbacks": true}}`
    - `MODELMELD_OPENROUTER_PROVIDER_SORT=throughput` → sort overridden
    - `MODELMELD_OPENROUTER_PROVIDER_SORT=""` → no `extra_body` (default load-balancing
  restored)
    - `TogetherAdapter` carries no `extra_body` (provider routing is OpenRouter-specific)
    - end-to-end: the preference actually reaches the wire — `chat()` calls the SDK with
  `extra_body={"provider": ...}` (mocked client, asserts the call kwargs)
  - Full suite: `pytest -q` → 1250 passed, 12 skipped. `ruff check` + `pyright` clean on the  changed files.

  ## Linked issues

  (none)

  ## Breaking changes

  None. Default behavior changes the *backend-selection within OpenRouter* (now
  deterministic-cheapest instead of load-balanced) but not the model served or the API
  contract. Operators who prefer the prior load-balancing can set
  `MODELMELD_OPENROUTER_PROVIDER_SORT=""`.

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [ ] Documentation updated if user-facing behavior changed
  - [x] `pytest` passes (full suite, not just the changed file)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md` first

  ## Additional context

  Completes the prompt-caching path for OpenAI-compatible upstreams: `cache_control`
  forwarding (the request-side markers) plus this backend-stickiness (so the cache survives
  across a multi-turn session). Net effect is materially lower input cost on long sessions
  for upstreams that support prompt caching, with availability preserved via fallbacks.