### PR TITLE
feat(scout): add per-model `enabled` flag to gate routing

### DIFF
--- a/src/modelmeld/scout/registry.py
+++ b/src/modelmeld/scout/registry.py
@@ -64,6 +64,15 @@ class ModelEntry:
     # below 7B parameters). CapabilityScout filters by this field
     # when the incoming request has `tools=[...]`.
     supports_tools: bool = True
+    # Whether this row is eligible to be routed to at all. Default True; a
+    # row with `enabled=False` stays in the registry (and keeps its scores,
+    # cost, latency) but is filtered out of `pick()`/`rank()` candidate
+    # selection entirely. This is the disable-not-delete switch: deprecate a
+    # model, quarantine a broken/ToS-problematic one, or hold a freshly-added
+    # candidate back until it has been validated — all without losing the row
+    # or its data. The registry/feed PRODUCER decides the policy that sets it;
+    # the gateway only honors the flag.
+    enabled: bool = True
     # --- Capability metadata for substitution-time feature reconciliation (B-3) ---
     # When alias/capability routing serves a different model than the client
     # tuned its request for, these tell the reconciler whether to forward,
@@ -242,6 +251,7 @@ class ModelRegistry:
                     source=row.get("source", ""),
                     provider_model_id=row.get("provider_model_id", ""),
                     supports_tools=bool(row.get("supports_tools", True)),
+                    enabled=bool(row.get("enabled", True)),
                     reasoning_interface=str(row.get("reasoning_interface", "none")),
                     max_output_tokens=(
                         int(row["max_output_tokens"])
@@ -306,6 +316,7 @@ class ModelRegistry:
         """Return the cheapest model meeting `quality_threshold` on `task_category`.
 
         Filters:
+        - enabled (disabled rows are never routed to)
         - task_scores[task_category] >= quality_threshold
         - provider in eligible_providers (if set)
         - context_window >= min_context_window
@@ -315,6 +326,8 @@ class ModelRegistry:
         """
         candidates: list[ModelEntry] = []
         for entry in self._by_id.values():
+            if not entry.enabled:
+                continue
             if eligible_providers is not None and entry.provider not in eligible_providers:
                 continue
             if entry.context_window < min_context_window:
@@ -348,6 +361,7 @@ class ModelRegistry:
         """All eligible candidates sorted cheapest-first. Returns (entry, blended_cost) pairs.
 
         Filters:
+          - enabled (disabled rows are never routed to)
           - task_scores[task_category] >= quality_threshold
           - provider in eligible_providers (if set)
           - context_window >= min_context_window
@@ -367,6 +381,8 @@ class ModelRegistry:
         """
         result: list[tuple[ModelEntry, float]] = []
         for entry in self._by_id.values():
+            if not entry.enabled:
+                continue
             if eligible_providers is not None and entry.provider not in eligible_providers:
                 continue
             if entry.context_window < min_context_window:

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -251,6 +251,82 @@ def test_rank_returns_all_candidates_sorted() -> None:
 
 
 # ---------------------------------------------------------------------------
+# enabled flag — disable-not-delete routing filter
+# ---------------------------------------------------------------------------
+
+def _toy_registry_with_disabled() -> ModelRegistry:
+    """Toy registry where the cheapest qualifying model is disabled."""
+    return ModelRegistry([
+        ModelEntry(
+            model_id="cheap-disabled", provider="vllm", context_window=32_000,
+            cost_per_m_input=0.05, cost_per_m_output=0.05,
+            task_scores={"coding": 0.90}, enabled=False,
+        ),
+        ModelEntry(
+            model_id="pricier-enabled", provider="vllm", context_window=32_000,
+            cost_per_m_input=0.50, cost_per_m_output=0.50,
+            task_scores={"coding": 0.90}, enabled=True,
+        ),
+    ])
+
+
+def test_enabled_defaults_true() -> None:
+    e = ModelEntry(
+        model_id="m", provider="p", context_window=1000,
+        cost_per_m_input=0.1, cost_per_m_output=0.1, task_scores={"coding": 0.9},
+    )
+    assert e.enabled is True
+
+
+def test_pick_skips_disabled_even_when_cheapest_and_qualifying() -> None:
+    reg = _toy_registry_with_disabled()
+    # cheap-disabled is cheaper AND clears the threshold, but is disabled →
+    # the pricier enabled row wins. The disabled row never routes.
+    assert reg.pick("coding", quality_threshold=0.80).model_id == "pricier-enabled"
+
+
+def test_rank_excludes_disabled() -> None:
+    reg = _toy_registry_with_disabled()
+    ranked = reg.rank("coding", quality_threshold=0.0)
+    assert [e.model_id for e, _ in ranked] == ["pricier-enabled"]
+
+
+def test_pick_none_when_only_candidate_is_disabled() -> None:
+    reg = ModelRegistry([
+        ModelEntry(
+            model_id="only-disabled", provider="vllm", context_window=32_000,
+            cost_per_m_input=0.05, cost_per_m_output=0.05,
+            task_scores={"coding": 0.95}, enabled=False,
+        ),
+    ])
+    # A disabled-only pool yields no route (the candidate-quarantine case).
+    assert reg.pick("coding", quality_threshold=0.50) is None
+
+
+def test_from_json_reads_enabled_and_defaults_true_when_absent() -> None:
+    payload = {
+        "version": 1,
+        "models": [
+            {
+                "model_id": "off", "provider": "p", "context_window": 1000,
+                "cost_per_m_input": 0.1, "cost_per_m_output": 0.2,
+                "task_scores": {"coding": 0.9}, "enabled": False,
+            },
+            {  # no `enabled` key → defaults True (backward compat)
+                "model_id": "legacy", "provider": "p", "context_window": 1000,
+                "cost_per_m_input": 0.1, "cost_per_m_output": 0.2,
+                "task_scores": {"coding": 0.9},
+            },
+        ],
+    }
+    reg = ModelRegistry.from_json(payload)
+    assert reg.get("off").enabled is False
+    assert reg.get("legacy").enabled is True
+    # the disabled row is filtered from routing; the legacy row routes
+    assert reg.pick("coding", quality_threshold=0.50).model_id == "legacy"
+
+
+# ---------------------------------------------------------------------------
 # JSON serialization round-trip
 # ---------------------------------------------------------------------------
 

--- a/tests/test_scout_auto_reliability.py
+++ b/tests/test_scout_auto_reliability.py
@@ -22,7 +22,7 @@ from modelmeld.scout import CapabilityScout, ModelEntry, ModelRegistry
 
 
 def _entry(model_id: str, cost_in: float, *, coding: float,
-           agentic: float | None) -> ModelEntry:
+           agentic: float | None, enabled: bool = True) -> ModelEntry:
     # a tool-bearing request classifies as `tool_use`; carry both category scores
     # so the threshold gate passes and the agentic_coding floor is what decides.
     scores: dict[str, float] = {"coding": coding, "tool_use": coding}
@@ -32,6 +32,7 @@ def _entry(model_id: str, cost_in: float, *, coding: float,
         model_id=model_id, provider="vllm", context_window=100_000,
         cost_per_m_input=cost_in, cost_per_m_output=cost_in * 3,
         task_scores=scores, last_updated="2026-06-17", source="test",
+        enabled=enabled,
     )
 
 
@@ -101,3 +102,21 @@ async def test_unprobed_wins_when_no_measured_reliable(monkeypatch) -> None:
     # no measured-RELIABLE model → fall back to the full ranking → cheapest wins
     # (a genuinely-new/all-unprobed pool still routes; never 503).
     assert decision.chosen_model_id == "cheap-unscored"
+
+
+async def test_disabled_unprobed_is_not_chosen_as_fallback(monkeypatch) -> None:
+    """A disabled un-probed model must NOT be the -auto agentic fallback.
+
+    Without `enabled`, the de-prefer logic falls back to the full ranking when
+    nothing is measured-reliable — which could route to an un-validated model.
+    Disabling filters it out of `rank()` BEFORE the fallback, so the enabled
+    (measured-reliable) model wins even though the disabled one is cheaper.
+    """
+    monkeypatch.delenv("MODELMELD_AGENTIC_RELIABILITY_FLOOR", raising=False)
+    registry = ModelRegistry([
+        _entry("cheap-unvalidated", 0.1, coding=0.85, agentic=None, enabled=False),
+        _entry("reliable", 0.5, coding=0.80, agentic=0.71, enabled=True),
+    ])
+    scout = CapabilityScout(registry=registry, quality_threshold=0.70)
+    decision = await scout.choose(_req_auto_tools())
+    assert decision.chosen_model_id == "reliable"


### PR DESCRIPTION
## Summary

  Operators need a way to take a model out of routing without deleting its row — to
  deprecate a model, quarantine one that's misbehaving, or hold a freshly-added candidate
  back until it's been validated — while keeping its scores, cost, and latency data intact
  for when it comes back. Today the only options are "in the registry and routable" or
  "gone." This adds a per-model `enabled: bool` (default `True`); a disabled row stays in
  the registry but is filtered out of `pick()`/`rank()` candidate selection entirely.
  Because the filter runs before ranking, a disabled row also can no longer slip in as the
  `-auto` agentic fallback (which otherwise falls back to the full ranking when nothing
  clears the reliability floor).

  ## Type of change

  - [x] New feature (non-breaking change that adds capability)

  ## Test plan

  - `tests/test_model_registry.py`: new cases — `enabled` defaults True; `pick()` skips a
  disabled row even when it's the cheapest qualifier; `rank()` excludes disabled; a
  disabled-only pool yields no route; `from_json` reads `enabled` and defaults True when the  key is absent (older snapshots).
  - `tests/test_scout_auto_reliability.py`: new case proving a disabled un-probed model is
  not chosen as the `-auto` agentic fallback (closes the full-ranking fallback path).
  - Ran the full suite: `pytest -q` → 1296 passed, 12 skipped. `ruff check` clean on the
  changed files.

  ## Linked issues

  (none)

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [x] Documentation updated if user-facing behavior changed (docstrings on
  `pick()`/`rank()` list the new filter; field is self-documented)
  - [ ] `pre-commit run --all-files` passes (please run on push)
  - [x] `pytest` passes (full suite, not just the changed file)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md` first — `enabled` is pure mechanism; the policy that *sets*
  it lives in the private feed producer.