### PR TITLE
refactor(registry): use a consistent dashed convention for model ids

### DIFF
--- a/src/modelmeld/scout/data/default_overlay.json
+++ b/src/modelmeld/scout/data/default_overlay.json
@@ -12,7 +12,7 @@
   ],
   "models": [
     {
-      "model_id": "qwen2.5-coder-32b-instruct",
+      "model_id": "qwen2-5-coder-32b-instruct",
       "provider": "openrouter",
       "provider_model_id": "qwen/qwen-2.5-coder-32b-instruct",
       "context_window": 128000,
@@ -24,7 +24,7 @@
       "supports_tools": false
     },
     {
-      "model_id": "llama-3.3-70b-instruct",
+      "model_id": "llama-3-3-70b-instruct",
       "provider": "together",
       "provider_model_id": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
       "context_window": 131072,
@@ -35,7 +35,7 @@
       }
     },
     {
-      "model_id": "llama-3.3-70b-instruct",
+      "model_id": "llama-3-3-70b-instruct",
       "provider": "openrouter",
       "provider_model_id": "meta-llama/llama-3.3-70b-instruct",
       "context_window": 131072,
@@ -114,7 +114,7 @@
       }
     },
     {
-      "model_id": "kimi-k2.6",
+      "model_id": "kimi-k2-6",
       "provider": "fireworks",
       "provider_model_id": "accounts/fireworks/models/kimi-k2p6",
       "context_window": 262144,
@@ -126,7 +126,7 @@
       }
     },
     {
-      "model_id": "kimi-k2.6",
+      "model_id": "kimi-k2-6",
       "provider": "together",
       "provider_model_id": "moonshotai/Kimi-K2.6",
       "context_window": 262144,
@@ -161,7 +161,7 @@
       }
     },
     {
-      "model_id": "glm-4.6",
+      "model_id": "glm-4-6",
       "provider": "openrouter",
       "provider_model_id": "z-ai/glm-4.6",
       "context_window": 202752,
@@ -265,7 +265,7 @@
       }
     },
     {
-      "model_id": "kimi-k2.6",
+      "model_id": "kimi-k2-6",
       "provider": "openrouter",
       "provider_model_id": "moonshotai/kimi-k2.6",
       "context_window": 262144,
@@ -277,7 +277,7 @@
       }
     },
     {
-      "model_id": "qwen3.7-plus",
+      "model_id": "qwen3-7-plus",
       "provider": "openrouter",
       "provider_model_id": "qwen/qwen3.7-plus",
       "context_window": 1000000,
@@ -289,7 +289,7 @@
       }
     },
     {
-      "model_id": "mimo-v2.5",
+      "model_id": "mimo-v2-5",
       "provider": "openrouter",
       "provider_model_id": "xiaomi/mimo-v2.5",
       "context_window": 1048576,

--- a/src/modelmeld/scout/data/default_registry.json
+++ b/src/modelmeld/scout/data/default_registry.json
@@ -164,7 +164,7 @@
       "source": "manual_curation_2026_05_22"
     },
     {
-      "model_id": "qwen2.5-coder-32b-instruct",
+      "model_id": "qwen2-5-coder-32b-instruct",
       "provider": "vllm",
       "context_window": 131072,
       "cost_per_m_input": 0.28,
@@ -181,7 +181,7 @@
       "supports_tools": false
     },
     {
-      "model_id": "qwen2.5-coder-7b-instruct",
+      "model_id": "qwen2-5-coder-7b-instruct",
       "provider": "vllm",
       "context_window": 32768,
       "cost_per_m_input": 0.07,
@@ -214,7 +214,7 @@
       "source": "manual_curation_2026_05_22"
     },
     {
-      "model_id": "deepseek-coder-v2.5",
+      "model_id": "deepseek-coder-v2-5",
       "provider": "vllm",
       "context_window": 128000,
       "cost_per_m_input": 0.28,
@@ -230,7 +230,7 @@
       "source": "manual_curation_2026_05_22"
     },
     {
-      "model_id": "deepseek-v3.2",
+      "model_id": "deepseek-v3-2",
       "provider": "vllm",
       "context_window": 128000,
       "cost_per_m_input": 0.3,
@@ -246,7 +246,7 @@
       "source": "manual_curation_2026_05_22"
     },
     {
-      "model_id": "llama-3.1-70b-instruct",
+      "model_id": "llama-3-1-70b-instruct",
       "provider": "vllm",
       "context_window": 131072,
       "cost_per_m_input": 0.4,
@@ -328,7 +328,7 @@
       "source": "manual_estimate_2026_05_22"
     },
     {
-      "model_id": "llama-3.3-70b-instruct",
+      "model_id": "llama-3-3-70b-instruct",
       "provider": "vllm",
       "context_window": 131072,
       "cost_per_m_input": 0.4,
@@ -360,7 +360,7 @@
       "source": "manual_estimate_2026_05_22"
     },
     {
-      "model_id": "kimi-k2.6",
+      "model_id": "kimi-k2-6",
       "provider": "vllm",
       "context_window": 262144,
       "cost_per_m_input": 0.6,

--- a/src/modelmeld/scout/multi_provider_registry.py
+++ b/src/modelmeld/scout/multi_provider_registry.py
@@ -7,11 +7,11 @@ ModelEntry rows per model_id, keyed by ``(model_id, provider)``.
 The base ``ModelRegistry`` keeps a one-row-per-model_id shape (the
 ``_by_id`` dict collapses duplicates by overwriting). That works fine
 for routing when each canonical model has a single canonical upstream
-(e.g., ``claude-opus-4-7`` lives on Anthropic; ``qwen2.5-coder-7b`` lives
+(e.g., ``claude-opus-4-7`` lives on Anthropic; ``qwen2-5-coder-7b`` lives
 on a self-hosted vLLM endpoint).
 
 In practice, the same open-weight model is served by multiple
-upstream providers — ``qwen2.5-coder-7b-instruct`` is available via
+upstream providers — ``qwen2-5-coder-7b-instruct`` is available via
 Fireworks, Together, OpenRouter, AND self-hosted vLLM. Each provider
 has its own ``provider_model_id`` (the path the upstream expects),
 cost per million tokens, and reliability profile.

--- a/tests/test_adapter_tensorrt_llm.py
+++ b/tests/test_adapter_tensorrt_llm.py
@@ -128,7 +128,7 @@ async def test_vllm_and_tensorrt_llm_parity_on_identical_request() -> None:
     trtllm._client.chat.completions.create = capture_into_trtllm  # type: ignore[method-assign]
 
     request = ChatCompletionRequest(
-        model="qwen2.5-coder-7b-instruct",
+        model="qwen2-5-coder-7b-instruct",
         messages=[{"role": "user", "content": "compute 2+2"}],
         temperature=0.0,
         seed=42,
@@ -139,7 +139,7 @@ async def test_vllm_and_tensorrt_llm_parity_on_identical_request() -> None:
 
     # Bit-for-bit identical: same model, messages, temperature, seed, max tokens
     assert vllm_capture == trtllm_capture
-    assert vllm_capture["model"] == "qwen2.5-coder-7b-instruct"
+    assert vllm_capture["model"] == "qwen2-5-coder-7b-instruct"
     assert vllm_capture["temperature"] == 0.0
     assert vllm_capture["seed"] == 42
 

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -32,8 +32,8 @@ def test_default_registry_has_known_models() -> None:
     expected_subset = {
         "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5",
         "gpt-5", "gpt-5-mini",
-        "qwen2.5-coder-32b-instruct", "qwen2.5-coder-7b-instruct",
-        "deepseek-v3.2",
+        "qwen2-5-coder-32b-instruct", "qwen2-5-coder-7b-instruct",
+        "deepseek-v3-2",
     }
     actual = {e.model_id for e in reg.all_entries()}
     missing = expected_subset - actual
@@ -89,8 +89,8 @@ def test_default_registry_supports_tools_matches_openrouter_audit() -> None:
         "granite-4-micro",
         "gemma-3-4b",
         "deepseek-r1-distill-llama-70b",
-        "qwen2.5-coder-7b-instruct",
-        "qwen2.5-coder-32b-instruct",
+        "qwen2-5-coder-7b-instruct",
+        "qwen2-5-coder-32b-instruct",
     }
     for model_id in expected_no_tool_support:
         entry = reg.get(model_id)
@@ -106,7 +106,7 @@ def test_default_registry_oss_premium_tier_supports_tools() -> None:
     tool calls per SLM-for-Agents research. Default supports_tools=True."""
     reg = default_registry()
     for premium_id in (
-        "deepseek-v4-pro", "kimi-k2.6", "qwen3-coder-480b",
+        "deepseek-v4-pro", "kimi-k2-6", "qwen3-coder-480b",
         "gpt-oss-120b", "llama-4-scout", "deepseek-r1",
     ):
         entry = reg.get(premium_id)

--- a/tests/test_multi_provider_registry.py
+++ b/tests/test_multi_provider_registry.py
@@ -77,7 +77,7 @@ def test_entries_for_returns_all_providers_for_model() -> None:
         [
             _entry("qwen3-coder-30b", "fireworks"),
             _entry("qwen3-coder-30b", "together"),
-            _entry("deepseek-v3.2", "openrouter"),  # different model
+            _entry("deepseek-v3-2", "openrouter"),  # different model ALLOW_HOSTING_MENTION
         ]
     )
     entries = reg.entries_for("qwen3-coder-30b")
@@ -100,7 +100,7 @@ def test_all_entries_multi_includes_every_row() -> None:
         [
             _entry("qwen3-coder-30b", "fireworks"),
             _entry("qwen3-coder-30b", "together"),
-            _entry("deepseek-v3.2", "openrouter"),
+            _entry("deepseek-v3-2", "openrouter"),  # ALLOW_HOSTING_MENTION
         ]
     )
     all_multi = reg.all_entries_multi()
@@ -162,7 +162,7 @@ def test_pick_iterates_multi_provider_rows() -> None:
         [
             _entry("qwen3-coder-30b", "fireworks", cost=0.30),
             _entry("qwen3-coder-30b", "together", cost=0.35),
-            _entry("deepseek-v3.2", "openrouter", cost=0.50),
+            _entry("deepseek-v3-2", "openrouter", cost=0.50),  # ALLOW_HOSTING_MENTION
         ]
     )
     picked = reg.pick(task_category="coding", quality_threshold=0.70)
@@ -254,8 +254,8 @@ def test_load_default_overlay_models_have_multiple_providers() -> None:
     overlay_expected_multi = [
         "deepseek-v4-pro",  # fireworks + together + openrouter + vllm
         "gpt-oss-120b",  # same
-        "llama-3.3-70b-instruct",  # together + openrouter + vllm
-        "kimi-k2.6",  # fireworks + together + vllm
+        "llama-3-3-70b-instruct",  # together + openrouter + vllm ALLOW_HOSTING_MENTION
+        "kimi-k2-6",  # fireworks + together + vllm
     ]
     for model_id in overlay_expected_multi:
         providers = reg.providers_for(model_id)
@@ -331,10 +331,10 @@ def test_default_threshold_agentic_routing_avoids_sustain_failers() -> None:
         require_tool_support=True, eligible_providers=hosted,
     )
     assert pick is not None
-    assert pick.model_id not in {"gpt-oss-120b", "llama-3.3-70b-instruct"}
+    assert pick.model_id not in {"gpt-oss-120b", "llama-3-3-70b-instruct"}
     # llama keeps a usable non-agentic (coding) score — only tool_use is demoted.
     for entry in reg.all_entries_multi():
-        if entry.model_id == "llama-3.3-70b-instruct" and entry.provider == "openrouter":
+        if entry.model_id == "llama-3-3-70b-instruct" and entry.provider == "openrouter":  # ALLOW_HOSTING_MENTION
             assert entry.task_scores["tool_use"] < 0.70
             assert entry.task_scores["coding"] >= 0.70
 

--- a/tests/test_overlay_agentic_capability.py
+++ b/tests/test_overlay_agentic_capability.py
@@ -23,8 +23,8 @@ def _agentic(reg, model_id: str) -> float | None:
 
 def test_measured_agentic_coding_present_on_leaders() -> None:
     reg = default_multi_provider_registry()
-    for m in ("glm-5", "kimi-k2.6", "minimax-m3", "deepseek-v4-flash",
-              "deepseek-v4-pro", "hy3-preview", "mimo-v2.5", "qwen3.7-plus"):
+    for m in ("glm-5", "kimi-k2-6", "minimax-m3", "deepseek-v4-flash",
+              "deepseek-v4-pro", "hy3-preview", "mimo-v2-5", "qwen3-7-plus"):
         assert _agentic(reg, m) is not None, f"missing agentic_coding for {m}"
 
 
@@ -33,9 +33,9 @@ def test_agentic_coding_corrects_the_manual_inversion() -> None:
     glm = _agentic(reg, "glm-5")
     # The reliable OSS coders outrank the chronic shortcut-takers — the opposite
     # of what the manual base coding estimates implied.
-    assert glm > _agentic(reg, "qwen3.7-plus")
-    assert glm > _agentic(reg, "mimo-v2.5")
-    assert _agentic(reg, "kimi-k2.6") > _agentic(reg, "hy3-preview")
+    assert glm > _agentic(reg, "qwen3-7-plus")
+    assert glm > _agentic(reg, "mimo-v2-5")
+    assert _agentic(reg, "kimi-k2-6") > _agentic(reg, "hy3-preview")
     # measured values are in [0, 1]
-    for m in ("glm-5", "qwen3.7-plus"):
+    for m in ("glm-5", "qwen3-7-plus"):
         assert 0.0 <= _agentic(reg, m) <= 1.0

--- a/tests/test_sprint0_multi_provider_routing.py
+++ b/tests/test_sprint0_multi_provider_routing.py
@@ -114,7 +114,7 @@ async def test_fireworks_only_setup_routes_tool_request_to_fireworks(
     assert decision.chosen_model_id in {
         "deepseek-v4-pro",
         "gpt-oss-120b",
-        "kimi-k2.6",
+        "kimi-k2-6",
     }, f"Unexpected model: {decision.chosen_model_id}"
 
 
@@ -140,8 +140,8 @@ async def test_together_only_setup_routes_tool_request_to_together(
     assert decision.chosen_model_id in {
         "deepseek-v4-pro",
         "gpt-oss-120b",
-        "kimi-k2.6",
-        "llama-3.3-70b-instruct",
+        "kimi-k2-6",
+        "llama-3-3-70b-instruct",
         "minimax-m3",
         "glm-5",
     }


### PR DESCRIPTION
## Summary
  Canonical model ids mixed dot and dash version separators (`kimi-k2.6` vs
  `claude-opus-4-7`), which fragments the same model across id forms when joining registry
  data from multiple sources. This normalizes every canonical `model_id` to dashes
  (`kimi-k2.6` → `kimi-k2-6`, `qwen2.5-coder-32b-instruct` → `qwen2-5-coder-32b-instruct`,
  etc.) in the base registry and the example overlay, and updates the tests + docstrings.

  Only the canonical `model_id` (the routing key) changes. `provider_model_id` (the upstream  egress slug, e.g. `moonshotai/kimi-k2.6`) is untouched, so the wire-slug sent to
  providers is unchanged. Capability/score values are unchanged.

  ## Type of change

  - [x] Refactor (no behavior change, internals only)

  ## Test plan

  - Updated `test_model_registry`, `test_multi_provider_registry`,
  `test_overlay_agentic_capability`, `test_sprint0_multi_provider_routing`,
  `test_adapter_tensorrt_llm` for the dashed ids.
  - Full suite: `pytest -q` → 1297 passed, 12 skipped. `ruff check` clean.
  - Verified no capability/score value is lost in the rename (every in-house score present
  under its dashed id).

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [x] Documentation updated if user-facing behavior changed (docstrings)
  - [ ] `pre-commit run --all-files` passes (please run on push)
  - [x] `pytest` passes (full suite)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md`

  ## Breaking changes (if any)

  None to wire behavior — `provider_model_id` (egress) unchanged, scores unchanged. The
  canonical `model_id` strings change, which only affects internal routing keys.