### PR TITLE
feat(scout): de-prefer un-probed models on -auto agentic routes

### DIFF
--- a/src/modelmeld/scout/capability.py
+++ b/src/modelmeld/scout/capability.py
@@ -470,27 +470,32 @@ class CapabilityScout:
             )
             quality_rationale = f"quality_agentic=capability_first(by={signal})"
 
-        # -auto agentic routing: drop models MEASURED unreliable on multi-provider
-        # agentic correctness, then keep the cheapest survivor (cheapest-RELIABLE,
-        # not cheapest-overall — the chronic shortcut-takers are cheap but ship
-        # latent multi-provider bugs). Only filters rows carrying a measured
-        # `agentic_coding` below the floor; un-probed rows pass through. Falls back
-        # to the full ranking if the floor would leave nothing — never 503s on
-        # reliability alone.
+        # -auto agentic routing: prefer the cheapest model with a MEASURED,
+        # reliable multi-provider-correctness score. A model qualifies only if it
+        # carries a measured `agentic_coding` >= floor — un-probed rows (no
+        # measured score) are DE-PREFERRED, not passed through, because the
+        # cheapest OSS coders are often unmeasured and would otherwise undercut a
+        # proven-reliable model (and some, e.g. gpt-oss-120b, are cheap but weak).
+        # If at least one measured-reliable model exists, restrict to those and
+        # take the cheapest; if NONE is measured-reliable, fall back to the full
+        # ranking (un-probed + below-floor) so a genuinely-new or all-unprobed
+        # pool still routes — never 503 on reliability alone. Tradeoff: a new
+        # model isn't picked for -auto agentic routes until it earns a measured
+        # score (or the operator sets MODELMELD_AGENTIC_RELIABILITY_FLOOR=0).
         auto_reliability_rationale = ""
         if policy is ModelMeldPolicy.AUTO and require_tool_support:
             floor = agentic_reliability_floor()
             if floor > 0:
                 reliable = [
                     (e, c) for (e, c) in ranked
-                    if e.task_scores.get(_AGENTIC_CAPABILITY_CATEGORY) is None
-                    or e.task_scores[_AGENTIC_CAPABILITY_CATEGORY] >= floor
+                    if e.task_scores.get(_AGENTIC_CAPABILITY_CATEGORY) is not None
+                    and e.task_scores[_AGENTIC_CAPABILITY_CATEGORY] >= floor
                 ]
-                dropped = len(ranked) - len(reliable)
-                if reliable and dropped:
+                if reliable and len(reliable) < len(ranked):
+                    dropped = len(ranked) - len(reliable)
                     ranked = reliable
                     auto_reliability_rationale = (
-                        f"auto_reliability=floor({floor};dropped={dropped})"
+                        f"auto_reliability=measured_floor({floor};dropped={dropped})"
                     )
 
         chosen_entry, chosen_cost = ranked[0]

--- a/tests/test_scout_auto_reliability.py
+++ b/tests/test_scout_auto_reliability.py
@@ -77,7 +77,7 @@ async def test_floor_falls_back_when_all_unreliable(monkeypatch) -> None:
     assert decision.chosen_model_id == "cheap-bad"
 
 
-async def test_unprobed_rows_pass_through(monkeypatch) -> None:
+async def test_unprobed_deprefered_when_reliable_exists(monkeypatch) -> None:
     monkeypatch.delenv("MODELMELD_AGENTIC_RELIABILITY_FLOOR", raising=False)
     registry = ModelRegistry([
         _entry("cheap-unscored", 0.1, coding=0.85, agentic=None),  # no measured score
@@ -85,5 +85,19 @@ async def test_unprobed_rows_pass_through(monkeypatch) -> None:
     ])
     scout = CapabilityScout(registry=registry, quality_threshold=0.70)
     decision = await scout.choose(_req_auto_tools())
-    # un-probed cheapest is NOT filtered (can't judge it) → it wins on cost
+    # un-probed cheapest is DE-PREFERRED: a measured-reliable model exists, so it
+    # wins despite being pricier (avoids the cheap-but-unmeasured trap).
+    assert decision.chosen_model_id == "reliable"
+
+
+async def test_unprobed_wins_when_no_measured_reliable(monkeypatch) -> None:
+    monkeypatch.delenv("MODELMELD_AGENTIC_RELIABILITY_FLOOR", raising=False)
+    registry = ModelRegistry([
+        _entry("cheap-unscored", 0.1, coding=0.85, agentic=None),   # un-probed, cheapest
+        _entry("measured-bad", 0.5, coding=0.80, agentic=0.20),     # measured, below floor
+    ])
+    scout = CapabilityScout(registry=registry, quality_threshold=0.70)
+    decision = await scout.choose(_req_auto_tools())
+    # no measured-RELIABLE model → fall back to the full ranking → cheapest wins
+    # (a genuinely-new/all-unprobed pool still routes; never 503).
     assert decision.chosen_model_id == "cheap-unscored"


### PR DESCRIPTION
## Summary

  Tightens the `-auto` agentic reliability floor. A model now qualifies only with a  **measured** `agentic_coding ≥ floor` — un-probed rows (no measured score) are
  **de-preferred**, not passed through. Rationale: the cheapest OSS coders are often  unmeasured and would otherwise undercut a proven-reliable model (and some, e.g.
  gpt-oss-120b, are cheap but weak). If ≥1 measured-reliable model exists, restrict to those  and take the cheapest; if none is measured-reliable, fall back to the full ranking (never
  503). Tradeoff: a new model isn't picked for `-auto` agentic routes until it earns a
  measured score (or `MODELMELD_AGENTIC_RELIABILITY_FLOOR=0`).

  ## Type of change
  - [x] New feature (non-breaking change that adds capability)
  - [x] Test-only change

  ## Test plan
  - `tests/test_scout_auto_reliability.py` — un-probed is de-preferred when a
  measured-reliable model exists; un-probed wins when none is measured-reliable (fallback);
  existing exclude/disable/fallback cases still hold.
  - `ruff` + `pyright` clean; full `pytest -q` → 1290 passed, 12 skipped.

  ## Additional context
  Follow-up to #114. Composes with the overlay scores from #113;
  `MODELMELD_AGENTIC_RELIABILITY_FLOOR` (default 0.40, 0 disables).