### PR TITLE
feat(scout): route the agentic-coding axis by the in-house value signal

### DIFF
--- a/src/modelmeld/scout/capability.py
+++ b/src/modelmeld/scout/capability.py
@@ -108,11 +108,19 @@ _AUTO_LATENCY_WEIGHT = 0.02
 # small fixed reference.
 _AGENTIC_REF_OUTPUT_TOKENS = 128
 
-# Capability category `-quality` ranks agentic (tool-bearing) requests by.
-# Sourced from AA's Coding Index via the live registry feed (a sustained-
-# agentic-coding success-rate prior); absent in the OSS snapshot, where the
-# scout falls back per-model to the request's category score.
+# The agentic-coding capability/value score the scout ranks + floors agentic
+# routes by. This is the operator's in-house convergence/cost-per-completed
+# measurement (the registry feed carries it; absent in the OSS snapshot, where
+# the scout falls back per-model to the request's category score). It is the
+# value-per-$ RANKER on top of the normalized `coding` capability PREFILTER.
 _AGENTIC_CAPABILITY_CATEGORY = "agentic_coding"
+
+# Classifier categories that constitute the "agentic-coding axis" — coding work,
+# whether or not the turn happens to carry a tools=[] array. The agentic
+# admission floor, the `-auto` reliability floor, and the `-quality` capability
+# re-rank apply to these (not only tool-bearing requests), so a plain coding
+# turn still routes by the agentic value-per-$ signal.
+_AGENTIC_ROUTE_CATEGORIES = frozenset({"coding", "tool_use"})
 
 # Optional dependency: framework-supplied hints. Imported under
 # TYPE_CHECKING to avoid an import cycle (api.routing_hints imports task_category).
@@ -406,6 +414,10 @@ class CapabilityScout:
         # in the model's context window so the response isn't truncated.
         require_tool_support = bool(request.tools)
         min_ctx_required = self._required_context_window(request)
+        # The agentic-coding axis (coding work, tools or not). Drives the
+        # agentic admission floor + the RO-3 re-rank/floor below, so a plain
+        # coding turn routes by the same value-per-$ signal as a tool-bearing one.
+        is_agentic_route = category in _AGENTIC_ROUTE_CATEGORIES
 
         # D1 latency term: only `-auto` + tool-bearing (agentic) requests rank
         # on latency-adjusted cost. `-saver` and non-alias requests stay pure
@@ -421,6 +433,13 @@ class CapabilityScout:
                 f"d1=latency(w={_AUTO_LATENCY_WEIGHT};ref_in={latency_ref_input})"
             )
 
+        # Agentic-axis routes ALSO admit models with a reliable in-house RO-3
+        # `agentic_coding` score even if they lack a (normalized) `coding` score
+        # — a model proven to converge on real tasks is a capable coder, so it
+        # isn't benched for want of an external benchmark number.
+        agentic_admit_floor = (
+            agentic_reliability_floor() if is_agentic_route else None
+        )
         ranked = self.registry.rank(
             task_category=category,
             quality_threshold=threshold,
@@ -430,6 +449,7 @@ class CapabilityScout:
             latency_weight=latency_weight,
             latency_ref_input_tokens=latency_ref_input,
             latency_ref_output_tokens=_AGENTIC_REF_OUTPUT_TOKENS,
+            agentic_admit_floor=agentic_admit_floor,
         )
         if not ranked:
             raise NoEligibleModelError(
@@ -457,7 +477,7 @@ class CapabilityScout:
         # mix is monotonic and degrades gracefully to the prior behavior when
         # the prior is absent.
         quality_rationale = ""
-        if policy is ModelMeldPolicy.QUALITY and require_tool_support:
+        if policy is ModelMeldPolicy.QUALITY and is_agentic_route:
             def _capability(entry: ModelEntry) -> float:
                 ts = entry.task_scores
                 return ts.get(_AGENTIC_CAPABILITY_CATEGORY, ts.get(category, 0.0))
@@ -483,7 +503,7 @@ class CapabilityScout:
         # model isn't picked for -auto agentic routes until it earns a measured
         # score (or the operator sets MODELMELD_AGENTIC_RELIABILITY_FLOOR=0).
         auto_reliability_rationale = ""
-        if policy is ModelMeldPolicy.AUTO and require_tool_support:
+        if policy is ModelMeldPolicy.AUTO and is_agentic_route:
             floor = agentic_reliability_floor()
             if floor > 0:
                 reliable = [

--- a/src/modelmeld/scout/multi_provider_registry.py
+++ b/src/modelmeld/scout/multi_provider_registry.py
@@ -117,6 +117,7 @@ class MultiProviderModelRegistry(ModelRegistry):
         latency_weight: float = 0.0,
         latency_ref_input_tokens: int = 0,
         latency_ref_output_tokens: int = 0,
+        agentic_admit_floor: float | None = None,
     ) -> list[tuple[ModelEntry, float]]:
         """Multi-provider rank: iterates over every ``(model_id, provider)``
         row, not just the base's collapsed ``_by_id`` representatives.
@@ -137,13 +138,22 @@ class MultiProviderModelRegistry(ModelRegistry):
         """
         result: list[tuple[ModelEntry, float]] = []
         for entry in self._by_key.values():
+            if not entry.enabled:
+                continue
             if eligible_providers is not None and entry.provider not in eligible_providers:
                 continue
             if entry.context_window < min_context_window:
                 continue
             if require_tool_support and not entry.supports_tools:
                 continue
-            if not entry.meets_threshold(task_category, quality_threshold):
+            admitted = entry.meets_threshold(task_category, quality_threshold) or (
+                # RO-3 admission for the coverage gap only: a model the benchmark
+                # hasn't scored on this category but proven by in-house RO-3.
+                agentic_admit_floor is not None
+                and task_category not in entry.task_scores
+                and entry.task_scores.get("agentic_coding", 0.0) >= agentic_admit_floor
+            )
+            if not admitted:
                 continue
             result.append((entry, entry.blended_cost_per_m()))
         return _sort_latency_adjusted(
@@ -167,6 +177,8 @@ class MultiProviderModelRegistry(ModelRegistry):
         """
         candidates: list[ModelEntry] = []
         for entry in self._by_key.values():
+            if not entry.enabled:
+                continue
             if eligible_providers is not None and entry.provider not in eligible_providers:
                 continue
             if entry.context_window < min_context_window:

--- a/src/modelmeld/scout/registry.py
+++ b/src/modelmeld/scout/registry.py
@@ -357,6 +357,7 @@ class ModelRegistry:
         latency_weight: float = 0.0,
         latency_ref_input_tokens: int = 0,
         latency_ref_output_tokens: int = 0,
+        agentic_admit_floor: float | None = None,
     ) -> list[tuple[ModelEntry, float]]:
         """All eligible candidates sorted cheapest-first. Returns (entry, blended_cost) pairs.
 
@@ -378,6 +379,15 @@ class ModelRegistry:
         the effective key), so callers' cost reporting stays truthful.
         ``latency_weight == 0`` (the default) is byte-identical to the old
         cost-only ranking — this is what keeps ``-saver`` ranking unchanged.
+
+        ``agentic_admit_floor`` (agentic-axis routes): when set, a model is ALSO
+        admitted if it has NO ``task_category`` score at all but its in-house
+        ``agentic_coding`` (RO-3) score is >= this floor. A model proven to
+        converge on real agentic-coding tasks is a capable coder even when no
+        external benchmark has scored it — so it isn't benched for lack of a
+        ``coding`` number. This deliberately does NOT admit a model the benchmark
+        DID score below threshold (it was measured and found wanting). None
+        (default) keeps the pure-threshold gate.
         """
         result: list[tuple[ModelEntry, float]] = []
         for entry in self._by_id.values():
@@ -389,7 +399,15 @@ class ModelRegistry:
                 continue
             if require_tool_support and not entry.supports_tools:
                 continue
-            if not entry.meets_threshold(task_category, quality_threshold):
+            admitted = entry.meets_threshold(task_category, quality_threshold) or (
+                # RO-3 admission applies ONLY to models the benchmark hasn't
+                # scored on this category (the coverage gap) — NOT to ones it
+                # measured below threshold (those were tested and found wanting).
+                agentic_admit_floor is not None
+                and task_category not in entry.task_scores
+                and entry.task_scores.get("agentic_coding", 0.0) >= agentic_admit_floor
+            )
+            if not admitted:
                 continue
             result.append((entry, entry.blended_cost_per_m()))
         return _sort_latency_adjusted(

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -241,6 +241,40 @@ def test_pick_tiebreak_prefers_larger_window() -> None:
     assert reg.pick("coding", quality_threshold=0.8).model_id == "big-window"
 
 
+def test_rank_agentic_admit_floor_admits_ro3_proven_model() -> None:
+    """A model with a reliable in-house agentic_coding score is admitted for an
+    agentic route even if it has no (or sub-threshold) `coding` score."""
+    reg = ModelRegistry([
+        ModelEntry(
+            model_id="ro3-proven", provider="vllm", context_window=100_000,
+            cost_per_m_input=0.1, cost_per_m_output=0.1,
+            task_scores={"agentic_coding": 0.6},  # NO coding score; RO-3 0.6
+        ),
+        ModelEntry(
+            model_id="benchmarked", provider="vllm", context_window=100_000,
+            cost_per_m_input=0.5, cost_per_m_output=0.5,
+            task_scores={"coding": 0.9},
+        ),
+    ])
+    # Without the admit floor, only the benchmarked model clears the coding gate.
+    assert [e.model_id for e, _ in reg.rank("coding", 0.70)] == ["benchmarked"]
+    # With the admit floor, the RO-3-proven model (agentic 0.6 >= 0.40) is admitted too.
+    ids = {e.model_id for e, _ in reg.rank("coding", 0.70, agentic_admit_floor=0.40)}
+    assert ids == {"ro3-proven", "benchmarked"}
+
+
+def test_rank_agentic_admit_floor_excludes_below_floor() -> None:
+    """A model whose RO-3 score is below the floor (and no coding) stays out."""
+    reg = ModelRegistry([
+        ModelEntry(
+            model_id="ro3-weak", provider="vllm", context_window=100_000,
+            cost_per_m_input=0.1, cost_per_m_output=0.1,
+            task_scores={"agentic_coding": 0.20},  # below 0.40 floor, no coding
+        ),
+    ])
+    assert reg.rank("coding", 0.70, agentic_admit_floor=0.40) == []
+
+
 def test_rank_returns_all_candidates_sorted() -> None:
     reg = _toy_registry()
     ranked = reg.rank("simple_qa", quality_threshold=0.0)

--- a/tests/test_scout_auto_reliability.py
+++ b/tests/test_scout_auto_reliability.py
@@ -44,6 +44,17 @@ def _req_auto_tools() -> ChatCompletionRequest:
     )
 
 
+def _req_auto_coding() -> ChatCompletionRequest:
+    # No tools — classifies as `coding` (the agentic axis), NOT `tool_use`.
+    return ChatCompletionRequest(
+        model="anthropic/modelmeld-auto",
+        messages=[UserMessage(
+            role="user",
+            content="write a python function to merge two sorted lists",
+        )],
+    )
+
+
 async def test_floor_excludes_cheap_shortcut_taker(monkeypatch) -> None:
     monkeypatch.delenv("MODELMELD_AGENTIC_RELIABILITY_FLOOR", raising=False)  # default 0.40
     registry = ModelRegistry([
@@ -102,6 +113,22 @@ async def test_unprobed_wins_when_no_measured_reliable(monkeypatch) -> None:
     # no measured-RELIABLE model → fall back to the full ranking → cheapest wins
     # (a genuinely-new/all-unprobed pool still routes; never 503).
     assert decision.chosen_model_id == "cheap-unscored"
+
+
+async def test_auto_admits_ro3_model_without_a_coding_score(monkeypatch) -> None:
+    """C4 admission: a model with a reliable RO-3 score but NO coding score is
+    routable on a coding route (would 503 before — coding 0.0 < threshold)."""
+    monkeypatch.delenv("MODELMELD_AGENTIC_RELIABILITY_FLOOR", raising=False)
+    registry = ModelRegistry([
+        ModelEntry(
+            model_id="ro3-only", provider="vllm", context_window=200_000,
+            cost_per_m_input=0.1, cost_per_m_output=0.1,
+            task_scores={"agentic_coding": 0.6},  # NO coding score
+        ),
+    ])
+    scout = CapabilityScout(registry=registry, quality_threshold=0.70)
+    decision = await scout.choose(_req_auto_coding())
+    assert decision.chosen_model_id == "ro3-only"
 
 
 async def test_disabled_unprobed_is_not_chosen_as_fallback(monkeypatch) -> None:

--- a/tests/test_scout_quality_agentic.py
+++ b/tests/test_scout_quality_agentic.py
@@ -91,11 +91,38 @@ async def test_quality_agentic_breaks_capability_ties_by_cost() -> None:
     assert decision.chosen_model_id == "cheap-strong"
 
 
-async def test_quality_simple_request_stays_cost_first() -> None:
-    # No tools + max_tokens None => not autocomplete-shape => QUALITY still goes
-    # frontier, but the capability-first re-rank must NOT apply. Cheapest wins.
+async def test_quality_notools_coding_is_capability_first() -> None:
+    # C4/§23: the -quality capability re-rank spans the whole agentic-coding axis
+    # — a plain coding turn with NO tools array still routes capability-first, so
+    # -quality never lands on the weakest frontier for coding work. (Pre-C4 this
+    # request stayed cost-first because the re-rank was tool-bearing-only.)
     scout = _scout(_weak_cheap(), _strong_pricey())
     decision = await scout.choose(_req(QUALITY, with_tools=False))
+    assert decision.chosen_model_id == "big-frontier"
+    assert "quality_agentic=capability_first" in decision.rationale
+
+
+async def test_quality_noncoding_stays_cost_first() -> None:
+    # A genuinely non-agentic -quality request (simple_qa) still goes frontier
+    # but stays cost-first: the re-rank is scoped to the coding/tool_use axis, so
+    # categories off that axis keep cheapest-frontier-wins.
+    weak = ModelEntry(
+        model_id="mini-frontier", provider="openai", context_window=200000,
+        cost_per_m_input=0.25, cost_per_m_output=2.0,
+        task_scores={"simple_qa": 0.75},
+    )
+    strong = ModelEntry(
+        model_id="big-frontier", provider="anthropic", context_window=200000,
+        cost_per_m_input=3.0, cost_per_m_output=15.0,
+        task_scores={"simple_qa": 0.90},
+    )
+    scout = CapabilityScout(
+        registry=MultiProviderModelRegistry([weak, strong]),
+        quality_threshold=0.70,
+    )
+    decision = await scout.choose(
+        _req(QUALITY, with_tools=False, text="What is the capital of France?")
+    )
     assert decision.chosen_model_id == "mini-frontier"
     assert "quality_agentic=capability_first" not in decision.rationale
 


### PR DESCRIPTION
## Summary

  Coding work routes by the in-house `agentic_coding` value-per-$ signal on every
  turn, not just turns that carry a `tools=[]` array. A planning turn or a first
  turn with no tools is still agentic-coding work, so it should be admitted,
  floored, and ranked the same way a tool-bearing turn is. This generalizes the
  existing `-auto` reliability floor and `-quality` capability re-rank from
  "tool-bearing only" to the whole coding axis (the `coding` and `tool_use`
  classifier categories), and lets a model proven by in-house measurement route
  even when no external benchmark has scored it on `coding` yet.

  ## Type of change

  - [ ] Bug fix (non-breaking change that resolves an issue)
  - [x] New feature (non-breaking change that adds capability)
  - [x] Breaking change (fix or feature that changes existing behavior in a way clients can
  observe)
  - [ ] Refactor (no behavior change, internals only)
  - [ ] Documentation
  - [ ] Test-only change
  - [ ] Build / CI / tooling

  ## Test plan

  - `tests/test_scout_auto_reliability.py` — adds
  `test_auto_admits_ro3_model_without_a_coding_score`
    (a model with only an `agentic_coding` score is now routable on a no-tools coding route;  it would
    503 before) alongside the existing floor/fallback/de-prefer/enabled cases.
  - `tests/test_model_registry.py` — two admit-floor cases: a model with only an
  `agentic_coding` score
    is admitted on the axis; a model the benchmark scored *below* threshold is still
  excluded.
  - `tests/test_scout_quality_agentic.py` — replaces the old "simple request stays
  cost-first" case
    (which used a coding prompt as its "simple" case) with two honest cases: a no-tools
  coding request
    under `-quality` now routes capability-first, and a genuinely non-coding (`simple_qa`)
  request still
    routes cost-first.
  - Full suite green (1301 passed, 12 skipped); `ruff` clean; `pyright` 0 errors on the
  changed files.

  ## Linked issues

  (none)

  ## Checklist

  - [x] Tests added or updated and they actually exercise the change
  - [x] Documentation updated if user-facing behavior changed (inline rationale + comments)
  - [ ] `pre-commit run --all-files` passes
  - [x] `pytest` passes (full suite, not just the changed file)
  - [x] All commits have DCO signoff (`git commit -s`)
  - [x] If this touches the open-core boundary or registry data, I've read
  `docs/open-core-boundary.md` first

  ## Breaking changes (if any)

  Observable routing change for `-quality`: a coding request with **no** `tools=[]` array
  now selects the
  strongest qualified model (capability-first) instead of the cheapest. Cost-first selection  is preserved
  for genuinely non-coding `-quality` requests. `-saver` is unaffected. No API surface or
  config change.