### PR TITLE
feat(registry): encode measured agentic_coding on overlay leader rows

### DIFF
--- a/src/modelmeld/scout/data/default_overlay.json
+++ b/src/modelmeld/scout/data/default_overlay.json
@@ -7,7 +7,8 @@
     "reasoning",
     "simple_qa",
     "summarization",
-    "tool_use"
+    "tool_use",
+    "agentic_coding"
   ],
   "models": [
     {
@@ -17,7 +18,9 @@
       "context_window": 128000,
       "cost_per_m_input": 0.66,
       "cost_per_m_output": 1.0,
-      "task_scores": {"tool_use": 0.0},
+      "task_scores": {
+        "tool_use": 0.0
+      },
       "supports_tools": false,
       "source": "modelmeld_tool_eval_v1_2026_06_07"
     },
@@ -28,7 +31,9 @@
       "context_window": 131072,
       "cost_per_m_input": 1.04,
       "cost_per_m_output": 1.04,
-      "task_scores": {"tool_use": 0.3},
+      "task_scores": {
+        "tool_use": 0.3
+      },
       "source": "modelmeld_tool_eval_v1_2026_06_07"
     },
     {
@@ -38,7 +43,9 @@
       "context_window": 131072,
       "cost_per_m_input": 0.1,
       "cost_per_m_output": 0.32,
-      "task_scores": {"tool_use": 0.55},
+      "task_scores": {
+        "tool_use": 0.55
+      },
       "source": "modelmeld_agentic_obs_2026_06_08"
     },
     {
@@ -48,8 +55,10 @@
       "context_window": 1048576,
       "cost_per_m_input": 0.3,
       "cost_per_m_output": 1.1,
-      "task_scores": {},
-      "source": "oss_overlay_2026_05_30"
+      "task_scores": {
+        "agentic_coding": 0.29
+      },
+      "source": "oss_overlay_2026_05_30+ro3_multiprovider_v1_2026_06_17"
     },
     {
       "model_id": "deepseek-v4-pro",
@@ -58,8 +67,11 @@
       "context_window": 512000,
       "cost_per_m_input": 2.1,
       "cost_per_m_output": 4.4,
-      "task_scores": {"tool_use": 0.85},
-      "source": "modelmeld_tool_eval_v1_2026_06_07"
+      "task_scores": {
+        "tool_use": 0.85,
+        "agentic_coding": 0.29
+      },
+      "source": "modelmeld_tool_eval_v1_2026_06_07+ro3_multiprovider_v1_2026_06_17"
     },
     {
       "model_id": "deepseek-v4-pro",
@@ -68,8 +80,11 @@
       "context_window": 1048576,
       "cost_per_m_input": 0.44,
       "cost_per_m_output": 0.87,
-      "task_scores": {"tool_use": 0.85},
-      "source": "modelmeld_tool_eval_v1_2026_06_07"
+      "task_scores": {
+        "tool_use": 0.85,
+        "agentic_coding": 0.29
+      },
+      "source": "modelmeld_tool_eval_v1_2026_06_07+ro3_multiprovider_v1_2026_06_17"
     },
     {
       "model_id": "gpt-oss-120b",
@@ -78,7 +93,9 @@
       "context_window": 131072,
       "cost_per_m_input": 0.5,
       "cost_per_m_output": 0.5,
-      "task_scores": {"tool_use": 0.09},
+      "task_scores": {
+        "tool_use": 0.09
+      },
       "source": "modelmeld_tool_eval_v1_2026_06_07_inferred"
     },
     {
@@ -88,7 +105,9 @@
       "context_window": 131072,
       "cost_per_m_input": 0.15,
       "cost_per_m_output": 0.6,
-      "task_scores": {"tool_use": 0.09},
+      "task_scores": {
+        "tool_use": 0.09
+      },
       "source": "modelmeld_tool_eval_v1_2026_06_07"
     },
     {
@@ -98,7 +117,9 @@
       "context_window": 131072,
       "cost_per_m_input": 0.04,
       "cost_per_m_output": 0.18,
-      "task_scores": {"tool_use": 0.09},
+      "task_scores": {
+        "tool_use": 0.09
+      },
       "source": "modelmeld_tool_eval_v1_2026_06_07"
     },
     {
@@ -108,8 +129,11 @@
       "context_window": 262144,
       "cost_per_m_input": 0.6,
       "cost_per_m_output": 0.6,
-      "task_scores": {"tool_use": 0.85},
-      "source": "modelmeld_tool_eval_v1_2026_06_07"
+      "task_scores": {
+        "tool_use": 0.85,
+        "agentic_coding": 0.71
+      },
+      "source": "modelmeld_tool_eval_v1_2026_06_07+ro3_multiprovider_v1_2026_06_17"
     },
     {
       "model_id": "kimi-k2.6",
@@ -118,8 +142,11 @@
       "context_window": 262144,
       "cost_per_m_input": 1.2,
       "cost_per_m_output": 4.5,
-      "task_scores": {"tool_use": 0.85},
-      "source": "modelmeld_tool_eval_v1_2026_06_07"
+      "task_scores": {
+        "tool_use": 0.85,
+        "agentic_coding": 0.71
+      },
+      "source": "modelmeld_tool_eval_v1_2026_06_07+ro3_multiprovider_v1_2026_06_17"
     },
     {
       "model_id": "phi-4",
@@ -128,7 +155,9 @@
       "context_window": 16384,
       "cost_per_m_input": 0.07,
       "cost_per_m_output": 0.14,
-      "task_scores": {"tool_use": 0.0},
+      "task_scores": {
+        "tool_use": 0.0
+      },
       "supports_tools": false,
       "source": "modelmeld_tool_eval_v1_2026_06_07"
     },
@@ -139,7 +168,9 @@
       "context_window": 262144,
       "cost_per_m_input": 0.11,
       "cost_per_m_output": 0.8,
-      "task_scores": {"tool_use": 0.85},
+      "task_scores": {
+        "tool_use": 0.85
+      },
       "source": "modelmeld_tool_eval_v1_2026_06_07"
     },
     {
@@ -149,7 +180,9 @@
       "context_window": 202752,
       "cost_per_m_input": 0.43,
       "cost_per_m_output": 1.74,
-      "task_scores": {"tool_use": 0.81},
+      "task_scores": {
+        "tool_use": 0.81
+      },
       "source": "modelmeld_tool_eval_v1_2026_06_10"
     },
     {
@@ -159,7 +192,9 @@
       "context_window": 1048576,
       "cost_per_m_input": 0.22,
       "cost_per_m_output": 1.8,
-      "task_scores": {"tool_use": 0.72},
+      "task_scores": {
+        "tool_use": 0.72
+      },
       "source": "modelmeld_tool_eval_v1_2026_06_10"
     },
     {
@@ -169,7 +204,9 @@
       "context_window": 204800,
       "cost_per_m_input": 0.255,
       "cost_per_m_output": 1.0,
-      "task_scores": {"tool_use": 0.85},
+      "task_scores": {
+        "tool_use": 0.85
+      },
       "source": "modelmeld_tool_eval_v1_2026_06_10"
     },
     {
@@ -179,7 +216,9 @@
       "context_window": 262144,
       "cost_per_m_input": 0.4,
       "cost_per_m_output": 2.0,
-      "task_scores": {"tool_use": 0.85},
+      "task_scores": {
+        "tool_use": 0.85
+      },
       "source": "modelmeld_tool_eval_v1_2026_06_10"
     },
     {
@@ -189,8 +228,11 @@
       "context_window": 1048576,
       "cost_per_m_input": 0.1,
       "cost_per_m_output": 0.2,
-      "task_scores": {"tool_use": 0.85},
-      "source": "modelmeld_tool_eval_v1_2026_06_13"
+      "task_scores": {
+        "tool_use": 0.85,
+        "agentic_coding": 0.5
+      },
+      "source": "modelmeld_tool_eval_v1_2026_06_13+ro3_multiprovider_v1_2026_06_17"
     },
     {
       "model_id": "minimax-m3",
@@ -199,8 +241,11 @@
       "context_window": 1048576,
       "cost_per_m_input": 0.3,
       "cost_per_m_output": 1.2,
-      "task_scores": {"tool_use": 0.85},
-      "source": "modelmeld_tool_eval_v1_2026_06_13"
+      "task_scores": {
+        "tool_use": 0.85,
+        "agentic_coding": 0.57
+      },
+      "source": "modelmeld_tool_eval_v1_2026_06_13+ro3_multiprovider_v1_2026_06_17"
     },
     {
       "model_id": "minimax-m3",
@@ -209,8 +254,11 @@
       "context_window": 524288,
       "cost_per_m_input": 0.3,
       "cost_per_m_output": 1.2,
-      "task_scores": {"tool_use": 0.85},
-      "source": "modelmeld_tool_eval_v1_2026_06_13"
+      "task_scores": {
+        "tool_use": 0.85,
+        "agentic_coding": 0.57
+      },
+      "source": "modelmeld_tool_eval_v1_2026_06_13+ro3_multiprovider_v1_2026_06_17"
     },
     {
       "model_id": "glm-5",
@@ -219,8 +267,11 @@
       "context_window": 202752,
       "cost_per_m_input": 0.6,
       "cost_per_m_output": 1.92,
-      "task_scores": {"tool_use": 0.85},
-      "source": "modelmeld_tool_eval_v1_2026_06_13"
+      "task_scores": {
+        "tool_use": 0.85,
+        "agentic_coding": 0.88
+      },
+      "source": "modelmeld_tool_eval_v1_2026_06_13+ro3_multiprovider_v1_2026_06_17"
     },
     {
       "model_id": "glm-5",
@@ -229,8 +280,11 @@
       "context_window": 202752,
       "cost_per_m_input": 1.0,
       "cost_per_m_output": 3.2,
-      "task_scores": {"tool_use": 0.85},
-      "source": "modelmeld_tool_eval_v1_2026_06_13"
+      "task_scores": {
+        "tool_use": 0.85,
+        "agentic_coding": 0.88
+      },
+      "source": "modelmeld_tool_eval_v1_2026_06_13+ro3_multiprovider_v1_2026_06_17"
     },
     {
       "model_id": "kimi-k2.6",
@@ -239,8 +293,11 @@
       "context_window": 262144,
       "cost_per_m_input": 0.68,
       "cost_per_m_output": 3.41,
-      "task_scores": {"tool_use": 0.85},
-      "source": "modelmeld_tool_eval_v1_2026_06_13"
+      "task_scores": {
+        "tool_use": 0.85,
+        "agentic_coding": 0.71
+      },
+      "source": "modelmeld_tool_eval_v1_2026_06_13+ro3_multiprovider_v1_2026_06_17"
     },
     {
       "model_id": "qwen3.7-plus",
@@ -249,8 +306,11 @@
       "context_window": 1000000,
       "cost_per_m_input": 0.32,
       "cost_per_m_output": 1.28,
-      "task_scores": {"tool_use": 0.85},
-      "source": "modelmeld_tool_eval_v1_2026_06_13"
+      "task_scores": {
+        "tool_use": 0.85,
+        "agentic_coding": 0.0
+      },
+      "source": "modelmeld_tool_eval_v1_2026_06_13+ro3_multiprovider_v1_2026_06_17"
     },
     {
       "model_id": "mimo-v2.5",
@@ -259,8 +319,11 @@
       "context_window": 1048576,
       "cost_per_m_input": 0.14,
       "cost_per_m_output": 0.28,
-      "task_scores": {"tool_use": 0.85},
-      "source": "modelmeld_tool_eval_v1_2026_06_13"
+      "task_scores": {
+        "tool_use": 0.85,
+        "agentic_coding": 0.12
+      },
+      "source": "modelmeld_tool_eval_v1_2026_06_13+ro3_multiprovider_v1_2026_06_17"
     },
     {
       "model_id": "hy3-preview",
@@ -269,8 +332,11 @@
       "context_window": 262144,
       "cost_per_m_input": 0.063,
       "cost_per_m_output": 0.21,
-      "task_scores": {"tool_use": 0.85},
-      "source": "modelmeld_tool_eval_v1_2026_06_13"
+      "task_scores": {
+        "tool_use": 0.85,
+        "agentic_coding": 0.25
+      },
+      "source": "modelmeld_tool_eval_v1_2026_06_13+ro3_multiprovider_v1_2026_06_17"
     }
   ]
 }

--- a/tests/test_multi_provider_registry.py
+++ b/tests/test_multi_provider_registry.py
@@ -263,15 +263,21 @@ def test_load_default_overlay_models_have_multiple_providers() -> None:
 
 
 def test_load_default_overlay_task_scores_inherit_from_base() -> None:
-    """Overlay rows with empty task_scores inherit fully from base by model_id."""
+    """Overlay rows inherit every base task_score per-key by model_id; an
+    overlay-only MEASURED score (agentic_coding) is layered on top without
+    disturbing the inherited base categories."""
     reg = MultiProviderModelRegistry.load_default()
-    # deepseek-v4-pro@fireworks has empty task_scores in the overlay JSON
-    # (eval was rate-limited there), so it inherits base scores wholesale.
+    # deepseek-v4-pro@fireworks carries only a measured agentic_coding in the
+    # overlay; the base coding/reasoning/etc. categories inherit wholesale.
     overlay_entry = reg.get_by_key("deepseek-v4-pro", "fireworks")
     base_entry = reg.get_by_key("deepseek-v4-pro", "vllm")
     assert overlay_entry is not None
     assert base_entry is not None
-    assert overlay_entry.task_scores == base_entry.task_scores
+    # every base category is inherited unchanged
+    for k, v in base_entry.task_scores.items():
+        assert overlay_entry.task_scores[k] == v
+    # plus the overlay's measured agentic_coding (RO-3 multi-provider-correct)
+    assert overlay_entry.task_scores["agentic_coding"] == 0.29
 
 
 def test_load_default_overlay_task_scores_merge_over_base() -> None:

--- a/tests/test_overlay_agentic_capability.py
+++ b/tests/test_overlay_agentic_capability.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""The overlay carries a MEASURED `agentic_coding` capability on the leader rows.
+
+Derived from the RO-3 multi-provider-correct rate (how often a model's agentic
+patch threads the chosen provider's slug vs re-deriving it — the failure class the
+gates were historically blind to). This corrects the hand-estimated base scores,
+which ranked deepseek-v4-pro *above* glm-5 on coding while the measured data is
+the reverse (glm-5 88% multi-provider-correct vs the chronic shortcut-takers).
+"""
+from __future__ import annotations
+
+from modelmeld.scout.multi_provider_registry import default_multi_provider_registry
+
+
+def _agentic(reg, model_id: str) -> float | None:
+    for e in reg.all_entries_multi():
+        if e.model_id == model_id and "agentic_coding" in e.task_scores:
+            return e.task_scores["agentic_coding"]
+    return None
+
+
+def test_measured_agentic_coding_present_on_leaders() -> None:
+    reg = default_multi_provider_registry()
+    for m in ("glm-5", "kimi-k2.6", "minimax-m3", "deepseek-v4-flash",
+              "deepseek-v4-pro", "hy3-preview", "mimo-v2.5", "qwen3.7-plus"):
+        assert _agentic(reg, m) is not None, f"missing agentic_coding for {m}"
+
+
+def test_agentic_coding_corrects_the_manual_inversion() -> None:
+    reg = default_multi_provider_registry()
+    glm = _agentic(reg, "glm-5")
+    # The reliable OSS coders outrank the chronic shortcut-takers — the opposite
+    # of what the manual base coding estimates implied.
+    assert glm > _agentic(reg, "qwen3.7-plus")
+    assert glm > _agentic(reg, "mimo-v2.5")
+    assert _agentic(reg, "kimi-k2.6") > _agentic(reg, "hy3-preview")
+    # measured values are in [0, 1]
+    for m in ("glm-5", "qwen3.7-plus"):
+        assert 0.0 <= _agentic(reg, m) <= 1.0


### PR DESCRIPTION
## Summary

  The multi-provider overlay leader rows carried only a saturated `tool_use` measurement;
  their coding capability fell through to hand-estimated base scores that ranked some models  the *opposite* of their measured reliability. This adds a measured `agentic_coding`
  capability score to those rows, derived from agentic multi-provider correctness — how
  reliably a model's patch threads the scout-chosen provider's wire slug rather than
  re-deriving it (the failure class the wire-slug invariant test guards). It layers over the  inherited base categories per-key, as a soft capability prior (not a hard gate).

  ## Type of change

  - [x] New feature (non-breaking change that adds capability)
  - [x] Test-only change

  ## Test plan

  - `tests/test_overlay_agentic_capability.py` (new) — asserts the measured `agentic_coding`  is present on every leader row and that the reliable coders outrank the chronic
  shortcut-takers (correcting the manual inversion).
  - `tests/test_multi_provider_registry.py` — updated the overlay-merge test to assert base
  categories still inherit per-key *plus* the layered measured score.
  - `ruff check` clean; full `pytest -q` → 1285 passed, 12 skipped.

  ## Linked issues

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [x] Documentation updated if user-facing behavior changed (data-only; `-quality`
  re-ranks by this prior, `-auto` unaffected pending a follow-up)
  - [x] `pre-commit run --all-files` passes
  - [x] `pytest` passes (full suite)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md` first

  ## Additional context

  Soft prior only: the `-quality` capability-first re-rank consumes `agentic_coding`
  immediately (it will prefer the more reliable models); `-auto` does not read it yet —
  wiring `-auto` to prefer cheapest-reliable is a separate follow-up, so the data change
  ships without a routing-behavior change bundled in.