### PR TITLE
feat(scout): -auto prefers the cheapest reliable model on agentic routes

### DIFF
--- a/src/modelmeld/scout/capability.py
+++ b/src/modelmeld/scout/capability.py
@@ -25,6 +25,7 @@ from modelmeld.scout.difficulty import (
 )
 from modelmeld.scout.policy import (
     ModelMeldPolicy,
+    agentic_reliability_floor,
     frontier_providers,
     large_context_threshold,
     oss_providers,
@@ -469,6 +470,29 @@ class CapabilityScout:
             )
             quality_rationale = f"quality_agentic=capability_first(by={signal})"
 
+        # -auto agentic routing: drop models MEASURED unreliable on multi-provider
+        # agentic correctness, then keep the cheapest survivor (cheapest-RELIABLE,
+        # not cheapest-overall — the chronic shortcut-takers are cheap but ship
+        # latent multi-provider bugs). Only filters rows carrying a measured
+        # `agentic_coding` below the floor; un-probed rows pass through. Falls back
+        # to the full ranking if the floor would leave nothing — never 503s on
+        # reliability alone.
+        auto_reliability_rationale = ""
+        if policy is ModelMeldPolicy.AUTO and require_tool_support:
+            floor = agentic_reliability_floor()
+            if floor > 0:
+                reliable = [
+                    (e, c) for (e, c) in ranked
+                    if e.task_scores.get(_AGENTIC_CAPABILITY_CATEGORY) is None
+                    or e.task_scores[_AGENTIC_CAPABILITY_CATEGORY] >= floor
+                ]
+                dropped = len(ranked) - len(reliable)
+                if reliable and dropped:
+                    ranked = reliable
+                    auto_reliability_rationale = (
+                        f"auto_reliability=floor({floor};dropped={dropped})"
+                    )
+
         chosen_entry, chosen_cost = ranked[0]
         fallbacks: list[str] = [
             entry.model_id for entry, _ in ranked[1 : 1 + self.fallback_depth]
@@ -488,6 +512,8 @@ class CapabilityScout:
             rationale = f"{rationale};{latency_rationale}"
         if quality_rationale:
             rationale = f"{rationale};{quality_rationale}"
+        if auto_reliability_rationale:
+            rationale = f"{rationale};{auto_reliability_rationale}"
 
         return CapabilityDecision(
             chosen_model_id=chosen_entry.model_id,

--- a/src/modelmeld/scout/policy.py
+++ b/src/modelmeld/scout/policy.py
@@ -232,9 +232,31 @@ def large_context_threshold() -> int:
     return _LARGE_CONTEXT_ESCALATE_TOKENS
 
 
+# -auto excludes models MEASURED unreliable on multi-provider agentic correctness
+# from agentic (tool-bearing) coding routes: a model whose `agentic_coding` score
+# sits below this floor ships latent multi-provider bugs too often to be a safe
+# cheap pick (e.g. the chronic shortcut-takers measured at 0-29% correct vs the
+# reliable coders at 50-88%). Conservative default; ONLY filters rows that carry a
+# measured score (un-probed rows pass through), and the caller falls back to the
+# full ranking if nothing clears it (never 503s on reliability alone). 0 disables.
+_AGENTIC_RELIABILITY_FLOOR = 0.40
+
+
+def agentic_reliability_floor() -> float:
+    """Min measured `agentic_coding` for a model to win an -auto agentic route."""
+    raw = os.environ.get("MODELMELD_AGENTIC_RELIABILITY_FLOOR", "").strip()
+    if raw:
+        try:
+            return max(0.0, float(raw))
+        except ValueError:
+            pass
+    return _AGENTIC_RELIABILITY_FLOOR
+
+
 __all__ = [
     "POLICY_QUALITY_THRESHOLD",
     "ModelMeldPolicy",
+    "agentic_reliability_floor",
     "detect_reasoning_markers",
     "extract_user_text",
     "frontier_providers",

--- a/tests/test_scout_auto_reliability.py
+++ b/tests/test_scout_auto_reliability.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 ModelMeld.
+
+"""`-auto` agentic routing drops MEASURED-unreliable models, then picks cheapest.
+
+A model with a low measured `agentic_coding` (the chronic multi-provider
+shortcut-takers) is cheap but ships latent bugs; for agentic (tool-bearing)
+coding routes, `-auto` should prefer the cheapest RELIABLE model over the
+cheapest-overall. Only rows carrying a measured score are filtered; un-probed
+rows pass through; and the filter falls back to the full ranking rather than
+503ing when nothing clears the floor.
+"""
+from __future__ import annotations
+
+from modelmeld.api.schemas import (
+    ChatCompletionRequest,
+    FunctionDef,
+    Tool,
+    UserMessage,
+)
+from modelmeld.scout import CapabilityScout, ModelEntry, ModelRegistry
+
+
+def _entry(model_id: str, cost_in: float, *, coding: float,
+           agentic: float | None) -> ModelEntry:
+    # a tool-bearing request classifies as `tool_use`; carry both category scores
+    # so the threshold gate passes and the agentic_coding floor is what decides.
+    scores: dict[str, float] = {"coding": coding, "tool_use": coding}
+    if agentic is not None:
+        scores["agentic_coding"] = agentic
+    return ModelEntry(
+        model_id=model_id, provider="vllm", context_window=100_000,
+        cost_per_m_input=cost_in, cost_per_m_output=cost_in * 3,
+        task_scores=scores, last_updated="2026-06-17", source="test",
+    )
+
+
+def _req_auto_tools() -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="anthropic/modelmeld-auto",
+        messages=[UserMessage(role="user", content="refactor this code")],
+        tools=[Tool(type="function", function=FunctionDef(name="edit_file"))],
+    )
+
+
+async def test_floor_excludes_cheap_shortcut_taker(monkeypatch) -> None:
+    monkeypatch.delenv("MODELMELD_AGENTIC_RELIABILITY_FLOOR", raising=False)  # default 0.40
+    registry = ModelRegistry([
+        _entry("cheap-shortcut", 0.1, coding=0.85, agentic=0.12),  # cheapest, unreliable
+        _entry("reliable", 0.5, coding=0.80, agentic=0.71),         # pricier, reliable
+    ])
+    scout = CapabilityScout(registry=registry, quality_threshold=0.70)
+    decision = await scout.choose(_req_auto_tools())
+    assert decision.chosen_model_id == "reliable"
+
+
+async def test_floor_disabled_picks_cheapest(monkeypatch) -> None:
+    monkeypatch.setenv("MODELMELD_AGENTIC_RELIABILITY_FLOOR", "0")
+    registry = ModelRegistry([
+        _entry("cheap-shortcut", 0.1, coding=0.85, agentic=0.12),
+        _entry("reliable", 0.5, coding=0.80, agentic=0.71),
+    ])
+    scout = CapabilityScout(registry=registry, quality_threshold=0.70)
+    decision = await scout.choose(_req_auto_tools())
+    assert decision.chosen_model_id == "cheap-shortcut"
+
+
+async def test_floor_falls_back_when_all_unreliable(monkeypatch) -> None:
+    monkeypatch.delenv("MODELMELD_AGENTIC_RELIABILITY_FLOOR", raising=False)
+    registry = ModelRegistry([
+        _entry("cheap-bad", 0.1, coding=0.85, agentic=0.12),
+        _entry("mid-bad", 0.5, coding=0.80, agentic=0.25),
+    ])
+    scout = CapabilityScout(registry=registry, quality_threshold=0.70)
+    decision = await scout.choose(_req_auto_tools())
+    # no reliable survivor → fall back to cheapest, never 503
+    assert decision.chosen_model_id == "cheap-bad"
+
+
+async def test_unprobed_rows_pass_through(monkeypatch) -> None:
+    monkeypatch.delenv("MODELMELD_AGENTIC_RELIABILITY_FLOOR", raising=False)
+    registry = ModelRegistry([
+        _entry("cheap-unscored", 0.1, coding=0.85, agentic=None),  # no measured score
+        _entry("reliable", 0.5, coding=0.80, agentic=0.71),
+    ])
+    scout = CapabilityScout(registry=registry, quality_threshold=0.70)
+    decision = await scout.choose(_req_auto_tools())
+    # un-probed cheapest is NOT filtered (can't judge it) → it wins on cost
+    assert decision.chosen_model_id == "cheap-unscored"


### PR DESCRIPTION
## Summary

  Under `-auto`, agentic (tool-bearing) coding requests were routed to the cheapest model
  clearing the category threshold — which can be cheap but measured-unreliable (ships latent  multi-provider bugs). This adds a conservative reliability floor: for `-auto` + tools,
  models whose **measured** `agentic_coding` sits below the floor are dropped before the
  cheapest survivor is picked — cheapest-*reliable*, not cheapest-overall. Only rows
  carrying a measured score are filtered (un-probed rows pass through), and it falls back to  the full ranking when nothing clears the floor (never 503s on reliability alone).

  ## Type of change

  - [x] New feature (non-breaking change that adds capability)
  - [x] Test-only change

  ## Test plan

  - `tests/test_scout_auto_reliability.py` (new) — floor excludes a cheap
  measured-unreliable model in favor of a reliable one;
  `MODELMELD_AGENTIC_RELIABILITY_FLOOR=0` disables it; falls back to cheapest when nothing
  clears the floor; un-probed rows pass through.
  - `ruff` + `pyright` clean; full `pytest -q` → 1287 passed, 12 skipped.

  ## Linked issues

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [x] Documentation updated if user-facing behavior changed (env
  `MODELMELD_AGENTIC_RELIABILITY_FLOOR`, default 0.40, 0 disables)
  - [x] `pre-commit run --all-files` passes
  - [x] `pytest` passes (full suite)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md` first

  ## Additional context

  Composes with the overlay measured-`agentic_coding` change in any merge order: this filter  is a **no-op until the registry carries measured `agentic_coding` scores**, so it cannot
  change behavior on its own. Floor default 0.40 (excludes models measured below ~40%
  multi-provider-correct).