### PR TITLE
feat(scout): observe-only stall detection for reactive escalation (shadow, default off)

### DIFF
--- a/src/modelmeld/api/routes/chat.py
+++ b/src/modelmeld/api/routes/chat.py
@@ -65,10 +65,60 @@ from modelmeld.memory import (
 from modelmeld.metrics import MetricsCollector
 from modelmeld.privacy import Redaction, Scrubber
 from modelmeld.router import Router, RouterError, RoutingDecision
+from modelmeld.scout.policy import ModelMeldPolicy, resolve_policy
 from modelmeld.scout.registry import ModelRegistry
+from modelmeld.scout.session_key import derive_session_key
+from modelmeld.scout.session_state import SessionStallStore
+from modelmeld.scout.stall import (
+    default_stall_weights,
+    detect_stall,
+    observations_from_internal,
+    stall_shadow_enabled,
+)
 from modelmeld.tokens import TokenCounter
 
 logger = logging.getLogger(__name__)
+
+
+def _maybe_stall_shadow_chat(
+    fastapi_request: Request,
+    request: ChatCompletionRequest,
+    tenant_id: str,
+) -> str | None:
+    """Observe-only stall detection for `-auto` on `/v1/chat/completions`.
+
+    A reduced form of the `/v1/messages` shadow hook: this surface has no native
+    Anthropic body, so the consecutive-error signal (which needs `is_error`, lost
+    in translation) is unavailable — loop / patch-before-explore / turn-floor
+    only. Changes NOTHING about routing; returns the `x-modelmeld-stall-shadow`
+    header value or None.
+    """
+    if not stall_shadow_enabled():
+        return None
+    if resolve_policy(request.model) is not ModelMeldPolicy.AUTO:
+        return None
+    store: SessionStallStore | None = getattr(
+        fastapi_request.app.state, "session_stall", None,
+    )
+    if store is None:
+        return None
+
+    key = derive_session_key(fastapi_request.headers, request, tenant_id)
+    state = store.get_or_create(key)
+    state.turns_seen += 1
+
+    decision = detect_stall(observations_from_internal(request), default_stall_weights())
+    if not decision.stalled:
+        return None
+
+    state.last_signals = decision.signals
+    if state.shadow_fired_turn is None:
+        state.shadow_fired_turn = state.turns_seen
+        logger.info(
+            "stall-shadow would_escalate session=%s turn=%d signals=%s",
+            key, state.turns_seen, list(decision.signals),
+        )
+    return f"turn={state.turns_seen};{'|'.join(decision.signals)}"
 
 router = APIRouter()
 
@@ -208,6 +258,14 @@ async def chat_completions(
         hints = extract_hints_from_headers(fastapi_request.headers)
     except RoutingHintError as e:
         raise HTTPException(status_code=400, detail=f"invalid_routing_hint: {e}") from e
+
+    # Reactive-escalation SHADOW (observe-only; see _maybe_stall_shadow_chat).
+    # Computed on the pre-injection request. The header is set on `response` for
+    # the non-streaming path; the streaming path uses its own headers dict (see
+    # the line ~295 note), so streaming chat relies on the log line only.
+    stall_shadow = _maybe_stall_shadow_chat(fastapi_request, request, mem_identity.tenant_id)
+    if stall_shadow is not None:
+        response.headers["x-modelmeld-stall-shadow"] = stall_shadow
 
     # BYOK header extraction. Customer can pass frontier-API keys via
     # `x-modelmeld-byok-{provider}` headers. Keys transit this request

--- a/src/modelmeld/api/routes/messages.py
+++ b/src/modelmeld/api/routes/messages.py
@@ -91,7 +91,16 @@ from modelmeld.memory import (
 )
 from modelmeld.privacy import Scrubber
 from modelmeld.router import Router, RouterError
+from modelmeld.scout.policy import ModelMeldPolicy, resolve_policy
 from modelmeld.scout.registry import ModelEntry
+from modelmeld.scout.session_key import derive_session_key
+from modelmeld.scout.session_state import SessionStallStore
+from modelmeld.scout.stall import (
+    default_stall_weights,
+    detect_stall,
+    observations_from_anthropic,
+    stall_shadow_enabled,
+)
 from modelmeld.tokens import TokenCounter
 from modelmeld.translation import (
     OpenAIToAnthropicStreamTranslator,
@@ -316,6 +325,47 @@ def _anthropic_json_response(
     return JSONResponse(content=body, headers=dict(base_response.headers))
 
 
+def _maybe_stall_shadow(
+    fastapi_request: Request,
+    body: AnthropicMessagesRequest,
+    internal_request: ChatCompletionRequest,
+    tenant_id: str,
+) -> str | None:
+    """Observe-only stall detection for `-auto` (MODELMELD_STALL_SHADOW gated).
+
+    Updates per-session stall state, logs the first "would escalate" signal of a
+    session, and returns the value for the `x-modelmeld-stall-shadow` response
+    header (or None when not stalled / not applicable). Changes NOTHING about
+    routing — this is the shadow increment that generates stall-truth labels.
+    """
+    if not stall_shadow_enabled():
+        return None
+    if resolve_policy(body.model) is not ModelMeldPolicy.AUTO:
+        return None
+    store: SessionStallStore | None = getattr(
+        fastapi_request.app.state, "session_stall", None,
+    )
+    if store is None:
+        return None
+
+    key = derive_session_key(fastapi_request.headers, internal_request, tenant_id)
+    state = store.get_or_create(key)
+    state.turns_seen += 1
+
+    decision = detect_stall(observations_from_anthropic(body), default_stall_weights())
+    if not decision.stalled:
+        return None
+
+    state.last_signals = decision.signals
+    if state.shadow_fired_turn is None:
+        state.shadow_fired_turn = state.turns_seen
+        logger.info(
+            "stall-shadow would_escalate session=%s turn=%d signals=%s",
+            key, state.turns_seen, list(decision.signals),
+        )
+    return f"turn={state.turns_seen};{'|'.join(decision.signals)}"
+
+
 @router.post("/messages", response_model=None)
 async def anthropic_messages(
     body: AnthropicMessagesRequest,
@@ -404,6 +454,16 @@ async def anthropic_messages(
         raise HTTPException(
             status_code=400, detail=f"invalid_routing_hint: {e}",
         ) from e
+
+    # Reactive-escalation SHADOW: observe the trajectory, emit telemetry, do not
+    # change routing. Computed before routing on the pre-injection history so the
+    # session key is stable. Propagated as a response header on both the
+    # streaming and non-streaming paths.
+    stall_shadow = _maybe_stall_shadow(
+        fastapi_request, body, internal_request, mem_identity.tenant_id,
+    )
+    if stall_shadow is not None:
+        response.headers["x-modelmeld-stall-shadow"] = stall_shadow
 
     # BYOK header extraction (mirrors chat.py — see modelmeld/api/byok.py).
     byok_creds = extract_byok_credentials(fastapi_request.headers.items())
@@ -509,6 +569,7 @@ async def anthropic_messages(
             native_request=body,
             model_registry=getattr(fastapi_request.app.state, "model_registry", None),
             extra_anthropic_headers=extra_anthropic_headers,
+            stall_shadow=stall_shadow,
         )
 
     # Cache lookup (exact-match + semantic). Cache is keyed by internal request
@@ -793,6 +854,7 @@ async def _stream_messages_with_failover(
     native_request: object | None = None,
     extra_anthropic_headers: dict[str, str] | None = None,
     model_registry: object | None = None,
+    stall_shadow: str | None = None,
 ) -> StreamingResponse:
     """Mirror of chat.py `_stream_with_failover` but emits Anthropic SSE.
 
@@ -872,6 +934,8 @@ async def _stream_messages_with_failover(
     )
     if cache_status is not None:
         headers["x-modelmeld-cache"] = cache_status
+    if stall_shadow is not None:
+        headers["x-modelmeld-stall-shadow"] = stall_shadow
 
     return StreamingResponse(
         _sse_anthropic_stream(

--- a/src/modelmeld/api/server.py
+++ b/src/modelmeld/api/server.py
@@ -29,6 +29,7 @@ from modelmeld.privacy import Scrubber, build_scrubber
 from modelmeld.router import Router, SingleAdapterRouter, build_router
 from modelmeld.scout import ModelRegistry, Scout, build_scout
 from modelmeld.scout.multi_provider_registry import default_multi_provider_registry
+from modelmeld.scout.session_state import SessionStallStore
 from modelmeld.tokens import TokenCounter, build_token_counter
 
 logger = logging.getLogger(__name__)
@@ -153,6 +154,11 @@ def build_app(
     app.state.completion_cache = completion_cache
     # Semantic cache. Consulted AFTER the exact-match cache.
     app.state.semantic_cache = semantic_cache
+
+    # Per-session stall state for reactive escalation. Constructed
+    # unconditionally (cheap, in-process TTL map); the SHADOW behaviour that
+    # reads it is gated by MODELMELD_STALL_SHADOW so tests can always reach it.
+    app.state.session_stall = SessionStallStore()
 
     if router is not None:
         app.state.router = router

--- a/src/modelmeld/scout/session_key.py
+++ b/src/modelmeld/scout/session_key.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""Per-session routing key derivation.
+
+Reactive (mid-session) escalation needs to correlate the turns of one agentic
+session so it can observe a trajectory across turns. The memory subsystem
+already defines `x-modelmeld-session-id` ([[memory.identity.HEADER_SESSION_ID]])
+for exactly this kind of correlation, so we reuse it when present.
+
+Many clients — notably Claude Code — do NOT send that header. For those we
+derive an IMPLICIT key from a stable conversation *prefix*: the system prompt
+plus the first user message. That prefix is constant across a session even as
+later turns accumulate, so every turn of the same session hashes to the same
+key, while different sessions (different opening task) hash apart.
+
+The key is ALWAYS tenant-salted. A content-hash collision must never let one
+tenant's trajectory be attributed to another's session — even in this
+shadow/observe-only increment, which has no routing or billing effect, the key
+is kept correct so the reactive-escalation increment can rely on it unchanged.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+
+from modelmeld.api.schemas import ChatCompletionRequest
+from modelmeld.memory.identity import HEADER_SESSION_ID
+
+# Length of the truncated hex digest for implicit keys. 16 hex chars = 64 bits;
+# collisions only matter within one gateway's TTL window AND one tenant, so this
+# is comfortably sufficient while keeping log lines short.
+_IMPLICIT_DIGEST_LEN = 16
+
+
+def _part_text(content: object) -> str:
+    """Flatten a message `content` (str or list of parts) to plain text.
+
+    Mirrors the user-text flattening in `policy.extract_user_text`: we read the
+    `.text` of any part that has one and ignore non-text parts (images/audio).
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            text = getattr(part, "text", None)
+            if text:
+                parts.append(text)
+        return " ".join(parts)
+    return ""
+
+
+def _stable_prefix(request: ChatCompletionRequest) -> str:
+    """The session-stable prefix: system prompt(s) + the FIRST user message.
+
+    Deliberately NOT all user turns (that grows every turn and would change the
+    key mid-session). The opening system+user pair is fixed for the session.
+    """
+    system_text = ""
+    first_user_text = ""
+    for msg in request.messages:
+        role = getattr(msg, "role", "")
+        if role == "system" and not system_text:
+            system_text = _part_text(getattr(msg, "content", None))
+        elif role == "user" and not first_user_text:
+            first_user_text = _part_text(getattr(msg, "content", None))
+        if system_text and first_user_text:
+            break
+    return f"{system_text}\n{first_user_text}"
+
+
+def derive_session_key(
+    headers: Mapping[str, str],
+    request: ChatCompletionRequest,
+    tenant_id: str,
+) -> str:
+    """Return a stable, tenant-salted session key for `request`.
+
+    Prefers the explicit `x-modelmeld-session-id` header; falls back to a hash
+    of the session-stable conversation prefix. Always prefixed with `tenant_id`
+    so keys never cross a tenant boundary.
+    """
+    lower = {k.lower(): v for k, v in headers.items()}
+    explicit = lower.get(HEADER_SESSION_ID, "").strip()
+    if explicit:
+        return f"{tenant_id}:sid:{explicit}"
+
+    digest = hashlib.sha256(
+        f"{tenant_id}\x00{_stable_prefix(request)}".encode()
+    ).hexdigest()[:_IMPLICIT_DIGEST_LEN]
+    return f"{tenant_id}:impl:{digest}"
+
+
+__all__ = ["derive_session_key"]

--- a/src/modelmeld/scout/session_state.py
+++ b/src/modelmeld/scout/session_state.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""Per-session stall state for reactive escalation.
+
+A small TTL-bounded store, keyed by the session key from
+[[scout.session_key.derive_session_key]], holding the running stall-detection
+state for each in-flight agentic session. Lives on `app.state.session_stall`
+for the gateway instance's lifetime.
+
+In this shadow/observe-only increment the state's only behavioural job is to
+de-duplicate telemetry — emit the "would escalate" signal ONCE per session
+(`shadow_fired_turn`) rather than on every subsequent turn. The reactive
+increment reuses the same store to carry the sticky escalation decision across
+turns, so the shape is built out now.
+
+The TTL/eviction idiom mirrors `CapabilityRouter._health_cache`: a monotonic
+clock, lazy expiry on access, no lock (the gateway runs each route coroutine on
+one event loop and these mutations have no `await` between read and write).
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+# Default TTL: a session goes idle and is evicted after this many seconds with
+# no turns. 30 min comfortably spans a coding session's think-time gaps.
+_DEFAULT_TTL_SEC = 1800.0
+# Hard cap on tracked sessions so a flood of distinct implicit keys can't grow
+# the store unbounded; oldest-by-last_seen are evicted past this.
+_DEFAULT_MAX_ENTRIES = 10_000
+
+
+@dataclass
+class SessionStallState:
+    """Mutable per-session stall-detection state."""
+
+    turns_seen: int = 0
+    last_signals: tuple[str, ...] = ()
+    # Turn number at which the shadow detector first fired for this session, or
+    # None if it never has. Used to emit telemetry exactly once per session.
+    shadow_fired_turn: int | None = None
+    last_seen: float = 0.0
+
+
+class SessionStallStore:
+    """TTL-bounded `session_key -> SessionStallState` map.
+
+    `clock` is injectable so tests can advance time deterministically; it
+    defaults to `time.monotonic` (never goes backwards, immune to wall-clock
+    adjustment — the same choice the router's health cache makes).
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_sec: float = _DEFAULT_TTL_SEC,
+        max_entries: int = _DEFAULT_MAX_ENTRIES,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._ttl_sec = ttl_sec
+        self._max_entries = max_entries
+        self._clock = clock
+        self._entries: dict[str, SessionStallState] = {}
+
+    def get_or_create(self, key: str) -> SessionStallState:
+        """Return the state for `key`, creating it if absent.
+
+        Evicts expired entries first; enforces the size cap after insert. The
+        returned state's `last_seen` is refreshed to now so the caller doesn't
+        have to remember to (it's about to be used).
+        """
+        now = self._clock()
+        self._evict_expired(now)
+        state = self._entries.get(key)
+        if state is None:
+            state = SessionStallState(last_seen=now)
+            self._entries[key] = state
+            # Stamp last_seen BEFORE enforcing the cap so the just-created entry
+            # isn't mistaken for the oldest and immediately evicted.
+            self._enforce_cap()
+        else:
+            state.last_seen = now
+        return state
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def _evict_expired(self, now: float) -> None:
+        if not self._entries:
+            return
+        cutoff = now - self._ttl_sec
+        expired = [k for k, s in self._entries.items() if s.last_seen < cutoff]
+        for k in expired:
+            del self._entries[k]
+
+    def _enforce_cap(self) -> None:
+        overflow = len(self._entries) - self._max_entries
+        if overflow <= 0:
+            return
+        # Drop the oldest-by-last_seen entries.
+        oldest = sorted(self._entries.items(), key=lambda kv: kv[1].last_seen)
+        for k, _ in oldest[:overflow]:
+            del self._entries[k]
+
+
+__all__ = ["SessionStallState", "SessionStallStore"]

--- a/src/modelmeld/scout/stall.py
+++ b/src/modelmeld/scout/stall.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""Trajectory stall detector for reactive escalation (SHADOW / observe-only).
+
+Predictive request-time difficulty routing was retired — the open-vs-frontier
+gap on agentic coding is small and structurally unpredictable at intake. The
+surviving signal for "this run needs help" is RUNTIME non-convergence, which the
+gateway can read retrospectively because the full conversation history arrives
+client-supplied on every turn:
+
+  - repeated identical tool calls across consecutive turns (a loop);
+  - consecutive error-bearing tool results (repair that isn't converging);
+  - patch-before-explore (editing before any exploration — correlates with
+    failure);
+  - a turn-count floor (the run is simply going long).
+
+This module is PURE (no ML, no I/O) so it is safe on the routing hot path. It
+emits a `StallDecision` only; in this increment the route handler logs it as a
+"would escalate here" shadow signal and **changes nothing about routing**. The
+reactive-escalation increment will act on the same decision.
+
+Detection reads the CUMULATIVE history (every turn carries it), so it is almost
+stateless; the per-session store exists to de-duplicate telemetry and to carry
+the future sticky decision, not to reconstruct the trajectory.
+
+Gated by `MODELMELD_STALL_SHADOW` (default OFF), mirroring
+[[scout.difficulty.difficulty_routing_enabled]].
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from modelmeld.api.schemas import (
+    AssistantMessage,
+    ChatCompletionRequest,
+    ToolMessage,
+)
+from modelmeld.api.schemas_anthropic import (
+    AnthropicMessagesRequest,
+    AnthropicToolResultBlock,
+    AnthropicToolUseBlock,
+)
+
+# --- tool classification ---------------------------------------------------- #
+# Names a coding agent uses to MODIFY the workspace vs to EXPLORE it. Matched
+# case-insensitively against the tool name; explicit sets cover the Claude Code
+# tools, substrings cover generic computer-use / framework variants.
+_EDIT_TOOLS: frozenset[str] = frozenset(
+    {"write", "edit", "multiedit", "notebookedit"}
+)
+_EDIT_SUBSTRINGS: tuple[str, ...] = ("str_replace", "create_file", "apply_patch", "edit")
+_READ_TOOLS: frozenset[str] = frozenset(
+    {"read", "grep", "glob", "ls", "notebookread", "cat", "find"}
+)
+_READ_SUBSTRINGS: tuple[str, ...] = ("read", "grep", "glob", "search")
+
+
+def _is_edit_tool(name: str) -> bool:
+    low = name.lower()
+    return low in _EDIT_TOOLS or any(s in low for s in _EDIT_SUBSTRINGS)
+
+
+def _is_read_tool(name: str) -> bool:
+    low = name.lower()
+    return low in _READ_TOOLS or any(s in low for s in _READ_SUBSTRINGS)
+
+
+# --- normalized observation ------------------------------------------------- #
+@dataclass(frozen=True)
+class TurnObservation:
+    """Shape-agnostic view of one message in the conversation history.
+
+    Extracted from either the native Anthropic body (full fidelity, incl.
+    `is_error`) or the internal OpenAI-shape request (no `is_error` — it is
+    dropped in translation, so `tool_error` is always False there).
+    """
+
+    role: str                       # "assistant" | "user" | "tool" | ...
+    tool_names: tuple[str, ...] = ()  # tool_use / tool_call names on this turn
+    has_tool_result: bool = False    # this turn carries >=1 tool result
+    tool_error: bool = False         # >=1 of those results is an error
+
+
+def observations_from_anthropic(
+    body: AnthropicMessagesRequest,
+) -> list[TurnObservation]:
+    """Full-fidelity observations from the native Anthropic request body."""
+    obs: list[TurnObservation] = []
+    for msg in body.messages:
+        content = msg.content
+        if not isinstance(content, list):
+            obs.append(TurnObservation(role=msg.role))
+            continue
+        names: list[str] = []
+        has_result = False
+        is_error = False
+        for block in content:
+            if isinstance(block, AnthropicToolUseBlock):
+                names.append(block.name)
+            elif isinstance(block, AnthropicToolResultBlock):
+                has_result = True
+                if block.is_error:
+                    is_error = True
+        obs.append(
+            TurnObservation(
+                role=msg.role,
+                tool_names=tuple(names),
+                has_tool_result=has_result,
+                tool_error=is_error,
+            )
+        )
+    return obs
+
+
+def observations_from_internal(
+    request: ChatCompletionRequest,
+) -> list[TurnObservation]:
+    """Observations from the internal OpenAI-shape request.
+
+    `is_error` does not survive Anthropic->OpenAI translation, so the
+    consecutive-error signal is unavailable here (tool_error stays False). Used
+    for `/v1/chat/completions`, which has no native Anthropic body.
+    """
+    obs: list[TurnObservation] = []
+    for msg in request.messages:
+        role = getattr(msg, "role", "")
+        if isinstance(msg, AssistantMessage) and msg.tool_calls:
+            names = tuple(tc.function.name for tc in msg.tool_calls)
+            obs.append(TurnObservation(role="assistant", tool_names=names))
+        elif isinstance(msg, ToolMessage):
+            obs.append(
+                TurnObservation(role="tool", has_tool_result=True, tool_error=False)
+            )
+        else:
+            obs.append(TurnObservation(role=role))
+    return obs
+
+
+# --- weights / decision ----------------------------------------------------- #
+@dataclass(frozen=True)
+class StallWeights:
+    """Tunable, precision-biased thresholds. Conservative defaults; a false
+    fire would (in the reactive increment) spend frontier budget, so we favour
+    precision and let the A/B retune."""
+
+    # consecutive identical-tool turns that count as a loop
+    repeat_threshold: int = 2
+    # consecutive error-bearing tool results that count as stuck repair
+    error_threshold: int = 2
+    # assistant-turn count at/above which the run is "going long"
+    max_turns: int = 8
+
+
+@dataclass(frozen=True)
+class StallDecision:
+    stalled: bool
+    signals: tuple[str, ...]
+    rationale: str
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if raw:
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            pass
+    return default
+
+
+def default_stall_weights() -> StallWeights:
+    """`StallWeights` with each threshold overridable via `MODELMELD_STALL_*`."""
+    return StallWeights(
+        repeat_threshold=_int_env("MODELMELD_STALL_REPEAT_THRESHOLD", 2),
+        error_threshold=_int_env("MODELMELD_STALL_ERROR_THRESHOLD", 2),
+        max_turns=_int_env("MODELMELD_STALL_MAX_TURNS", 8),
+    )
+
+
+def _trailing_identical_run(assistant_obs: list[TurnObservation]) -> int:
+    """Length of the trailing run of assistant turns calling the SAME tool set."""
+    if not assistant_obs:
+        return 0
+    last = assistant_obs[-1].tool_names
+    if not last:
+        return 0
+    run = 0
+    for o in reversed(assistant_obs):
+        if o.tool_names == last:
+            run += 1
+        else:
+            break
+    return run
+
+
+def _trailing_error_run(observations: list[TurnObservation]) -> int:
+    """Length of the trailing run of error-bearing tool-result turns.
+
+    Assistant turns interleave tool-result turns, so we look only at the ordered
+    sequence of result-bearing turns and count the trailing errors."""
+    results = [o.tool_error for o in observations if o.has_tool_result]
+    run = 0
+    for errored in reversed(results):
+        if errored:
+            run += 1
+        else:
+            break
+    return run
+
+
+def _patch_before_explore(observations: list[TurnObservation]) -> bool:
+    """True if an edit-class tool was used before any read-class tool appeared."""
+    first_edit: int | None = None
+    first_read: int | None = None
+    for i, o in enumerate(observations):
+        for name in o.tool_names:
+            if first_read is None and _is_read_tool(name):
+                first_read = i
+            if first_edit is None and _is_edit_tool(name):
+                first_edit = i
+    if first_edit is None:
+        return False
+    return first_read is None or first_edit < first_read
+
+
+def detect_stall(
+    observations: list[TurnObservation],
+    weights: StallWeights | None = None,
+) -> StallDecision:
+    """Decide whether the trajectory in `observations` looks stalled.
+
+    Composite, precision-biased: fire on the turn-count floor alone, OR when at
+    least TWO independent structural signals agree. A single weak signal never
+    fires."""
+    w = weights or DEFAULT_STALL_WEIGHTS
+    assistant_obs = [o for o in observations if o.role == "assistant"]
+    turn_count = len(assistant_obs)
+
+    signals: list[str] = []
+
+    loop_run = _trailing_identical_run(assistant_obs)
+    loop = loop_run >= w.repeat_threshold
+    if loop:
+        # loop implies a non-empty trailing tool set, so [0] is safe.
+        signals.append(f"tool_loop({assistant_obs[-1].tool_names[0]}x{loop_run})")
+
+    error_run = _trailing_error_run(observations)
+    consecutive_errors = error_run >= w.error_threshold
+    if consecutive_errors:
+        signals.append(f"tool_errors(x{error_run})")
+
+    pbe = _patch_before_explore(observations)
+    if pbe:
+        signals.append("patch_before_explore")
+
+    structural_count = int(loop) + int(consecutive_errors) + int(pbe)
+
+    turn_floor = turn_count >= w.max_turns
+    if turn_floor:
+        signals.append(f"turn_floor({turn_count})")
+
+    stalled = turn_floor or structural_count >= 2
+    if stalled:
+        rationale = "stall:" + ",".join(signals)
+    else:
+        rationale = f"no_stall:turns={turn_count},structural={structural_count}"
+    return StallDecision(stalled=stalled, signals=tuple(signals), rationale=rationale)
+
+
+DEFAULT_STALL_WEIGHTS = StallWeights()
+
+
+def stall_shadow_enabled() -> bool:
+    """Whether `MODELMELD_STALL_SHADOW` enables observe-only stall telemetry.
+
+    Default OFF. When on, the route handler runs `detect_stall` and emits a log
+    line + `x-modelmeld-stall-shadow` header but does NOT change routing."""
+    return os.environ.get("MODELMELD_STALL_SHADOW", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+__all__ = [
+    "DEFAULT_STALL_WEIGHTS",
+    "StallDecision",
+    "StallWeights",
+    "TurnObservation",
+    "default_stall_weights",
+    "detect_stall",
+    "observations_from_anthropic",
+    "observations_from_internal",
+    "stall_shadow_enabled",
+]

--- a/tests/test_route_messages.py
+++ b/tests/test_route_messages.py
@@ -1031,3 +1031,91 @@ def test_native_body_preserves_thinking_when_no_substitution() -> None:
     assert (out.model_extra or {}).get("thinking") == thinking
     # served None → unchanged too.
     assert _native_body_for_upstream(body, None) is body
+
+
+# ---------------------------------------------------------------------------
+# Reactive-escalation SHADOW (observe-only) — x-modelmeld-stall-shadow header
+# ---------------------------------------------------------------------------
+
+_STALL_MESSAGES = [
+    {"role": "user", "content": "fix the failing test"},
+    {
+        "role": "assistant",
+        "content": [{"type": "tool_use", "id": "e1", "name": "Edit", "input": {}}],
+    },
+    {
+        "role": "user",
+        "content": [
+            {"type": "tool_result", "tool_use_id": "e1", "content": "boom", "is_error": True}
+        ],
+    },
+    {
+        "role": "assistant",
+        "content": [{"type": "tool_use", "id": "e2", "name": "Edit", "input": {}}],
+    },
+    {
+        "role": "user",
+        "content": [
+            {"type": "tool_result", "tool_use_id": "e2", "content": "boom", "is_error": True}
+        ],
+    },
+]
+
+
+async def test_stall_shadow_emits_header_without_changing_routing(
+    monkeypatch,
+) -> None:
+    """With the flag on and an -auto request whose history looks stalled, the
+    gateway emits x-modelmeld-stall-shadow AND still serves the OSS adapter
+    (observe-only: routing is unchanged)."""
+    monkeypatch.setenv("MODELMELD_STALL_SHADOW", "on")
+    app = build_app(adapter=_EchoAdapter())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/v1/messages", json={
+            "model": "anthropic/modelmeld-auto",
+            "max_tokens": 256,
+            "messages": _STALL_MESSAGES,
+        })
+
+    assert resp.status_code == 200
+    shadow = resp.headers.get("x-modelmeld-stall-shadow")
+    assert shadow is not None
+    assert shadow.startswith("turn=")
+    assert "patch_before_explore" in shadow
+    # Observe-only: the routed model is still the non-frontier echo adapter.
+    assert resp.headers.get("x-modelmeld-routed-model") != "claude-opus-4-8"
+
+
+async def test_stall_shadow_silent_when_flag_off(monkeypatch) -> None:
+    monkeypatch.delenv("MODELMELD_STALL_SHADOW", raising=False)
+    app = build_app(adapter=_EchoAdapter())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/v1/messages", json={
+            "model": "anthropic/modelmeld-auto",
+            "max_tokens": 256,
+            "messages": _STALL_MESSAGES,
+        })
+
+    assert resp.status_code == 200
+    assert "x-modelmeld-stall-shadow" not in resp.headers
+
+
+async def test_stall_shadow_skips_non_auto_policy(monkeypatch) -> None:
+    """-saver / plain models never participate, even with a stalled history."""
+    monkeypatch.setenv("MODELMELD_STALL_SHADOW", "on")
+    app = build_app(adapter=_EchoAdapter())
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/v1/messages", json={
+            "model": "anthropic/modelmeld-saver",
+            "max_tokens": 256,
+            "messages": _STALL_MESSAGES,
+        })
+
+    assert resp.status_code == 200
+    assert "x-modelmeld-stall-shadow" not in resp.headers

--- a/tests/test_session_key.py
+++ b/tests/test_session_key.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""Unit tests for session-key derivation (scout/session_key.py)."""
+
+from __future__ import annotations
+
+from modelmeld.api.schemas import ChatCompletionRequest, SystemMessage, UserMessage
+from modelmeld.memory.identity import HEADER_SESSION_ID
+from modelmeld.scout.session_key import derive_session_key
+
+
+def _req(system: str, first_user: str, *later_user: str) -> ChatCompletionRequest:
+    messages: list = [
+        SystemMessage(role="system", content=system),
+        UserMessage(role="user", content=first_user),
+    ]
+    for u in later_user:
+        messages.append(UserMessage(role="user", content=u))
+    return ChatCompletionRequest(model="anthropic/modelmeld-auto", messages=messages)
+
+
+def test_explicit_session_id_header_wins() -> None:
+    key = derive_session_key(
+        {HEADER_SESSION_ID: "sess-123"}, _req("sys", "hello"), "tenantA"
+    )
+    assert key == "tenantA:sid:sess-123"
+
+
+def test_implicit_key_is_stable_across_growing_history() -> None:
+    # Same opening system+first-user, different later turns → same key.
+    k1 = derive_session_key({}, _req("sys", "build a parser"), "t1")
+    k2 = derive_session_key(
+        {}, _req("sys", "build a parser", "now add tests", "fix the bug"), "t1"
+    )
+    assert k1 == k2
+    assert k1.startswith("t1:impl:")
+
+
+def test_different_first_user_diverges() -> None:
+    k1 = derive_session_key({}, _req("sys", "task one"), "t1")
+    k2 = derive_session_key({}, _req("sys", "task two"), "t1")
+    assert k1 != k2
+
+
+def test_tenant_salt_isolates_identical_content() -> None:
+    k1 = derive_session_key({}, _req("sys", "same task"), "tenantA")
+    k2 = derive_session_key({}, _req("sys", "same task"), "tenantB")
+    assert k1 != k2
+
+
+def test_empty_session_id_header_falls_back_to_implicit() -> None:
+    key = derive_session_key({HEADER_SESSION_ID: "  "}, _req("sys", "x"), "t1")
+    assert key.startswith("t1:impl:")

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""Unit tests for the per-session stall state store (scout/session_state.py)."""
+
+from __future__ import annotations
+
+from modelmeld.scout.session_state import SessionStallState, SessionStallStore
+
+
+class _Clock:
+    """Deterministic monotonic-style clock for TTL tests."""
+
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+def test_get_or_create_is_idempotent() -> None:
+    store = SessionStallStore()
+    a = store.get_or_create("k")
+    a.turns_seen += 1
+    b = store.get_or_create("k")
+    assert a is b
+    assert b.turns_seen == 1
+    assert len(store) == 1
+
+
+def test_default_state_shape() -> None:
+    s = SessionStallState()
+    assert s.turns_seen == 0
+    assert s.last_signals == ()
+    assert s.shadow_fired_turn is None
+
+
+def test_ttl_eviction() -> None:
+    clock = _Clock()
+    store = SessionStallStore(ttl_sec=100.0, clock=clock)
+    store.get_or_create("old")
+    clock.advance(101.0)
+    # Touching a different key triggers lazy eviction of the expired one.
+    store.get_or_create("fresh")
+    assert len(store) == 1
+
+
+def test_active_session_not_evicted() -> None:
+    clock = _Clock()
+    store = SessionStallStore(ttl_sec=100.0, clock=clock)
+    store.get_or_create("k")
+    clock.advance(50.0)
+    store.get_or_create("k")  # refreshes last_seen
+    clock.advance(60.0)       # 60 < ttl since last touch
+    store.get_or_create("k")
+    assert len(store) == 1
+
+
+def test_max_entries_cap_evicts_oldest() -> None:
+    clock = _Clock()
+    store = SessionStallStore(max_entries=2, clock=clock)
+    store.get_or_create("a")
+    clock.advance(1.0)
+    store.get_or_create("b")
+    clock.advance(1.0)
+    store.get_or_create("c")  # over cap → oldest ("a") evicted
+    assert len(store) == 2
+    keys = set(store._entries)  # type: ignore[attr-defined]
+    assert keys == {"b", "c"}

--- a/tests/test_stall.py
+++ b/tests/test_stall.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""Unit tests for the observe-only stall detector (scout/stall.py)."""
+
+from __future__ import annotations
+
+import pytest
+
+from modelmeld.api.schemas import (
+    AssistantMessage,
+    ChatCompletionRequest,
+    FunctionCall,
+    ToolCall,
+    ToolMessage,
+    UserMessage,
+)
+from modelmeld.api.schemas_anthropic import (
+    AnthropicMessage,
+    AnthropicMessagesRequest,
+    AnthropicTextBlock,
+    AnthropicToolResultBlock,
+    AnthropicToolUseBlock,
+)
+from modelmeld.scout.stall import (
+    StallWeights,
+    TurnObservation,
+    default_stall_weights,
+    detect_stall,
+    observations_from_anthropic,
+    observations_from_internal,
+    stall_shadow_enabled,
+)
+
+
+# --- helpers ---------------------------------------------------------------- #
+def _a(*tools: str) -> TurnObservation:
+    """An assistant turn calling `tools`."""
+    return TurnObservation(role="assistant", tool_names=tools)
+
+
+def _result(error: bool) -> TurnObservation:
+    """A user turn carrying a tool result (errored or not)."""
+    return TurnObservation(role="user", has_tool_result=True, tool_error=error)
+
+
+# --- component signals ------------------------------------------------------ #
+def test_loop_alone_does_not_stall() -> None:
+    # Two identical Bash turns is a loop (1 structural signal) but not 2 — and
+    # patch-before-explore can't fire on a non-edit tool, so this stays calm.
+    obs = [_a("Bash"), _result(False), _a("Bash"), _result(False)]
+    assert detect_stall(obs).stalled is False
+
+
+def test_loop_plus_errors_stalls() -> None:
+    obs = [_a("Bash"), _result(True), _a("Bash"), _result(True)]
+    d = detect_stall(obs)
+    assert d.stalled is True
+    assert any(s.startswith("tool_loop") for s in d.signals)
+    assert any(s.startswith("tool_errors") for s in d.signals)
+
+
+def test_single_error_does_not_count_as_consecutive() -> None:
+    # One errored result is below the error threshold; loop alone won't fire.
+    obs = [_a("Bash"), _result(False), _a("Bash"), _result(True)]
+    assert detect_stall(obs).stalled is False
+
+
+def test_patch_before_explore_plus_loop_stalls() -> None:
+    obs = [_a("Edit"), _a("Edit")]  # edit, edit — never read first
+    d = detect_stall(obs)
+    assert d.stalled is True
+    assert "patch_before_explore" in d.signals
+
+
+def test_patch_before_explore_alone_does_not_stall() -> None:
+    obs = [_a("Edit"), _a("Read")]  # one structural signal only
+    assert detect_stall(obs).stalled is False
+
+
+def test_read_then_edit_is_not_patch_before_explore() -> None:
+    obs = [_a("Read"), _a("Edit"), _a("Read"), _a("Edit")]
+    d = detect_stall(obs)
+    assert "patch_before_explore" not in d.signals
+
+
+def test_turn_floor_fires_alone() -> None:
+    obs = [_a() for _ in range(8)]  # 8 plain assistant turns, no tools
+    d = detect_stall(obs)
+    assert d.stalled is True
+    assert any(s.startswith("turn_floor") for s in d.signals)
+
+
+def test_below_turn_floor_does_not_fire() -> None:
+    obs = [_a() for _ in range(7)]
+    assert detect_stall(obs).stalled is False
+
+
+def test_repeat_threshold_is_respected() -> None:
+    # With repeat_threshold=3, two identical turns no longer count as a loop.
+    w = StallWeights(repeat_threshold=3)
+    obs = [_a("Bash"), _result(True), _a("Bash"), _result(True)]
+    d = detect_stall(obs, w)
+    assert not any(s.startswith("tool_loop") for s in d.signals)
+
+
+# --- extractors ------------------------------------------------------------- #
+def test_observations_from_anthropic_reads_tools_and_errors() -> None:
+    body = AnthropicMessagesRequest(
+        model="anthropic/modelmeld-auto",
+        max_tokens=256,
+        messages=[
+            AnthropicMessage(
+                role="assistant",
+                content=[AnthropicToolUseBlock(type="tool_use", id="t1", name="Edit")],
+            ),
+            AnthropicMessage(
+                role="user",
+                content=[
+                    AnthropicToolResultBlock(
+                        type="tool_result",
+                        tool_use_id="t1",
+                        content=[AnthropicTextBlock(type="text", text="boom")],
+                        is_error=True,
+                    )
+                ],
+            ),
+        ],
+    )
+    obs = observations_from_anthropic(body)
+    assert obs[0].role == "assistant"
+    assert obs[0].tool_names == ("Edit",)
+    assert obs[1].has_tool_result is True
+    assert obs[1].tool_error is True
+
+
+def test_observations_from_internal_loses_is_error() -> None:
+    req = ChatCompletionRequest(
+        model="anthropic/modelmeld-auto",
+        messages=[
+            UserMessage(role="user", content="fix it"),
+            AssistantMessage(
+                role="assistant",
+                tool_calls=[
+                    ToolCall(
+                        id="c1",
+                        type="function",
+                        function=FunctionCall(name="Edit", arguments="{}"),
+                    )
+                ],
+            ),
+            ToolMessage(role="tool", content="AssertionError", tool_call_id="c1"),
+        ],
+    )
+    obs = observations_from_internal(req)
+    assert obs[1].tool_names == ("Edit",)
+    assert obs[2].has_tool_result is True
+    # is_error is dropped in translation, so the internal extractor can't see it.
+    assert obs[2].tool_error is False
+
+
+# --- env gating ------------------------------------------------------------- #
+def test_stall_shadow_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MODELMELD_STALL_SHADOW", raising=False)
+    assert stall_shadow_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "YES", "on"])
+def test_stall_shadow_enabled_truthy(monkeypatch: pytest.MonkeyPatch, val: str) -> None:
+    monkeypatch.setenv("MODELMELD_STALL_SHADOW", val)
+    assert stall_shadow_enabled() is True
+
+
+def test_weights_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODELMELD_STALL_MAX_TURNS", "20")
+    monkeypatch.setenv("MODELMELD_STALL_REPEAT_THRESHOLD", "3")
+    monkeypatch.setenv("MODELMELD_STALL_ERROR_THRESHOLD", "4")
+    w = default_stall_weights()
+    assert (w.max_turns, w.repeat_threshold, w.error_threshold) == (20, 3, 4)
+
+
+def test_weights_env_invalid_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODELMELD_STALL_MAX_TURNS", "not-an-int")
+    assert default_stall_weights().max_turns == 8


### PR DESCRIPTION
## Summary

  Lays the groundwork for reactive (mid-session) frontier escalation on the `-auto` policy,
  but ships it as **shadow / observe-only**: it detects a stalled agentic trajectory and
  emits telemetry, and changes **nothing** about routing. Predictive request-time difficulty  routing was retired; the surviving signal for "this run needs help" is *runtime*
  non-convergence, which the gateway can read retrospectively because the full conversation
  history arrives client-supplied on every turn. This increment exists to generate the
  stall-truth labels needed to validate (via an A/B) whether *acting* on a stall is
  net-positive before any routing change ships.

  ## Type of change

  - [x] New feature (non-breaking change that adds capability)
  - [x] Test-only change

  ## Test plan

  New, pure (no ML, hot-path-safe) modules under `scout/`:
  - `stall.py` — `detect_stall()` over a shape-agnostic `TurnObservation` list, with
  extractors for the native Anthropic body (full fidelity incl. `is_error`) and the internal  OpenAI shape. Signals: repeated identical tool calls across consecutive turns,
  consecutive error-bearing tool results, patch-before-explore, and a turn-count floor.
  Precision-biased composite (fire on the floor alone, or ≥2 structural signals).
  - `session_state.py` — `SessionStallStore`, a TTL-bounded per-session map (mirrors the
  router health-cache idiom) used to de-duplicate telemetry.
  - `session_key.py` — `derive_session_key()`: explicit `x-modelmeld-session-id` when
  present, else a tenant-salted hash of the stable conversation prefix.

  Integration is observe-only, `-auto` only, gated by `MODELMELD_STALL_SHADOW` (default
  OFF): `/v1/messages` runs the full signal set off the native body and emits an
  `x-modelmeld-stall-shadow` response header (propagated on both streaming and non-streaming  paths) plus a once-per-session log line. `/v1/chat/completions` runs the reduced set (no
  `is_error` on that surface).

  Verified:
  - `tests/test_stall.py` — each signal in isolation, the composite threshold, the shape
  extractors, and `MODELMELD_STALL_*` env parsing.
  - `tests/test_session_state.py` — `get_or_create` idempotency, TTL eviction, max-entries
  cap eviction.
  - `tests/test_session_key.py` — explicit-header path, implicit-hash stability across a
  growing history, tenant isolation.
  - `tests/test_route_messages.py` — end-to-end: header appears under `-auto` with the flag
  on while routing is unchanged; nothing fires with the flag off or under a non-`-auto`
  policy.
  - Full suite: `ruff check src tests` clean, `pyright` 0 errors, `pytest -q` → 1276 passed,  12 skipped.

  ## Linked issues

  <!-- add tracking issue if desired -->

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [ ] Documentation updated if user-facing behavior changed (no user-facing behavior
  change — flag default OFF, observe-only)
  - [x] `pre-commit run --all-files` passes
  - [x] `pytest` passes (full suite, not just the changed file)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md` first