### PR TITLE
feat(scout): large-context escalation prior for -auto

### DIFF
--- a/src/modelmeld/scout/capability.py
+++ b/src/modelmeld/scout/capability.py
@@ -26,6 +26,7 @@ from modelmeld.scout.difficulty import (
 from modelmeld.scout.policy import (
     ModelMeldPolicy,
     frontier_providers,
+    large_context_threshold,
     oss_providers,
     resolve_policy,
     should_escalate_to_frontier,
@@ -337,6 +338,17 @@ class CapabilityScout:
                 else:
                     escalate, marker_count = should_escalate_to_frontier(request)
                     esc_detail = f"markers={marker_count}"
+                # Large-context prior (always on for AUTO; -saver keeps its OSS
+                # ceiling). Open-weight models collapse on long-context repair
+                # past the threshold, so route up regardless of the signal above
+                # — a high-precision, near-deterministic prior, unlike the broad
+                # difficulty heuristics.
+                lc_threshold = large_context_threshold()
+                if lc_threshold > 0:
+                    ctx_tokens = self._estimated_input_tokens(request)
+                    if ctx_tokens >= lc_threshold:
+                        escalate = True
+                        esc_detail = f"{esc_detail};large_context({ctx_tokens}tok)"
                 if escalate:
                     fr = frontier_providers()
                     if available_frontier_providers is not None:

--- a/src/modelmeld/scout/policy.py
+++ b/src/modelmeld/scout/policy.py
@@ -213,12 +213,32 @@ def should_escalate_to_frontier(request) -> tuple[bool, int]:
     return (count >= _REASONING_MARKER_ESCALATION_COUNT, count)
 
 
+# Open-weight models collapse to near-0% on long-context code REPAIR past
+# ~64k tokens; -auto routes such requests UP to frontier. A high-precision,
+# near-deterministic predictive prior — distinct from the broad difficulty
+# heuristics that do NOT predict the frontier gap. Tunable via
+# MODELMELD_LARGE_CONTEXT_ESCALATE_TOKENS; 0 disables.
+_LARGE_CONTEXT_ESCALATE_TOKENS = 64_000
+
+
+def large_context_threshold() -> int:
+    """Input-token count above which -auto escalates to frontier (0 disables)."""
+    raw = os.environ.get("MODELMELD_LARGE_CONTEXT_ESCALATE_TOKENS", "").strip()
+    if raw:
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            pass
+    return _LARGE_CONTEXT_ESCALATE_TOKENS
+
+
 __all__ = [
     "POLICY_QUALITY_THRESHOLD",
     "ModelMeldPolicy",
     "detect_reasoning_markers",
     "extract_user_text",
     "frontier_providers",
+    "large_context_threshold",
     "oss_providers",
     "reasoning_markers",
     "resolve_policy",

--- a/tests/test_scout_capability.py
+++ b/tests/test_scout_capability.py
@@ -641,6 +641,34 @@ async def test_auto_structural_flag_ignores_reasoning_markers(
     assert "escalated=no" in decision.rationale
 
 
+# ~70k input tokens: over the 64k large-context escalate threshold, under the
+# 100k context window of the test registry's rows (so it's the PRIOR escalating,
+# not a context-window-fit fallback). No reasoning markers in the text.
+_BIG_CONTEXT = "# padding line of code for context size\n" * 7000
+
+
+async def test_auto_escalates_on_large_context() -> None:
+    """Large-context prior: a request whose estimated input exceeds the threshold
+    escalates to frontier regardless of reasoning markers — open-weight models
+    collapse on long-context repair past it."""
+    scout = CapabilityScout(registry=_mixed_tier_registry())
+    decision = await scout.choose(_policy_req("anthropic/modelmeld-auto", _BIG_CONTEXT))
+    assert decision.chosen_provider == "anthropic"
+    assert "large_context" in decision.rationale
+
+
+async def test_large_context_prior_disabled_via_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the threshold set to 0 the prior is off; a marker-free large request
+    stays OSS (no escalation)."""
+    monkeypatch.setenv("MODELMELD_LARGE_CONTEXT_ESCALATE_TOKENS", "0")
+    scout = CapabilityScout(registry=_mixed_tier_registry())
+    decision = await scout.choose(_policy_req("anthropic/modelmeld-auto", _BIG_CONTEXT))
+    assert decision.chosen_provider != "anthropic"  # stayed OSS
+    assert "escalated=no" in decision.rationale
+
+
 async def test_auto_alias_single_marker_does_not_escalate() -> None:
     """Single marker is not enough — must be 2+ distinct."""
     scout = CapabilityScout(registry=_mixed_tier_registry())


### PR DESCRIPTION
## Summary

  `-auto` now routes requests whose estimated input exceeds a token threshold (default ~64k)  up to frontier. Open-weight coding models collapse to near-0% on long-context code repair
  past this range, so large-context requests are the one near-deterministic, high-precision
  case for escalation — distinct from (and not gated by) the structural difficulty
  detector, which the data showed does not predict the frontier gap. `-saver` is unaffected
  (keeps its OSS cost ceiling); `-quality` already starts frontier. The threshold is tunable  via `MODELMELD_LARGE_CONTEXT_ESCALATE_TOKENS` (set `0` to disable). Reuses the scout's
  existing `_estimated_input_tokens`.

  ## Type of change
  - [x] New feature (non-breaking; escalation prior on -auto only)

  ## Test plan
  - New `tests/test_scout_capability.py`: a >64k-token request under `-auto` escalates to
  frontier (rationale contains `large_context`); with the threshold env set to `0`, a
  marker-free large request stays OSS.
  - Full suite: `pytest -q` -> 1252 passed, 12 skipped. ruff + pyright clean.